### PR TITLE
Allow base-compat-0.10

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -77,7 +77,7 @@ library
                         Algebra.Graph.Relation.Transitive
     build-depends:      array       >= 0.4     && < 0.6,
                         base        >= 4.7     && < 5,
-                        base-compat >= 0.9.1   && < 0.10,
+                        base-compat >= 0.9.1   && < 0.11,
                         containers  >= 0.5.5.1 && < 0.8,
                         deepseq     >= 1.3.0.1 && < 1.5
     if !impl(ghc >= 8.0)


### PR DESCRIPTION
A revision, or new release would be great! 

Note: PVP says next version can be `0.1.1.1`, as first three digits stays the same we "communicate" that there are no publicly visible changes in the API - which makes update a no-brainer. FWIW, 0.1.1 could been `0.1.0.1` - I was a little disappointed as there weren't "new features" in 0.1.1 :( - That said, it's not wrong, it's only not as semantically precise as it could be. I'm confused by those things myself.