### PR TITLE
Split difference lists from documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 0.1.0
 
 * Start complying with PVP.
-* #39: Factor out difference lists into `Algebra.Graph.Utilities`.
+* #39: Factor out difference lists into `Algebra.Graph.Internal`.
 * #33: Add `Algebra.Graph.NonEmpty`.
 * #32: Remove smart constructor `graph`.
 * #27: Support GHC >= 7.8.

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -63,6 +63,7 @@ library
                         Algebra.Graph.HigherKinded.Class,
                         Algebra.Graph.IntAdjacencyMap,
                         Algebra.Graph.IntAdjacencyMap.Internal,
+                        Algebra.Graph.Internal,
                         Algebra.Graph.NonEmpty,
                         Algebra.Graph.Relation,
                         Algebra.Graph.Relation.Internal,
@@ -70,8 +71,7 @@ library
                         Algebra.Graph.Relation.Preorder,
                         Algebra.Graph.Relation.Reflexive,
                         Algebra.Graph.Relation.Symmetric,
-                        Algebra.Graph.Relation.Transitive,
-                        Algebra.Graph.Utilities
+                        Algebra.Graph.Relation.Transitive
     build-depends:      array       >= 0.4     && < 0.6,
                         base        >= 4.7     && < 5,
                         base-compat >= 0.9.1   && < 0.10,
@@ -112,9 +112,9 @@ test-suite test-alga
                         Algebra.Graph.Test.Generic,
                         Algebra.Graph.Test.Graph,
                         Algebra.Graph.Test.IntAdjacencyMap,
+                        Algebra.Graph.Test.Internal,
                         Algebra.Graph.Test.NonEmptyGraph,
-                        Algebra.Graph.Test.Relation,
-                        Algebra.Graph.Test.Utilities
+                        Algebra.Graph.Test.Relation
     build-depends:      algebraic-graphs,
                         base         >= 4.7     && < 5,
                         base-compat  >= 0.9.1   && < 0.10,

--- a/src/Algebra/Graph/Export.hs
+++ b/src/Algebra/Graph/Export.hs
@@ -32,7 +32,7 @@ import Prelude hiding (unlines)
 
 import Algebra.Graph.AdjacencyMap
 import Algebra.Graph.Class (ToGraph (..))
-import Algebra.Graph.Utilities
+import Algebra.Graph.Internal
 
 newtype Doc s = Doc (List s) deriving (Monoid, Semigroup)
 

--- a/src/Algebra/Graph/Export.hs
+++ b/src/Algebra/Graph/Export.hs
@@ -25,6 +25,7 @@ module Algebra.Graph.Export (
     export
   ) where
 
+import Control.Applicative (pure)
 import Data.Foldable (fold)
 import Data.Semigroup
 import Data.String hiding (unlines)

--- a/src/Algebra/Graph/Export.hs
+++ b/src/Algebra/Graph/Export.hs
@@ -35,6 +35,15 @@ import Algebra.Graph.AdjacencyMap
 import Algebra.Graph.Class (ToGraph (..))
 import Algebra.Graph.Internal
 
+-- | An abstract document data type with /O(1)/ time concatenation (the current
+-- implementation uses difference lists). Here @s@ is the type of abstract
+-- symbols or strings (text or binary). 'Doc' @s@ is a 'Monoid', therefore
+-- 'mempty' corresponds to the empty document and two documents can be
+-- concatenated with 'mappend' (or operator 'Data.Monoid.<>'). Documents
+-- comprising a single symbol or string can be constructed using the function
+-- 'literal'. Alternatively, you can construct documents as string literals, e.g.
+-- simply as @"alga"@, by using the @OverloadedStrings@ GHC extension. To extract
+-- the document contents use the function 'render'. See some examples below.
 newtype Doc s = Doc (List s) deriving (Monoid, Semigroup)
 
 instance (Monoid s, Show s) => Show (Doc s) where
@@ -49,8 +58,8 @@ instance (Monoid s, Ord s) => Ord (Doc s) where
 instance IsString s => IsString (Doc s) where
     fromString = literal . fromString
 
