### PR TITLE
Extend Algebra.Graph.NonEmpty API

### DIFF
--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -16,7 +16,7 @@
 -----------------------------------------------------------------------------
 module Algebra.Graph.NonEmpty (
     -- * Algebraic data type for non-empty graphs
-    NonEmptyGraph (..),
+    NonEmptyGraph (..), toNonEmptyGraph,
 
     -- * Basic graph construction primitives
     vertex, edge, overlay, connect, vertices1, edges1, overlays1, connects1,
@@ -161,7 +161,13 @@ instance Monad NonEmptyGraph where
     return  = pure
     g >>= f = foldg1 f Overlay Connect g
 
--- TODO: Export
+-- | Convert a 'G.Graph' into 'NonEmptyGraph', returning 'Nothing' if the
+-- argument is 'G.empty'. Complexity: /O(s)/ time, memory and size.
+--
+-- @
+-- toNonEmptyGraph 'G.empty'       == Nothing
+-- toNonEmptyGraph ('C.toGraph' x) == Just (x :: NonEmptyGraph a)
+-- @
 toNonEmptyGraph :: G.Graph a -> Maybe (NonEmptyGraph a)
 toNonEmptyGraph = G.foldg Nothing (Just . Vertex) (go Overlay) (go Connect)
   where

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -19,7 +19,8 @@ module Algebra.Graph.NonEmpty (
     NonEmptyGraph (..), toNonEmptyGraph,
 
     -- * Basic graph construction primitives
-    vertex, edge, overlay, connect, vertices1, edges1, overlays1, connects1,
+    vertex, edge, overlay, overlay1, connect, vertices1, edges1, overlays1,
+    connects1,
 
     -- * Graph folding
     foldg1,
@@ -217,6 +218,18 @@ edge u v = connect (vertex u) (vertex v)
 -- @
 overlay :: NonEmptyGraph a -> NonEmptyGraph a -> NonEmptyGraph a
 overlay = Overlay
+
+-- | Overlay a possibly empty graph with a non-empty graph. If the first
+-- argument is 'G.empty', the function returns the second argument; otherwise
+-- it is semantically the same as 'overlay'. Complexity: /O(s1)/ time and
+-- memory, and /O(s1 + s2)/ size.
+--
+-- @
+--                overlay1 'G.empty' x == x
+-- x /= 'G.empty' ==> overlay1 x     y == overlay (fromJust $ toNonEmptyGraph x) y
+-- @
+overlay1 :: G.Graph a -> NonEmptyGraph a -> NonEmptyGraph a
+overlay1 = maybe id overlay . toNonEmptyGraph
 
 -- | /Connect/ two graphs. An alias for the constructor 'Connect'. This is an
 -- associative operation, which distributes over 'overlay' and obeys the
@@ -575,10 +588,6 @@ removeEdge s t g = case interface (focus (==s) g) of
 
 focus :: (a -> Bool) -> NonEmptyGraph a -> Focus a
 focus f = foldg1 (vertexFocus f) overlayFoci connectFoci
-
--- TODO: Export
-overlay1 :: G.Graph a -> NonEmptyGraph a -> NonEmptyGraph a
-overlay1 = maybe id overlay . toNonEmptyGraph
 
 -- | The function @'replaceVertex' x y@ replaces vertex @x@ with vertex @y@ in a
 -- given 'NonEmptyGraph'. If @y@ already exists, @x@ and @y@ will be merged.

--- a/test/Algebra/Graph/Test/NonEmptyGraph.hs
+++ b/test/Algebra/Graph/Test/NonEmptyGraph.hs
@@ -22,9 +22,11 @@ import Data.Tuple
 import Algebra.Graph.NonEmpty
 import Algebra.Graph.Test hiding (axioms, theorems)
 
-import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.Set           as Set
-import qualified Data.IntSet        as IntSet
+import qualified Algebra.Graph       as G
+import qualified Algebra.Graph.Class as C
+import qualified Data.List.NonEmpty  as NonEmpty
+import qualified Data.Set            as Set
+import qualified Data.IntSet         as IntSet
 
 type G = NonEmptyGraph Int
 
@@ -82,6 +84,13 @@ testNonEmptyGraph = do
 
     test "((x >>= f) >>= g)    == (x >>= (\\y -> (f y) >>= g))" $ mapSize (min 10) $ \(x :: G) (apply -> f) (apply -> g) ->
           ((x >>= f) >>= g)    == (x >>= (\(y :: Int) -> (f y) >>= (g :: Int -> G)))
+
+    putStrLn $ "\n============ Graph.NonEmpty.toNonEmptyGraph ============"
+    test "toNonEmptyGraph empty       == Nothing" $
+          toNonEmptyGraph (G.empty :: G.Graph Int) == Nothing
+
+    test "toNonEmptyGraph (toGraph x) == Just (g :: NonEmptyGraph a)" $ \x ->
+          toNonEmptyGraph (C.toGraph x) == Just (x :: NonEmptyGraph Int)
 
     putStrLn $ "\n============ Graph.NonEmpty.vertex ============"
     test "hasVertex x (vertex x) == True" $ \(x :: Int) ->

--- a/test/Algebra/Graph/Test/NonEmptyGraph.hs
+++ b/test/Algebra/Graph/Test/NonEmptyGraph.hs
@@ -15,6 +15,7 @@ module Algebra.Graph.Test.NonEmptyGraph (
   ) where
 
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe
 import Data.Semigroup
 import Data.Tree
 import Data.Tuple
@@ -89,7 +90,7 @@ testNonEmptyGraph = do
     test "toNonEmptyGraph empty       == Nothing" $
           toNonEmptyGraph (G.empty :: G.Graph Int) == Nothing
 
-    test "toNonEmptyGraph (toGraph x) == Just (g :: NonEmptyGraph a)" $ \x ->
+    test "toNonEmptyGraph (toGraph x) == Just (x :: NonEmptyGraph a)" $ \x ->
           toNonEmptyGraph (C.toGraph x) == Just (x :: NonEmptyGraph Int)
 
     putStrLn $ "\n============ Graph.NonEmpty.vertex ============"
@@ -145,6 +146,14 @@ testNonEmptyGraph = do
 
     test "edgeCount   (overlay 1 2) == 0" $
           edgeCount   (overlay 1 2 :: G) == 0
+
+    putStrLn $ "\n============ Graph.NonEmpty.overlay1 ============"
+    test "               overlay1 empty x == x" $ \(x :: G) ->
+                         overlay1 G.empty x == x
+
+    test "x /= empty ==> overlay1 x     y == overlay (fromJust $ toNonEmptyGraph x) y" $ \(x :: G.Graph Int) (y :: G) ->
+          x /= G.empty ==> overlay1 x   y == overlay (fromJust $ toNonEmptyGraph x) y
+
 
     putStrLn $ "\n============ Graph.NonEmpty.connect ============"
     test "hasVertex z (connect x y) == hasVertex z x || hasVertex z y" $ \(x :: G) y z ->


### PR DESCRIPTION
Export `toNonEmptyGraph` and `overlay1` functions implemented as part of #43. 