### PR TITLE
Remove smart constructor 'graph'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.1.0
 
 * Start complying with PVP.
+* #32: Remove smart constructor 'graph'.
 * #27: Support GHC >= 7.8.
 * #25: Add `NFData Graph` instance.
 * Minor code and documentation revision.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -23,7 +23,6 @@ module Algebra.Graph (
 
     -- * Basic graph construction primitives
     empty, vertex, edge, overlay, connect, vertices, edges, overlays, connects,
-    graph,
 
     -- * Graph folding
     foldg,
@@ -325,20 +324,6 @@ overlays = H.overlays
 -- @
 connects :: [Graph a] -> Graph a
 connects = H.connects
-
--- | Construct the graph from given lists of vertices /V/ and edges /E/.
--- The resulting graph contains the vertices /V/ as well as all the vertices
--- referred to by the edges /E/.
--- Complexity: /O(|V| + |E|)/ time, memory and size.
---
--- @
--- graph []  []      == 'empty'
--- graph [x] []      == 'vertex' x
--- graph []  [(x,y)] == 'edge' x y
--- graph vs  es      == 'overlay' ('vertices' vs) ('edges' es)
--- @
-graph :: [a] -> [(a, a)] -> Graph a
-graph = H.graph
 
 -- | Generalised 'Graph' folding: recursively collapse a 'Graph' by applying
 -- the provided functions to the leaves and internal nodes of the expression.

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -22,7 +22,7 @@ module Algebra.Graph.AdjacencyMap (
 
     -- * Basic graph construction primitives
     empty, vertex, edge, overlay, connect, vertices, edges, overlays, connects,
-    graph, fromAdjacencyList,
+    fromAdjacencyList,
 
     -- * Relations on graphs
     isSubgraphOf,
@@ -178,20 +178,6 @@ overlays = C.overlays
 -- @
 connects :: Ord a => [AdjacencyMap a] -> AdjacencyMap a
 connects = C.connects
-
--- | Construct the graph from given lists of vertices /V/ and edges /E/.
--- The resulting graph contains the vertices /V/ as well as all the vertices
--- referred to by the edges /E/.
--- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
---
--- @
--- graph []  []      == 'empty'
--- graph [x] []      == 'vertex' x
--- graph []  [(x,y)] == 'edge' x y
--- graph vs  es      == 'overlay' ('vertices' vs) ('edges' es)
--- @
-graph :: Ord a => [a] -> [(a, a)] -> AdjacencyMap a
-graph vs es = overlay (vertices vs) (edges es)
 
 -- | Construct a graph from an adjacency list.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.

--- a/src/Algebra/Graph/AdjacencyMap/Internal.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Internal.hs
@@ -18,6 +18,7 @@ module Algebra.Graph.AdjacencyMap.Internal (
     GraphKL (..), mkGraphKL
   ) where
 
+import Data.List
 import Data.Map.Strict (Map, keysSet, fromSet)
 import Data.Set (Set)
 
@@ -44,7 +45,7 @@ show (1         :: AdjacencyMap Int) == "vertex 1"
 show (1 + 2     :: AdjacencyMap Int) == "vertices [1,2]"
 show (1 * 2     :: AdjacencyMap Int) == "edge 1 2"
 show (1 * 2 * 3 :: AdjacencyMap Int) == "edges [(1,2),(1,3),(2,3)]"
-show (1 * 2 + 3 :: AdjacencyMap Int) == "graph [1,2,3] [(1,2)]"@
+show (1 * 2 + 3 :: AdjacencyMap Int) == "overlay (vertex 3) (edge 1 2)"@
 
 The 'Eq' instance satisfies all axioms of algebraic graphs:
 
@@ -106,18 +107,18 @@ instance Eq a => Eq (AdjacencyMap a) where
 
 instance (Ord a, Show a) => Show (AdjacencyMap a) where
     show (AM m _)
-        | m == Map.empty = "empty"
-        | null es        = if Set.size vs > 1 then "vertices " ++ show (Set.toAscList vs)
-                                              else "vertex "   ++ show v
-        | vs == referred = if length es > 1 then "edges " ++ show es
-                                            else "edge "  ++ show e ++ " " ++ show f
-        | otherwise      = "graph " ++ show (Set.toAscList vs) ++ " " ++ show es
+        | null vs    = "empty"
+        | null es    = vshow vs
+        | vs == used = eshow es
+        | otherwise  = "overlay (" ++ vshow (vs \\ used) ++ ") (" ++ eshow es ++ ")"
       where
-        vs       = keysSet m
-        es       = internalEdgeList m
-        v        = head $ Set.toList vs
-        (e, f)   = head es
-        referred = referredToVertexSet m
+        vs             = Set.toAscList (keysSet m)
+        es             = internalEdgeList m
+        vshow [x]      = "vertex "   ++ show x
+        vshow xs       = "vertices " ++ show xs
+        eshow [(x, y)] = "edge "     ++ show x ++ " " ++ show y
+        eshow xs       = "edges "    ++ show xs
+        used           = Set.toAscList (referredToVertexSet m)
 
 instance Ord a => Graph (AdjacencyMap a) where
     type Vertex (AdjacencyMap a) = a

--- a/src/Algebra/Graph/Class.hs
+++ b/src/Algebra/Graph/Class.hs
@@ -38,7 +38,7 @@ module Algebra.Graph.Class (
     Preorder,
 
     -- * Basic graph construction primitives
-    edge, vertices, overlays, connects, edges, graph,
+    edge, vertices, overlays, connects, edges,
 
     -- * Relations on graphs
     isSubgraphOf,
@@ -270,20 +270,6 @@ overlays = foldr overlay empty
 -- @
 connects :: Graph g => [g] -> g
 connects = foldr connect empty
-
--- | Construct the graph from given lists of vertices /V/ and edges /E/.
--- The resulting graph contains the vertices /V/ as well as all the vertices
--- referred to by the edges /E/.
--- Complexity: /O(|V| + |E|)/ time, memory and size.
---
--- @
--- graph []  []      == 'empty'
--- graph [x] []      == 'vertex' x
--- graph []  [(x,y)] == 'edge' x y
--- graph vs  es      == 'overlay' ('vertices' vs) ('edges' es)
--- @
-graph :: Graph g => [Vertex g] -> [(Vertex g, Vertex g)] -> g
-graph vs es = overlay (vertices vs) (edges es)
 
 -- | The 'isSubgraphOf' function takes two graphs and returns 'True' if the
 -- first graph is a /subgraph/ of the second. Here is the current implementation:

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -24,7 +24,6 @@ module Algebra.Graph.Fold (
 
     -- * Basic graph construction primitives
     empty, vertex, edge, overlay, connect, vertices, edges, overlays, connects,
-    C.graph,
 
     -- * Graph folding
     foldg,
@@ -79,7 +78,7 @@ show (1         :: Fold Int) == "vertex 1"
 show (1 + 2     :: Fold Int) == "vertices [1,2]"
 show (1 * 2     :: Fold Int) == "edge 1 2"
 show (1 * 2 * 3 :: Fold Int) == "edges [(1,2),(1,3),(2,3)]"
-show (1 * 2 + 3 :: Fold Int) == "graph [1,2,3] [(1,2)]"@
+show (1 * 2 + 3 :: Fold Int) == "overlay (vertex 3) (edge 1 2)"@
 
 The 'Eq' instance is currently implemented using the 'AM.AdjacencyMap' as the
 /canonical graph representation/ and satisfies all axioms of algebraic graphs:

--- a/src/Algebra/Graph/HigherKinded/Class.hs
+++ b/src/Algebra/Graph/HigherKinded/Class.hs
@@ -37,7 +37,7 @@ module Algebra.Graph.HigherKinded.Class (
     Preorder,
 
     -- * Basic graph construction primitives
-    edge, vertices, edges, overlays, connects, graph,
+    edge, vertices, edges, overlays, connects,
 
     -- * Relations on graphs
     isSubgraphOf,
@@ -249,20 +249,6 @@ overlays = msum
 -- @
 connects :: Graph g => [g a] -> g a
 connects = foldr connect empty
-
--- | Construct the graph from given lists of vertices /V/ and edges /E/.
--- The resulting graph contains the vertices /V/ as well as all the vertices
--- referred to by the edges /E/.
--- Complexity: /O(|V| + |E|)/ time, memory and size.
---
--- @
--- graph []  []      == 'empty'
--- graph [x] []      == 'vertex' x
--- graph []  [(x,y)] == 'edge' x y
--- graph vs  es      == 'overlay' ('vertices' vs) ('edges' es)
--- @
-graph :: Graph g => [a] -> [(a, a)] -> g a
-graph vs es = overlay (vertices vs) (edges es)
 
 -- | The 'isSubgraphOf' function takes two graphs and returns 'True' if the
 -- first graph is a /subgraph/ of the second. Here is the current implementation:
@@ -617,4 +603,3 @@ box x y = msum $ xs ++ ys
 -- @
 class ToGraph t where
     toGraph :: Graph g => t a -> g a
-

--- a/src/Algebra/Graph/IntAdjacencyMap.hs
+++ b/src/Algebra/Graph/IntAdjacencyMap.hs
@@ -22,7 +22,7 @@ module Algebra.Graph.IntAdjacencyMap (
 
     -- * Basic graph construction primitives
     empty, vertex, edge, overlay, connect, vertices, edges, overlays, connects,
-    graph, fromAdjacencyList,
+    fromAdjacencyList,
 
     -- * Relations on graphs
     isSubgraphOf,
@@ -179,20 +179,6 @@ overlays = C.overlays
 -- @
 connects :: [IntAdjacencyMap] -> IntAdjacencyMap
 connects = C.connects
-
--- | Construct the graph from given lists of vertices /V/ and edges /E/.
--- The resulting graph contains the vertices /V/ as well as all the vertices
--- referred to by the edges /E/.
--- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
---
--- @
--- graph []  []      == 'empty'
--- graph [x] []      == 'vertex' x
--- graph []  [(x,y)] == 'edge' x y
--- graph vs  es      == 'overlay' ('vertices' vs) ('edges' es)
--- @
-graph :: [Int] -> [(Int, Int)] -> IntAdjacencyMap
-graph vs es = overlay (vertices vs) (edges es)
 
 -- | Construct a graph from an adjacency list.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.

--- a/src/Algebra/Graph/IntAdjacencyMap/Internal.hs
+++ b/src/Algebra/Graph/IntAdjacencyMap/Internal.hs
@@ -20,6 +20,7 @@ module Algebra.Graph.IntAdjacencyMap.Internal (
 
 import Data.IntMap.Strict (IntMap, keysSet, fromSet)
 import Data.IntSet (IntSet)
+import Data.List
 
 import Algebra.Graph.Class
 
@@ -44,7 +45,7 @@ show (1         :: IntAdjacencyMap Int) == "vertex 1"
 show (1 + 2     :: IntAdjacencyMap Int) == "vertices [1,2]"
 show (1 * 2     :: IntAdjacencyMap Int) == "edge 1 2"
 show (1 * 2 * 3 :: IntAdjacencyMap Int) == "edges [(1,2),(1,3),(2,3)]"
-show (1 * 2 + 3 :: IntAdjacencyMap Int) == "graph [1,2,3] [(1,2)]"@
+show (1 * 2 + 3 :: IntAdjacencyMap Int) == "overlay (vertex 3) (edge 1 2)"@
 
 The 'Eq' instance satisfies all axioms of algebraic graphs:
 
@@ -106,18 +107,18 @@ instance Eq IntAdjacencyMap where
 
 instance Show IntAdjacencyMap where
     show (AM m _)
-        | m == IntMap.empty = "empty"
-        | null es           = if IntSet.size vs > 1 then "vertices " ++ show (IntSet.toAscList vs)
-                                                    else "vertex "   ++ show v
-        | vs == referred    = if length es > 1 then "edges " ++ show es
-                                               else "edge "  ++ show e ++ " " ++ show f
-        | otherwise         = "graph " ++ show (IntSet.toAscList vs) ++ " " ++ show es
+        | null vs    = "empty"
+        | null es    = vshow vs
+        | vs == used = eshow es
+        | otherwise  = "overlay (" ++ vshow (vs \\ used) ++ ") (" ++ eshow es ++ ")"
       where
-        vs       = keysSet m
-        es       = internalEdgeList m
-        v        = head $ IntSet.toList vs
-        (e, f)   = head es
-        referred = referredToVertexSet m
+        vs             = IntSet.toAscList (keysSet m)
+        es             = internalEdgeList m
+        vshow [x]      = "vertex "   ++ show x
+        vshow xs       = "vertices " ++ show xs
+        eshow [(x, y)] = "edge "     ++ show x ++ " " ++ show y
+        eshow xs       = "edges "    ++ show xs
+        used           = IntSet.toAscList (referredToVertexSet m)
 
 instance Graph IntAdjacencyMap where
     type Vertex IntAdjacencyMap = Int

--- a/src/Algebra/Graph/Relation.hs
+++ b/src/Algebra/Graph/Relation.hs
@@ -20,7 +20,7 @@ module Algebra.Graph.Relation (
 
     -- * Basic graph construction primitives
     empty, vertex, edge, overlay, connect, vertices, edges, overlays, connects,
-    graph, fromAdjacencyList,
+    fromAdjacencyList,
 
     -- * Relations on graphs
     isSubgraphOf,
@@ -175,20 +175,6 @@ overlays = C.overlays
 -- @
 connects :: Ord a => [Relation a] -> Relation a
 connects = C.connects
-
--- | Construct the graph from given lists of vertices /V/ and edges /E/.
--- The resulting graph contains the vertices /V/ as well as all the vertices
--- referred to by the edges /E/.
--- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
---
--- @
--- graph []  []      == 'empty'
--- graph [x] []      == 'vertex' x
--- graph []  [(x,y)] == 'edge' x y
--- graph vs  es      == 'overlay' ('vertices' vs) ('edges' es)
--- @
-graph :: Ord a => [a] -> [(a, a)] -> Relation a
-graph = C.graph
 
 -- | Construct a graph from an adjacency list.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.

--- a/test/Algebra/Graph/Test/API.hs
+++ b/test/Algebra/Graph/Test/API.hs
@@ -39,8 +39,6 @@ class Graph g => GraphAPI g where
     overlays          = notImplemented
     connects          :: [g] -> g
     connects          = notImplemented
-    graph             :: [Vertex g] -> [(Vertex g, Vertex g)] -> g
-    graph             = notImplemented
     fromAdjacencyList :: [(Vertex g, [Vertex g])] -> g
     fromAdjacencyList = notImplemented
     foldg             :: r -> (Vertex g -> r) -> (r -> r -> r) -> (r -> r -> r) -> g -> r
@@ -141,7 +139,6 @@ instance Ord a => GraphAPI (AdjacencyMap.AdjacencyMap a) where
     edges             = AdjacencyMap.edges
     overlays          = AdjacencyMap.overlays
     connects          = AdjacencyMap.connects
-    graph             = AdjacencyMap.graph
     fromAdjacencyList = AdjacencyMap.fromAdjacencyList
     isSubgraphOf      = AdjacencyMap.isSubgraphOf
     isEmpty           = AdjacencyMap.isEmpty
@@ -182,7 +179,6 @@ instance Ord a => GraphAPI (Fold.Fold a) where
     edges         = Fold.edges
     overlays      = Fold.overlays
     connects      = Fold.connects
-    graph         = Fold.graph
     foldg         = Fold.foldg
     isSubgraphOf  = Fold.isSubgraphOf
     isEmpty       = Fold.isEmpty
@@ -224,7 +220,6 @@ instance Ord a => GraphAPI (Graph.Graph a) where
     edges         = Graph.edges
     overlays      = Graph.overlays
     connects      = Graph.connects
-    graph         = Graph.graph
     foldg         = Graph.foldg
     isSubgraphOf  = Graph.isSubgraphOf
     (===)         = (Graph.===)
@@ -267,7 +262,6 @@ instance GraphAPI IntAdjacencyMap.IntAdjacencyMap where
     edges             = IntAdjacencyMap.edges
     overlays          = IntAdjacencyMap.overlays
     connects          = IntAdjacencyMap.connects
-    graph             = IntAdjacencyMap.graph
     fromAdjacencyList = IntAdjacencyMap.fromAdjacencyList
     isSubgraphOf      = IntAdjacencyMap.isSubgraphOf
     isEmpty           = IntAdjacencyMap.isEmpty
@@ -308,7 +302,6 @@ instance Ord a => GraphAPI (Relation.Relation a) where
     edges             = Relation.edges
     overlays          = Relation.overlays
     connects          = Relation.connects
-    graph             = Relation.graph
     fromAdjacencyList = Relation.fromAdjacencyList
     isSubgraphOf      = Relation.isSubgraphOf
     isEmpty           = Relation.isEmpty

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -60,8 +60,7 @@ testBasicPrimitives = mconcat [ testEmpty
                               , testVertices
                               , testEdges
                               , testOverlays
-                              , testConnects
-                              , testGraph ]
+                              , testConnects ]
 
 testProperties :: Testsuite -> IO ()
 testProperties = mconcat [ testIsEmpty
@@ -96,23 +95,23 @@ testTransformations = mconcat [ testRemoveVertex
 testShow :: Testsuite -> IO ()
 testShow (Testsuite prefix (%)) = do
     putStrLn $ "\n============ " ++ prefix ++ "Show ============"
-    test "show (empty     :: IntAdjacencyMap) == \"empty\"" $
-          show % empty                        == "empty"
+    test "show (empty    ) == \"empty\"" $
+          show % empty     ==  "empty"
 
-    test "show (1         :: IntAdjacencyMap) == \"vertex 1\"" $
-          show % 1                            == "vertex 1"
+    test "show (1        ) == \"vertex 1\"" $
+          show % 1         ==  "vertex 1"
 
-    test "show (1 + 2     :: IntAdjacencyMap) == \"vertices [1,2]\"" $
-          show % (1 + 2)                      == "vertices [1,2]"
+    test "show (1 + 2    ) == \"vertices [1,2]\"" $
+          show % (1 + 2)   ==  "vertices [1,2]"
 
-    test "show (1 * 2     :: IntAdjacencyMap) == \"edge 1 2\"" $
-          show % (1 * 2)                      == "edge 1 2"
+    test "show (1 * 2    ) == \"edge 1 2\"" $
+          show % (1 * 2)   ==  "edge 1 2"
 
-    test "show (1 * 2 * 3 :: IntAdjacencyMap) == \"edges [(1,2),(1,3),(2,3)]\"" $
-          show % (1 * 2 * 3)                  == "edges [(1,2),(1,3),(2,3)]"
+    test "show (1 * 2 * 3) == \"edges [(1,2),(1,3),(2,3)]\"" $
+          show % (1 * 2 * 3) == "edges [(1,2),(1,3),(2,3)]"
 
-    test "show (1 * 2 + 3 :: IntAdjacencyMap) == \"graph [1,2,3] [(1,2)]\"" $
-          show % (1 * 2 + 3)                  == "graph [1,2,3] [(1,2)]"
+    test "show (1 * 2 + 3) == \"overlay (vertex 3) (edge 1 2)\"" $
+          show % (1 * 2 + 3) == "overlay (vertex 3) (edge 1 2)"
 
 testEmpty :: Testsuite -> IO ()
 testEmpty (Testsuite prefix (%)) = do
@@ -284,21 +283,6 @@ testConnects (Testsuite prefix (%)) = do
 
     test "isEmpty . connects == all isEmpty" $ mapSize (min 10) $ \xs ->
           isEmpty % connects xs == all isEmpty xs
-
-testGraph :: Testsuite -> IO ()
-testGraph (Testsuite prefix (%)) = do
-    putStrLn $ "\n============ " ++ prefix ++ "graph ============"
-    test "graph []  []      == empty" $
-          graph []  []      == id % empty
-
-    test "graph [x] []      == vertex x" $ \x ->
-          graph [x] []      == id % vertex x
-
-    test "graph []  [(x,y)] == edge x y" $ \x y ->
-          graph []  [(x,y)] == id % edge x y
-
-    test "graph vs  es      == overlay (vertices vs) (edges es)" $ \vs es ->
-          graph vs  es      == overlay (vertices vs) % edges es
 
 testFromAdjacencyList :: Testsuite -> IO ()
 testFromAdjacencyList (Testsuite prefix (%)) = do


### PR DESCRIPTION
After using the library for a while I think we can drop the smart constructor `graph` for the following reasons:
* It's very rarely needed and it's easy to implement via `overlay` if need be.
* It's awkward, because it brings us back to the `(V,E)` definition of graphs and can lead to a confusion between `graph [1] [(1, 2)]` and `graph [1, 2] [(1, 2)]`. 
* It takes up a useful name `graph`.
* It's one extra function to maintain, test and document.