--- | Construct a document comprising a single symbol or word. If @a@ is an
--- instance of class 'IsString', then documents of type 'Doc' @a@ can be
+-- | Construct a document comprising a single symbol or string. If @s@ is an
+-- instance of class 'IsString', then documents of type 'Doc' @s@ can be
 -- constructed directly from string literals (see the second example below).
 --
 -- @
@@ -63,8 +72,7 @@ instance IsString s => IsString (Doc s) where
 literal :: s -> Doc s
 literal = Doc . pure
 
--- | Render a document as a single string or word. An inverse of the function
--- 'literal'.
+-- | Render the document as a single string. An inverse of the function 'literal'.
 --
 -- @
 -- render ('literal' "al" 'Data.Monoid.<>' 'literal' "ga") :: ('IsString' s, 'Monoid' s) => s

--- a/src/Algebra/Graph/Internal.hs
+++ b/src/Algebra/Graph/Internal.hs
@@ -10,8 +10,9 @@
 -- in Haskell. See <https://github.com/snowleopard/alga-paper this paper> for the
 -- motivation behind the library, the underlying theory, and implementation details.
 --
--- This module defines various utilities used throughout the library, such as
--- lists with fast concatenation.
+-- This module defines various internal utilities and data structures used
+-- throughout the library, such as lists with fast concatenation. The API
+-- is unstable and unsafe.
 -----------------------------------------------------------------------------
 module Algebra.Graph.Internal (
     -- * Data structures
@@ -23,18 +24,16 @@ import Data.Foldable (Foldable (foldMap))
 import Data.Semigroup
 import GHC.Exts
 
--- | An abstract document data type with /O(1)/ time concatenation (the current
--- implementation uses difference lists). Here @a@ is the type of abstract
--- symbols or words -- for example, text strings or binary blocks. 'Doc' @a@
--- is a 'Monoid': 'mempty' corresponds to the empty document and two documents
--- can be concatenated with 'mappend' (or operator 'Data.Monoid.<>'). Documents
--- comprising a single symbol or word can be constructed using the function
--- 'literal'. 'Doc' @a@ is also an instance of 'IsList', therefore you can use
--- list literals to construct documents, e.g. @["al", "ga"]@ @::@ 'Doc' @String@
--- is the same as 'literal' @"al"@ 'Data.Monoid.<>' 'literal' @"ga"@; note that
--- this requires the @OverloadedLists@ GHC extension. Finally, by using the
--- @OverloadedStrings@ GHC extension you can construct documents as string
--- literals, e.g. simply as @"alga"@. See some examples below.
+-- | An abstract list data type with /O(1)/ time concatenation (the current
+-- implementation uses difference lists). Here @a@ is the type of list elements.
+-- 'List' @a@ is a 'Monoid': 'mempty' corresponds to the empty list and two lists
+-- can be concatenated with 'mappend' (or operator 'Data.Monoid.<>'). Singleton
+-- lists can be constructed using the function 'pure' from the 'Applicative'
+-- instance. 'List' @a@ is also an instance of 'IsList', therefore you can use
+-- list literals, e.g. @[1,4]@ @::@ 'List' @Int@ is the same as 'pure' @1@
+-- 'Data.Monoid.<>' 'pure' @4@; note that this requires the @OverloadedLists@
+-- GHC extension. To extract plain Haskell lists you can use the 'toList'
+-- function from the 'Foldable' instance.
 newtype List a = List (Endo [a]) deriving (Monoid, Semigroup)
 
 instance Show a => Show (List a) where

--- a/src/Algebra/Graph/Internal.hs
+++ b/src/Algebra/Graph/Internal.hs
@@ -18,9 +18,8 @@ module Algebra.Graph.Internal (
     List (..)
   ) where
 
-import Prelude ()
-import Prelude.Compat
-
+import Control.Applicative (Applicative (..))
+import Data.Foldable (Foldable (foldMap))
 import Data.Semigroup
 import GHC.Exts
 

--- a/src/Algebra/Graph/Internal.hs
+++ b/src/Algebra/Graph/Internal.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- |
--- Module     : Algebra.Graph.Utilities
+-- Module     : Algebra.Graph.Internal
 -- Copyright  : (c) Andrey Mokhov 2016-2017
 -- License    : MIT (see the file LICENSE)
 -- Maintainer : andrey.mokhov@gmail.com
@@ -13,7 +13,7 @@
 -- This module defines various utilities used throughout the library, such as
 -- lists with fast concatenation.
 -----------------------------------------------------------------------------
-module Algebra.Graph.Utilities (
+module Algebra.Graph.Internal (
     -- * Data structures
     List (..)
   ) where

--- a/src/Algebra/Graph/Utilities.hs
+++ b/src/Algebra/Graph/Utilities.hs
@@ -18,6 +18,9 @@ module Algebra.Graph.Utilities (
     List (..)
   ) where
 
+import Prelude ()
+import Prelude.Compat
+
 import Data.Semigroup
 import GHC.Exts
 
@@ -44,6 +47,7 @@ instance Eq a => Eq (List a) where
 instance Ord a => Ord (List a) where
     compare x y = compare (toList x) (toList y)
 
+-- TODO: Add rewrite rules? fromList . toList == toList . fromList == id
 instance IsList (List a) where
     type Item (List a) = a
     fromList        = List . Endo . (<>)

--- a/test/Algebra/Graph/Test/Export.hs
+++ b/test/Algebra/Graph/Test/Export.hs
@@ -27,6 +27,29 @@ import qualified Algebra.Graph.Export.Dot as ED
 
 testExport :: IO ()
 testExport = do
+    putStrLn "\n============ Export.literal ============"
+    test "literal \"Hello, \" <> literal \"World!\" == literal \"Hello, World!\"" $
+          literal "Hello, " <> literal "World!" == literal ("Hello, World!" :: String)
+
+    test "literal \"I am just a string literal\"  == \"I am just a string literal\"" $
+          literal "I am just a string literal"  == ("I am just a string literal" :: Doc String)
+
+    test "literal mempty                        == mempty" $
+          literal mempty                        == (mempty :: Doc String)
+
+    test "render . literal                      == id" $ \(x :: String) ->
+         (render . literal) x                   == x
+
+    test "literal . render                      == id" $ \(xs :: [String]) -> let x = mconcat (map literal xs) in
+         (literal . render) x                   == x
+
+    putStrLn "\n============ Export.render ============"
+    test "render (literal \"al\" <> literal \"ga\") == \"alga\"" $
+          render (literal "al" <> literal "ga") == ("alga" :: String)
+
+    test "render mempty                         == mempty" $
+          render mempty                         == (mempty :: Doc String)
+
     putStrLn "\n============ Export.<+> ============"
     test "x <+> mempty         == x" $ \(x :: Doc String) ->
           x <+> mempty         == x

--- a/test/Algebra/Graph/Test/Internal.hs
+++ b/test/Algebra/Graph/Test/Internal.hs
@@ -1,27 +1,27 @@
 {-# LANGUAGE OverloadedLists #-}
 -----------------------------------------------------------------------------
 -- |
--- Module     : Algebra.Graph.Test.Utilities
+-- Module     : Algebra.Graph.Test.Internal
 -- Copyright  : (c) Andrey Mokhov 2016-2017
 -- License    : MIT (see the file LICENSE)
 -- Maintainer : andrey.mokhov@gmail.com
 -- Stability  : experimental
 --
--- Testsuite for "Algebra.Graph.Utilities".
+-- Testsuite for "Algebra.Graph.Internal".
 -----------------------------------------------------------------------------
-module Algebra.Graph.Test.Utilities (
+module Algebra.Graph.Test.Internal (
     -- * Testsuite
-    testUtilities
+    testInternal
   ) where
 
 import Prelude
 import Data.Monoid
 
-import Algebra.Graph.Utilities
+import Algebra.Graph.Internal
 import Algebra.Graph.Test
 
-testUtilities :: IO ()
-testUtilities = do
-    putStrLn "\n============ Utilities.List ============"
+testInternal :: IO ()
+testInternal = do
+    putStrLn "\n============ Internal.List ============"
     test "pure \"al\" <> pure \"ga\"          == [\"al\", \"ga\"]" $
           pure "al" <> pure "ga"          == (["al", "ga"] :: List String)

--- a/test/Algebra/Graph/Test/Internal.hs
+++ b/test/Algebra/Graph/Test/Internal.hs
@@ -14,7 +14,7 @@ module Algebra.Graph.Test.Internal (
     testInternal
   ) where
 
-import Prelude
+import Control.Applicative (pure)
 import Data.Monoid
 
 import Algebra.Graph.Internal
@@ -23,5 +23,5 @@ import Algebra.Graph.Test
 testInternal :: IO ()
 testInternal = do
     putStrLn "\n============ Internal.List ============"
-    test "pure \"al\" <> pure \"ga\"          == [\"al\", \"ga\"]" $
-          pure "al" <> pure "ga"          == (["al", "ga"] :: List String)
+    test "pure 1 <> pure 4 == [1, 4]" $
+          pure 1 <> pure 4 == ([1, 4] :: List Int)

--- a/test/Algebra/Graph/Test/Utilities.hs
+++ b/test/Algebra/Graph/Test/Utilities.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Test.Utilities
@@ -22,28 +22,6 @@ import Algebra.Graph.Test
 
 testUtilities :: IO ()
 testUtilities = do
-    putStrLn "\n============ Utilities.literal ============"
-    test "literal \"Hello, \" <> literal \"World!\" == literal \"Hello, World!\"" $
-          literal "Hello, " <> literal "World!" == literal ("Hello, World!" :: String)
-
-    test "literal \"I am just a string literal\"  == \"I am just a string literal\"" $
-          literal "I am just a string literal"  == ("I am just a string literal" :: Doc String)
-
-    test "literal mempty                        == mempty" $
-          literal mempty                        == (mempty :: Doc String)
-
-    test "literal \"al\" <> literal \"ga\"          == [\"al\", \"ga\"]" $
-          literal "al" <> literal "ga"          == (["al", "ga"] :: Doc String)
-
-    test "render . literal                      == id" $ \(x :: String) ->
-         (render . literal) x                   == x
-
-    test "literal . render                      == id" $ \(xs :: [String]) -> let x = mconcat (map literal xs) in
-         (literal . render) x                   == x
-
-    putStrLn "\n============ Utilities.render ============"
-    test "render (literal \"al\" <> literal \"ga\") == \"alga\"" $
-          render (literal "al" <> literal "ga") == ("alga" :: String)
-
-    test "render mempty                         == mempty" $
-          render mempty                         == (mempty :: Doc String)
+    putStrLn "\n============ Utilities.List ============"
+    test "pure \"al\" <> pure \"ga\"          == [\"al\", \"ga\"]" $
+          pure "al" <> pure "ga"          == (["al", "ga"] :: List String)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,9 +3,9 @@ import Algebra.Graph.Test.Export
 import Algebra.Graph.Test.Fold
 import Algebra.Graph.Test.Graph
 import Algebra.Graph.Test.IntAdjacencyMap
+import Algebra.Graph.Test.Internal
 import Algebra.Graph.Test.NonEmptyGraph
 import Algebra.Graph.Test.Relation
-import Algebra.Graph.Test.Utilities
 
 main :: IO ()
 main = do
@@ -14,6 +14,6 @@ main = do
     testFold
     testGraph
     testIntAdjacencyMap
+    testInternal
     testNonEmptyGraph
     testRelation
-    testUtilities


### PR DESCRIPTION
We should really split difference lists `List a` whose semantics is a list of elements from documents `Doc a` whose semantics is a single concatenated string (the contents). Mixing these notions leads to surprises.

TODO: update documentation and tests.