### PR TITLE
Draft for extracting King-Launchbury graphs from AdjacencyMap

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -67,7 +67,6 @@ library
                         Algebra.Graph.IntAdjacencyMap,
                         Algebra.Graph.IntAdjacencyMap.Internal,
                         Algebra.Graph.Internal,
-                        Algebra.Graph.KingLaunchbury,
                         Algebra.Graph.NonEmpty,
                         Algebra.Graph.Relation,
                         Algebra.Graph.Relation.Internal,
@@ -75,7 +74,8 @@ library
                         Algebra.Graph.Relation.Preorder,
                         Algebra.Graph.Relation.Reflexive,
                         Algebra.Graph.Relation.Symmetric,
-                        Algebra.Graph.Relation.Transitive
+                        Algebra.Graph.Relation.Transitive,
+                        Data.Graph.Typed
     build-depends:      array       >= 0.4     && < 0.6,
                         base        >= 4.7     && < 5,
                         base-compat >= 0.9.1   && < 0.11,

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -67,6 +67,7 @@ library
                         Algebra.Graph.IntAdjacencyMap,
                         Algebra.Graph.IntAdjacencyMap.Internal,
                         Algebra.Graph.Internal,
+                        Algebra.Graph.KingLaunchbury,
                         Algebra.Graph.NonEmpty,
                         Algebra.Graph.Relation,
                         Algebra.Graph.Relation.Internal,

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -118,8 +118,10 @@ test-suite test-alga
                         Algebra.Graph.Test.IntAdjacencyMap,
                         Algebra.Graph.Test.Internal,
                         Algebra.Graph.Test.NonEmptyGraph,
-                        Algebra.Graph.Test.Relation
+                        Algebra.Graph.Test.Relation,
+                        Data.Graph.Test.Typed
     build-depends:      algebraic-graphs,
+                        array        >= 0.4     && < 0.6,
                         base         >= 4.7     && < 5,
                         base-compat  >= 0.9.1   && < 0.10,
                         base-orphans >= 0.5.4   && < 0.8,

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -623,8 +623,7 @@ topSort :: Ord a => AdjacencyMap a -> Maybe [a]
 topSort m =
     if isTopSort result m then Just result else Nothing
   where
-    (Typed.GraphKL g r _) = Typed.fromAdjacencyMap m
-    result = map r (KL.topSort g)
+    result = Typed.topSort (Typed.fromAdjacencyMap m)
 
 -- | Check if a given list of vertices is a valid /topological sort/ of a graph.
 --

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -50,7 +50,6 @@ import Algebra.Graph.AdjacencyMap.Internal
 import qualified Algebra.Graph.Class as C
 import qualified Data.Map.Strict     as Map
 import qualified Data.Set            as Set
-import qualified Data.List           as List
 
 -- | Construct the /empty graph/.
 -- Complexity: /O(1)/ time and memory.
@@ -593,7 +592,9 @@ dfsForest g = dfsForestFrom (vertexList g) g
 dfsForestFrom :: Ord a => [a] -> AdjacencyMap a -> Forest a
 dfsForestFrom vs g = snd (chop Set.empty (map (go g) valid))
   where
-    valid = List.intersect vs (vertexList g)
+    -- We need to keep the order of vs
+    valid = filter (flip Set.member valid') vs
+    valid' = Set.intersection (Set.fromList vs) (Map.keysSet (adjacencyMap g))
 
     go :: Ord a => AdjacencyMap a -> a -> Tree a
     go g v = Node v (map (go g) (maybe [] Set.toList (Map.lookup v (adjacencyMap g))))

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -596,7 +596,7 @@ dfsForestFrom vs g = snd (chop Set.empty (map (go g) valid))
     valid = List.intersect vs (vertexList g)
 
     go :: Ord a => AdjacencyMap a -> a -> Tree a
-    go g v = Node v (map (go g) (maybe [] Set.toList (adjacencyMap g Map.!? v)))
+    go g v = Node v (map (go g) (maybe [] Set.toList (Map.lookup v (adjacencyMap g))))
 
     chop :: Ord a => Set a -> Forest a -> (Set a, Forest a)
     chop known [] = (known, [])

--- a/src/Algebra/Graph/IntAdjacencyMap.hs
+++ b/src/Algebra/Graph/IntAdjacencyMap.hs
@@ -49,7 +49,6 @@ import Algebra.Graph.IntAdjacencyMap.Internal
 
 import qualified Algebra.Graph.Class as C
 import qualified Data.Graph.Typed    as Typed
-import qualified Data.Graph          as KL
 import qualified Data.IntMap.Strict  as IntMap
 import qualified Data.IntSet         as IntSet
 import qualified Data.Set            as Set
@@ -626,8 +625,7 @@ topSort :: IntAdjacencyMap -> Maybe [Int]
 topSort m =
     if isTopSort result m then Just result else Nothing
   where
-    (Typed.GraphKL g r _) = Typed.fromIntAdjacencyMap m
-    result = map r (KL.topSort g)
+    result = Typed.topSort (Typed.fromIntAdjacencyMap m)
 
 -- | Check if a given list of vertices is a valid /topological sort/ of a graph.
 --

--- a/src/Algebra/Graph/IntAdjacencyMap.hs
+++ b/src/Algebra/Graph/IntAdjacencyMap.hs
@@ -42,13 +42,13 @@ module Algebra.Graph.IntAdjacencyMap (
   ) where
 
 import Data.IntSet (IntSet)
-import Data.Maybe
 import Data.Set (Set)
 import Data.Tree
 
 import Algebra.Graph.IntAdjacencyMap.Internal
 
 import qualified Algebra.Graph.Class as C
+import qualified Data.Graph.Typed    as Typed
 import qualified Data.Graph          as KL
 import qualified Data.IntMap.Strict  as IntMap
 import qualified Data.IntSet         as IntSet
@@ -141,7 +141,7 @@ connect = C.connect
 -- 'vertexIntSet' . vertices == IntSet.'IntSet.fromList'
 -- @
 vertices :: [Int] -> IntAdjacencyMap
-vertices = mkAM . IntMap.fromList . map (\x -> (x, IntSet.empty))
+vertices = AM . IntMap.fromList . map (\x -> (x, IntSet.empty))
 
 -- | Construct the graph from a list of edges.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
@@ -192,7 +192,7 @@ connects = C.connects
 -- 'overlay' (fromAdjacencyList xs) (fromAdjacencyList ys) == fromAdjacencyList (xs ++ ys)
 -- @
 fromAdjacencyList :: [(Int, [Int])] -> IntAdjacencyMap
-fromAdjacencyList as = mkAM $ IntMap.unionWith IntSet.union vs es
+fromAdjacencyList as = AM $ IntMap.unionWith IntSet.union vs es
   where
     ss = map (fmap IntSet.fromList) as
     vs = IntMap.fromSet (const IntSet.empty) . IntSet.unions $ map snd ss
@@ -298,7 +298,7 @@ vertexList = IntMap.keys . adjacencyMap
 -- edgeList . 'transpose'    == 'Data.List.sort' . map 'Data.Tuple.swap' . edgeList
 -- @
 edgeList :: IntAdjacencyMap -> [(Int, Int)]
-edgeList (AM m _) = [ (x, y) | (x, ys) <- IntMap.toAscList m, y <- IntSet.toAscList ys ]
+edgeList (AM m) = [ (x, y) | (x, ys) <- IntMap.toAscList m, y <- IntSet.toAscList ys ]
 
 -- | The sorted /adjacency list/ of a graph.
 -- Complexity: /O(n + m)/ time and /O(m)/ memory.
@@ -399,7 +399,7 @@ clique = C.clique
 -- biclique xs      ys      == 'connect' ('vertices' xs) ('vertices' ys)
 -- @
 biclique :: [Int] -> [Int] -> IntAdjacencyMap
-biclique xs ys = mkAM $ IntMap.fromSet adjacent (x `IntSet.union` y)
+biclique xs ys = AM $ IntMap.fromSet adjacent (x `IntSet.union` y)
   where
     x = IntSet.fromList xs
     y = IntSet.fromList ys
@@ -468,7 +468,7 @@ forest = C.forest
 -- removeVertex x . removeVertex x == removeVertex x
 -- @
 removeVertex :: Int -> IntAdjacencyMap -> IntAdjacencyMap
-removeVertex x = mkAM . IntMap.map (IntSet.delete x) . IntMap.delete x . adjacencyMap
+removeVertex x = AM . IntMap.map (IntSet.delete x) . IntMap.delete x . adjacencyMap
 
 -- | Remove an edge from a given graph.
 -- Complexity: /O(log(n))/ time.
@@ -481,7 +481,7 @@ removeVertex x = mkAM . IntMap.map (IntSet.delete x) . IntMap.delete x . adjacen
 -- removeEdge 1 2 (1 * 1 * 2 * 2)  == 1 * 1 + 2 * 2
 -- @
 removeEdge :: Int -> Int -> IntAdjacencyMap -> IntAdjacencyMap
-removeEdge x y = mkAM . IntMap.adjust (IntSet.delete y) x . adjacencyMap
+removeEdge x y = AM . IntMap.adjust (IntSet.delete y) x . adjacencyMap
 
 -- | The function @'replaceVertex' x y@ replaces vertex @x@ with vertex @y@ in a
 -- given 'IntAdjacencyMap'. If @y@ already exists, @x@ and @y@ will be merged.
@@ -519,7 +519,7 @@ mergeVertices p v = gmap $ \u -> if p u then v else u
 -- 'edgeList' . transpose  == 'Data.List.sort' . map 'Data.Tuple.swap' . 'edgeList'
 -- @
 transpose :: IntAdjacencyMap -> IntAdjacencyMap
-transpose (AM m _) = mkAM $ IntMap.foldrWithKey combine vs m
+transpose (AM m) = AM $ IntMap.foldrWithKey combine vs m
   where
     combine v es = IntMap.unionWith IntSet.union (IntMap.fromSet (const $ IntSet.singleton v) es)
     vs           = IntMap.fromSet (const IntSet.empty) (IntMap.keysSet m)
@@ -537,7 +537,7 @@ transpose (AM m _) = mkAM $ IntMap.foldrWithKey combine vs m
 -- gmap f . gmap g   == gmap (f . g)
 -- @
 gmap :: (Int -> Int) -> IntAdjacencyMap -> IntAdjacencyMap
-gmap f = mkAM . IntMap.map (IntSet.map f) . IntMap.mapKeysWith IntSet.union f . adjacencyMap
+gmap f = AM . IntMap.map (IntSet.map f) . IntMap.mapKeysWith IntSet.union f . adjacencyMap
 
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
@@ -552,7 +552,7 @@ gmap f = mkAM . IntMap.map (IntSet.map f) . IntMap.mapKeysWith IntSet.union f . 
 -- 'isSubgraphOf' (induce p x) x == True
 -- @
 induce :: (Int -> Bool) -> IntAdjacencyMap -> IntAdjacencyMap
-induce p = mkAM . IntMap.map (IntSet.filter p) . IntMap.filterWithKey (\k _ -> p k) . adjacencyMap
+induce p = AM . IntMap.map (IntSet.filter p) . IntMap.filterWithKey (\k _ -> p k) . adjacencyMap
 
 -- | Compute the /depth-first search/ forest of a graph.
 --
@@ -572,7 +572,7 @@ induce p = mkAM . IntMap.map (IntSet.filter p) . IntMap.filterWithKey (\k _ -> p
 --                                                                      , subForest = [] }]}]
 -- @
 dfsForest :: IntAdjacencyMap -> Forest Int
-dfsForest (AM _ (GraphKL g r _)) = fmap (fmap r) (KL.dff g)
+dfsForest = Typed.dfsForest . Typed.fromIntAdjacencyMap
 
 -- | Compute the /depth-first search/ forest of a graph, searching from each of
 -- the given vertices in order. Note that the resulting forest does not
@@ -595,7 +595,7 @@ dfsForest (AM _ (GraphKL g r _)) = fmap (fmap r) (KL.dff g)
 --                                                        , subForest = [] }]
 -- @
 dfsForestFrom :: [Int] -> IntAdjacencyMap -> Forest Int
-dfsForestFrom vs (AM _ (GraphKL g r t)) = fmap (fmap r) (KL.dfs g (mapMaybe t vs))
+dfsForestFrom vs = Typed.dfsForestFrom vs . Typed.fromIntAdjacencyMap
 
 -- | Compute the list of vertices visited by the /depth-first search/ in a graph,
 -- when searching from each of the given vertices in order.
@@ -623,9 +623,10 @@ dfs vs = concatMap flatten . dfsForestFrom vs
 -- fmap (flip 'isTopSort' x) (topSort x) /= Just False
 -- @
 topSort :: IntAdjacencyMap -> Maybe [Int]
-topSort m@(AM _ (GraphKL g r _)) =
+topSort m =
     if isTopSort result m then Just result else Nothing
   where
+    (Typed.GraphKL g r _) = Typed.fromIntAdjacencyMap m
     result = map r (KL.topSort g)
 
 -- | Check if a given list of vertices is a valid /topological sort/ of a graph.

--- a/src/Algebra/Graph/IntAdjacencyMap/Internal.hs
+++ b/src/Algebra/Graph/IntAdjacencyMap/Internal.hs
@@ -12,10 +12,7 @@
 -----------------------------------------------------------------------------
 module Algebra.Graph.IntAdjacencyMap.Internal (
     -- * Adjacency map implementation
-    IntAdjacencyMap (..), mkAM, consistent,
-
-    -- * Interoperability with King-Launchbury graphs
-    GraphKL (..), mkGraphKL
+    IntAdjacencyMap(..), consistent
   ) where
 
 import Data.IntMap.Strict (IntMap, keysSet, fromSet)
@@ -24,7 +21,6 @@ import Data.List
 
 import Algebra.Graph.Class
 
-import qualified Data.Graph         as KL
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.IntSet        as IntSet
 
@@ -88,25 +84,16 @@ The following useful theorems can be proved from the above set of axioms.
 When specifying the time and memory complexity of graph algorithms, /n/ and /m/
 will denote the number of vertices and edges in the graph, respectively.
 -}
-data IntAdjacencyMap = AM {
+newtype IntAdjacencyMap = AM {
     -- | The /adjacency map/ of the graph: each vertex is associated with a set
     -- of its direct successors.
-    adjacencyMap :: !(IntMap IntSet),
-    -- | Cached King-Launchbury representation.
-    -- /Note: this field is for internal use only/.
-    graphKL :: GraphKL }
-
--- | Construct an 'AdjacencyMap' from a map of successor sets and (lazily)
--- compute the corresponding King-Launchbury representation.
--- /Note: this function is for internal use only/.
-mkAM :: IntMap IntSet -> IntAdjacencyMap
-mkAM m = AM m (mkGraphKL m)
+    adjacencyMap :: IntMap IntSet}
 
 instance Eq IntAdjacencyMap where
     x == y = adjacencyMap x == adjacencyMap y
 
 instance Show IntAdjacencyMap where
-    show (AM m _)
+    show (AM m)
         | null vs    = "empty"
         | null es    = vshow vs
         | vs == used = eshow es
@@ -122,10 +109,10 @@ instance Show IntAdjacencyMap where
 
 instance Graph IntAdjacencyMap where
     type Vertex IntAdjacencyMap = Int
-    empty       = mkAM   IntMap.empty
-    vertex x    = mkAM $ IntMap.singleton x IntSet.empty
-    overlay x y = mkAM $ IntMap.unionWith IntSet.union (adjacencyMap x) (adjacencyMap y)
-    connect x y = mkAM $ IntMap.unionsWith IntSet.union [ adjacencyMap x, adjacencyMap y,
+    empty       = AM   IntMap.empty
+    vertex x    = AM $ IntMap.singleton x IntSet.empty
+    overlay x y = AM $ IntMap.unionWith IntSet.union (adjacencyMap x) (adjacencyMap y)
+    connect x y = AM $ IntMap.unionsWith IntSet.union [ adjacencyMap x, adjacencyMap y,
         fromSet (const . keysSet $ adjacencyMap y) (keysSet $ adjacencyMap x) ]
 
 instance Num IntAdjacencyMap where
@@ -156,7 +143,7 @@ instance ToGraph IntAdjacencyMap where
 -- consistent ('Algebra.Graph.IntAdjacencyMap.fromAdjacencyList' xs) == True
 -- @
 consistent :: IntAdjacencyMap -> Bool
-consistent (AM m _) = referredToVertexSet m `IntSet.isSubsetOf` keysSet m
+consistent (AM m) = referredToVertexSet m `IntSet.isSubsetOf` keysSet m
 
 -- The set of vertices that are referred to by the edges
 referredToVertexSet :: IntMap IntSet -> IntSet
@@ -165,32 +152,3 @@ referredToVertexSet = IntSet.fromList . uncurry (++) . unzip . internalEdgeList
 -- The list of edges in adjacency map
 internalEdgeList :: IntMap IntSet -> [(Int, Int)]
 internalEdgeList m = [ (x, y) | (x, ys) <- IntMap.toAscList m, y <- IntSet.toAscList ys ]
-
--- | 'GraphKL' encapsulates King-Launchbury graphs, which are implemented in
--- the "Data.Graph" module of the @containers@ library.
--- /Note: this data structure is for internal use only/.
---
--- If @mkGraphKL (adjacencyMap g) == h@ then the following holds:
---
--- @
--- map ('fromVertexKL' h) ('Data.Graph.vertices' $ 'toGraphKL' h)                               == 'Algebra.Graph.AdjacencyMap.vertexList' g
--- map (\\(x, y) -> ('fromVertexKL' h x, 'fromVertexKL' h y)) ('Data.Graph.edges' $ 'toGraphKL' h) == 'Algebra.Graph.AdjacencyMap.edgeList' g
--- @
-data GraphKL = GraphKL {
-    -- | Array-based graph representation (King and Launchbury, 1995).
-    toGraphKL :: KL.Graph,
-    -- | A mapping of "Data.Graph.Vertex" to vertices of type @Int@.
-    fromVertexKL :: KL.Vertex -> Int,
-    -- | A mapping from vertices of type @Int@ to "Data.Graph.Vertex".
-    -- Returns 'Nothing' if the argument is not in the graph.
-    toVertexKL :: Int -> Maybe KL.Vertex }
-
--- | Build 'GraphKL' from a map of successor sets.
--- /Note: this function is for internal use only/.
-mkGraphKL :: IntMap IntSet -> GraphKL
-mkGraphKL m = GraphKL
-    { toGraphKL    = g
-    , fromVertexKL = \u -> case r u of (_, v, _) -> v
-    , toVertexKL   = t }
-  where
-    (g, r, t) = KL.graphFromEdges [ ((), v, IntSet.toAscList us) | (v, us) <- IntMap.toAscList m ]

--- a/src/Algebra/Graph/KingLaunchbury.hs
+++ b/src/Algebra/Graph/KingLaunchbury.hs
@@ -1,0 +1,182 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module     : Algebra.Graph.KingLaunchbury
+-- Copyright  : (c) Anton Lorenzen 2016-2018
+-- License    : MIT (see the file LICENSE)
+-- Maintainer : andrey.mokhov@gmail.com
+-- Stability  : experimental
+--
+-- __Alga__ is a library for algebraic construction and manipulation of graphs
+-- in Haskell. See <https://github.com/snowleopard/alga-paper this paper> for the
+-- motivation behind the library, the underlying theory, and implementation details.
+--
+-- This module provides primitives for interoperability between this library and
+-- the 'Data.Graph' module of the containers library.
+-----------------------------------------------------------------------------
+module Algebra.Graph.KingLaunchbury (
+  GraphKL(..),
+  fromAdjacencyMap, toAdjacenyMap, toAdjacenyMap2,
+  dfsForest, dfsForestFrom, dfs, topSort, isTopSort, scc
+  ) where
+
+import qualified Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap.Internal
+
+import Data.Tree
+import Data.Set (Set)
+import Data.Foldable (toList)
+import Data.Maybe
+
+import qualified Data.Graph as KL
+import qualified Data.Map.Strict     as Map
+import qualified Data.Set            as Set
+import qualified Data.Array          as Array
+import qualified Data.List           as List
+
+-- | 'GraphKL' encapsulates King-Launchbury graphs, which are implemented in
+-- the "Data.Graph" module of the @containers@ library.
+data GraphKL a = GraphKL {
+    -- | Array-based graph representation (King and Launchbury, 1995).
+    toGraphKL :: KL.Graph,
+    -- | A mapping of "Data.Graph.Vertex" to vertices of type @a@.
+    fromVertexKL :: KL.Vertex -> a,
+    -- | A mapping from vertices of type @a@ to "Data.Graph.Vertex".
+    -- Returns 'Nothing' if the argument is not in the graph.
+    toVertexKL :: a -> Maybe KL.Vertex }
+
+-- | Build 'GraphKL' from an 'AdjacencyMap'.
+-- If @mkGraphKL (adjacencyMap g) == h@ then the following holds:
+--
+-- @
+-- map ('fromVertexKL' h) ('Data.Graph.vertices' $ 'toGraphKL' h)                               == 'Algebra.Graph.AdjacencyMap.vertexList' g
+-- map (\\(x, y) -> ('fromVertexKL' h x, 'fromVertexKL' h y)) ('Data.Graph.edges' $ 'toGraphKL' h) == 'Algebra.Graph.AdjacencyMap.edgeList' g
+-- @
+fromAdjacencyMap :: Ord a => AdjacencyMap a -> GraphKL a
+fromAdjacencyMap (AM m) = GraphKL
+    { toGraphKL    = g
+    , fromVertexKL = \u -> case r u of (_, v, _) -> v
+    , toVertexKL   = t }
+  where
+    (g, r, t) = KL.graphFromEdges [ ((), v, Set.toAscList us) | (v, us) <- Map.toAscList m ]
+
+-- | Build an 'AdjacencyMap' from a 'GraphKL'.
+toAdjacenyMap :: Ord a => GraphKL a -> AdjacencyMap a
+toAdjacenyMap (GraphKL g from _) = AM $ Map.fromList
+  $ map (\v -> (from v, Set.fromList $ map from $ g Array.! v)) $ KL.vertices g
+
+-- | Build an 'AdjacencyMap' from a 'GraphKL'.
+-- Alternative, possible faster implementation -> TODO: Benchmark!
+toAdjacenyMap2 :: Ord a => GraphKL a -> AdjacencyMap a
+toAdjacenyMap2 (GraphKL g from _) = AM $ Map.mapKeys from $ Map.fromDistinctAscList
+  $ map (\v -> (v, Set.fromList $ map from $ g Array.! v)) $ KL.vertices g
+
+-- | Compute the /depth-first search/ forest of a graph.
+--
+-- @
+-- 'forest' (dfsForest $ 'edge' 1 1)         == 'vertex' 1
+-- 'forest' (dfsForest $ 'edge' 1 2)         == 'edge' 1 2
+-- 'forest' (dfsForest $ 'edge' 2 1)         == 'vertices' [1, 2]
+-- 'isSubgraphOf' ('forest' $ dfsForest x) x == True
+-- dfsForest . 'forest' . dfsForest        == dfsForest
+-- dfsForest ('vertices' vs)               == map (\\v -> Node v []) ('Data.List.nub' $ 'Data.List.sort' vs)
+-- 'dfsForestFrom' ('vertexList' x) x        == dfsForest x
+-- dfsForest $ 3 * (1 + 4) * (1 + 5)     == [ Node { rootLabel = 1
+--                                                 , subForest = [ Node { rootLabel = 5
+--                                                                      , subForest = [] }]}
+--                                          , Node { rootLabel = 3
+--                                                 , subForest = [ Node { rootLabel = 4
+--                                                                      , subForest = [] }]}]
+-- @
+dfsForest :: GraphKL a -> Forest a
+dfsForest (GraphKL g r _) = fmap (fmap r) (KL.dff g)
+
+-- | Compute the /depth-first search/ forest of a graph, searching from each of
+-- the given vertices in order. Note that the resulting forest does not
+-- necessarily span the whole graph, as some vertices may be unreachable.
+--
+-- @
+-- 'forest' (dfsForestFrom [1]    $ 'edge' 1 1)     == 'vertex' 1
+-- 'forest' (dfsForestFrom [1]    $ 'edge' 1 2)     == 'edge' 1 2
+-- 'forest' (dfsForestFrom [2]    $ 'edge' 1 2)     == 'vertex' 2
+-- 'forest' (dfsForestFrom [3]    $ 'edge' 1 2)     == 'empty'
+-- 'forest' (dfsForestFrom [2, 1] $ 'edge' 1 2)     == 'vertices' [1, 2]
+-- 'isSubgraphOf' ('forest' $ dfsForestFrom vs x) x == True
+-- dfsForestFrom ('vertexList' x) x               == 'dfsForest' x
+-- dfsForestFrom vs             ('vertices' vs)   == map (\\v -> Node v []) ('Data.List.nub' vs)
+-- dfsForestFrom []             x               == []
+-- dfsForestFrom [1, 4] $ 3 * (1 + 4) * (1 + 5) == [ Node { rootLabel = 1
+--                                                        , subForest = [ Node { rootLabel = 5
+--                                                                             , subForest = [] }
+--                                                 , Node { rootLabel = 4
+--                                                        , subForest = [] }]
+-- @
+dfsForestFrom :: [a] -> GraphKL a -> Forest a
+dfsForestFrom vs (GraphKL g r t) = fmap (fmap r) (KL.dfs g (mapMaybe t vs))
+
+-- | Compute the list of vertices visited by the /depth-first search/ in a graph,
+-- when searching from each of the given vertices in order.
+--
+-- @
+-- dfs [1]    $ 'edge' 1 1                == [1]
+-- dfs [1]    $ 'edge' 1 2                == [1, 2]
+-- dfs [2]    $ 'edge' 1 2                == [2]
+-- dfs [3]    $ 'edge' 1 2                == []
+-- dfs [1, 2] $ 'edge' 1 2                == [1, 2]
+-- dfs [2, 1] $ 'edge' 1 2                == [2, 1]
+-- dfs []     $ x                       == []
+-- dfs [1, 4] $ 3 * (1 + 4) * (1 + 5)   == [1, 5, 4]
+-- 'isSubgraphOf' ('vertices' $ dfs vs x) x == True
+-- @
+dfs :: [a] -> GraphKL a -> [a]
+dfs vs = concatMap flatten . dfsForestFrom vs
+
+-- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph
+-- is cyclic.
+--
+-- @
+-- topSort (1 * 2 + 3 * 1)             == Just [3,1,2]
+-- topSort (1 * 2 + 2 * 1)             == Nothing
+-- fmap (flip 'isTopSort' x) (topSort x) /= Just False
+-- @
+topSort :: GraphKL a -> Maybe [a]
+topSort m@(GraphKL g r _) =
+    if isTopSort result m then Just result else Nothing
+  where
+    result = map r (KL.topSort g)
+
+-- | Check if a given list of vertices is a valid /topological sort/ of a graph.
+--
+-- @
+-- isTopSort [3, 1, 2] (1 * 2 + 3 * 1) == True
+-- isTopSort [1, 2, 3] (1 * 2 + 3 * 1) == False
+-- isTopSort []        (1 * 2 + 3 * 1) == False
+-- isTopSort []        'empty'           == True
+-- isTopSort [x]       ('vertex' x)      == True
+-- isTopSort [x]       ('edge' x x)      == False
+-- @
+isTopSort :: [a] -> GraphKL a -> Bool
+isTopSort xs (GraphKL g _ t) = maybe False (go []) (mapM t xs)
+  where
+    go seen []     = seen == KL.vertices g
+    go seen (v:vs) = let newSeen = seen `seq` v:seen
+        in KL.reachable g v `List.intersect` newSeen == [] && go newSeen vs
+
+-- | Compute the /condensation/ of a graph, where each vertex corresponds to a
+-- /strongly-connected component/ of the original graph.
+--
+-- @
+-- scc 'empty'               == 'empty'
+-- scc ('vertex' x)          == 'vertex' (Set.'Set.singleton' x)
+-- scc ('edge' x y)          == 'edge' (Set.'Set.singleton' x) (Set.'Set.singleton' y)
+-- scc ('circuit' (1:xs))    == 'edge' (Set.'Set.fromList' (1:xs)) (Set.'Set.fromList' (1:xs))
+-- scc (3 * 1 * 4 * 1 * 5) == 'edges' [ (Set.'Set.fromList' [1,4], Set.'Set.fromList' [1,4])
+--                                  , (Set.'Set.fromList' [1,4], Set.'Set.fromList' [5]  )
+--                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [1,4])
+--                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [5]  )]
+-- @
+scc :: Ord a => AdjacencyMap a -> GraphKL a -> AdjacencyMap (Set a)
+scc m (GraphKL g r _) =
+    AM.gmap (\v -> Map.findWithDefault Set.empty v components) m
+  where
+    components = Map.fromList $ concatMap (expand . fmap r . toList) (KL.scc g)
+    expand xs  = let s = Set.fromList xs in map (\x -> (x, s)) xs

--- a/src/Data/Graph/Typed.hs
+++ b/src/Data/Graph/Typed.hs
@@ -1,9 +1,9 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.KingLaunchbury
--- Copyright  : (c) Anton Lorenzen 2016-2018
+-- Copyright  : (c) Anton Lorenzen, Andrey Mokhov 2016-2018
 -- License    : MIT (see the file LICENSE)
--- Maintainer : andrey.mokhov@gmail.com
+-- Maintainer : anfelor@posteo.de, andrey.mokhov@gmail.com
 -- Stability  : unstable
 --
 -- __Alga__ is a library for algebraic construction and manipulation of graphs

--- a/src/Data/Graph/Typed.hs
+++ b/src/Data/Graph/Typed.hs
@@ -18,7 +18,7 @@ module Data.Graph.Typed (
   GraphKL(..),
   fromAdjacencyMap, toAdjacenyMap, toAdjacenyMap2,
   fromIntAdjacencyMap, toIntAdjacencyMap,
-  dfsForest, dfsForestFrom, dfs
+  dfsForest, dfsForestFrom, dfs, topSort
   ) where
 
 import Algebra.Graph.AdjacencyMap.Internal as AM (AdjacencyMap(..))
@@ -143,3 +143,14 @@ dfsForestFrom vs (GraphKL g r t) = fmap (fmap r) (KL.dfs g (mapMaybe t vs))
 -- @
 dfs :: [a] -> GraphKL a -> [a]
 dfs vs = concatMap flatten . dfsForestFrom vs
+
+-- | Compute the /topological sort/ of a graph.
+-- Unlike the (Int)AdjacencyMap algorithm this returns
+-- a result even if the graph is cyclic.
+--
+-- @
+-- topSort (1 * 2 + 3 * 1)             == [3,1,2]
+-- topSort (1 * 2 + 2 * 1)             == [1,2]
+-- @
+topSort :: GraphKL a -> [a]
+topSort (GraphKL g r _) = map r (KL.topSort g)

--- a/src/Data/Graph/Typed.hs
+++ b/src/Data/Graph/Typed.hs
@@ -16,8 +16,7 @@
 -----------------------------------------------------------------------------
 module Data.Graph.Typed (
   GraphKL(..),
-  fromAdjacencyMap, toAdjacenyMap, toAdjacenyMap2,
-  fromIntAdjacencyMap, toIntAdjacencyMap,
+  fromAdjacencyMap, fromIntAdjacencyMap,
   dfsForest, dfsForestFrom, dfs, topSort
   ) where
 
@@ -32,7 +31,6 @@ import qualified Data.Map.Strict    as Map
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Set           as Set
 import qualified Data.IntSet        as IntSet
-import qualified Data.Array         as Array
 
 -- | 'GraphKL' encapsulates King-Launchbury graphs, which are implemented in
 -- the "Data.Graph" module of the @containers@ library.
@@ -67,22 +65,6 @@ fromIntAdjacencyMap (IAM.AM m) = GraphKL
     , toVertexKL   = t }
   where
     (g, r, t) = KL.graphFromEdges [ ((), v, IntSet.toAscList us) | (v, us) <- IntMap.toAscList m ]
-
--- | Build an 'AdjacencyMap' from a 'GraphKL'.
-toAdjacenyMap :: Ord a => GraphKL a -> AdjacencyMap a
-toAdjacenyMap (GraphKL g from _) = AM.AM $ Map.fromList
-  $ map (\v -> (from v, Set.fromList $ map from $ g Array.! v)) $ KL.vertices g
-
--- | Build an 'AdjacencyMap' from a 'GraphKL'.
--- Alternative, possible faster implementation -> TODO: Benchmark!
-toAdjacenyMap2 :: Ord a => GraphKL a -> AdjacencyMap a
-toAdjacenyMap2 (GraphKL g from _) = AM.AM $ Map.mapKeys from $ Map.fromDistinctAscList
-  $ map (\v -> (v, Set.fromList $ map from $ g Array.! v)) $ KL.vertices g
-
-toIntAdjacencyMap :: GraphKL Int -> IntAdjacencyMap
-toIntAdjacencyMap (GraphKL g from _) = IAM.AM $ IntMap.mapKeys from
-  $ IntMap.fromDistinctAscList $ map (\v -> (v, IntSet.fromList $ map from $ g Array.! v))
-  $ KL.vertices g
 
 -- | Compute the /depth-first search/ forest of a graph.
 --

--- a/test/Algebra/Graph/Test/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/AdjacencyMap.hs
@@ -18,7 +18,6 @@ import Algebra.Graph.AdjacencyMap.Internal
 import Algebra.Graph.Test
 import Algebra.Graph.Test.Generic
 
-import qualified Data.Graph as KL
 import qualified Data.Set   as Set
 
 t :: Testsuite
@@ -70,12 +69,3 @@ testAdjacencyMap = do
                                            , (Set.fromList [1,4], Set.fromList [5]  )
                                            , (Set.fromList [3]  , Set.fromList [1,4])
                                            , (Set.fromList [3]  , Set.fromList [5 :: Int])]
-
-    putStrLn "\n============ AdjacencyMap.Internal.GraphKL ============"
-    test "map (fromVertexKL h) (vertices $ toGraphKL h) == vertexList g"
-      $ \(g :: AI) -> let h = mkGraphKL (adjacencyMap g) in
-          map (fromVertexKL h) (KL.vertices $ toGraphKL h) == vertexList g
-
-    test "map (\\(x, y) -> (fromVertexKL h x, fromVertexKL h y)) (edges $ toGraphKL h) == edgeList g"
-      $ \(g :: AI) -> let h = mkGraphKL (adjacencyMap g) in
-          map ( \(x, y) -> (fromVertexKL h x, fromVertexKL h y)) (KL.edges $ toGraphKL h) == edgeList g

--- a/test/Algebra/Graph/Test/IntAdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/IntAdjacencyMap.hs
@@ -18,9 +18,6 @@ import Algebra.Graph.IntAdjacencyMap.Internal
 import Algebra.Graph.Test
 import Algebra.Graph.Test.Generic
 
-import qualified Data.Graph  as KL
-import qualified Data.IntSet as IntSet
-
 t :: Testsuite
 t = testsuite "IntAdjacencyMap." empty
 
@@ -49,12 +46,3 @@ testIntAdjacencyMap = do
     testDfs               t
     testTopSort           t
     testIsTopSort         t
-
-    putStrLn "\n============ IntAdjacencyMap.Internal.GraphKL ============"
-    test "map (fromVertexKL h) (vertices $ toGraphKL h) == IntSet.toAscList (vertexIntSet g)"
-      $ \g -> let h = mkGraphKL (adjacencyMap g) in
-        map (fromVertexKL h) (KL.vertices $ toGraphKL h) == IntSet.toAscList (vertexIntSet g)
-
-    test "map (\\(x, y) -> (fromVertexKL h x, fromVertexKL h y)) (edges $ toGraphKL h) == edgeList g"
-      $ \g -> let h = mkGraphKL (adjacencyMap g) in
-        map (\(x, y) -> (fromVertexKL h x, fromVertexKL h y)) (KL.edges $ toGraphKL h) == edgeList g

--- a/test/Data/Graph/Test/Typed.hs
+++ b/test/Data/Graph/Test/Typed.hs
@@ -1,0 +1,71 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module     : Algebra.Graph.Test.IntAdjacencyMap
+-- Copyright  : (c) Andrey Mokhov 2016-2018
+-- License    : MIT (see the file LICENSE)
+-- Maintainer : anfelor@posteo.de, andrey.mokhov@gmail.com
+-- Stability  : experimental
+--
+-- Testsuite for "Algebra.Graph.IntAdjacencyMap".
+-----------------------------------------------------------------------------
+module Data.Graph.Test.Typed (
+    -- * Testsuite
+    testTyped
+  ) where
+
+import qualified Algebra.Graph.AdjacencyMap as AM
+import qualified Algebra.Graph.IntAdjacencyMap as IM
+import Algebra.Graph.Test
+import Data.Array (array)
+import Data.Graph.Typed
+
+import qualified Data.Graph  as KL
+import qualified Data.IntSet as IntSet
+
+type AI = AM.AdjacencyMap Int
+
+testTyped :: IO ()
+testTyped = do
+    putStrLn "\n============ Typed ============"
+
+    putStrLn "\n============ Typed.fromAdjacencyMap ============"
+
+    test "toGraphKL (fromAdjacencyMap (1 * 2 + 3 * 1)) == array (0,2) [(0,[1]),(1,[]),(2,[0])]" $
+          toGraphKL (fromAdjacencyMap (1 * 2 + 3 * 1 :: AI)) == array (0,2) [(0,[1]),(1,[]),(2,[0])]
+
+    test "toGraphKL (fromAdjacencyMap (1 * 2 + 2 * 1)) == array (0,1) [(0,[1]),(1,[0])]" $
+          toGraphKL (fromAdjacencyMap (1 * 2 + 2 * 1 :: AI)) == array (0,1) [(0,[1]),(1,[0])]
+
+    test "map (fromVertexKL h) (vertices $ toGraphKL h) == vertexList g"
+      $ \(g :: AI) -> let h = fromAdjacencyMap g in
+          map (fromVertexKL h) (KL.vertices $ toGraphKL h) == AM.vertexList g
+
+    test "map (\\(x, y) -> (fromVertexKL h x, fromVertexKL h y)) (edges $ toGraphKL h) == edgeList g"
+      $ \(g :: AI) -> let h = fromAdjacencyMap g in
+          map (\(x, y) -> (fromVertexKL h x, fromVertexKL h y))
+              (KL.edges $ toGraphKL h) == AM.edgeList g
+
+    putStrLn "\n============ Typed.fromIntAdjacencyMap ============"
+
+    test "toGraphKL (fromIntAdjacencyMap (1 * 2 + 3 * 1)) == array (0,2) [(0,[1]),(1,[]),(2,[0])]" $
+          toGraphKL (fromIntAdjacencyMap (1 * 2 + 3 * 1)) == array (0,2) [(0,[1]),(1,[]),(2,[0])]
+
+    test "toGraphKL (fromIntAdjacencyMap (1 * 2 + 2 * 1)) == array (0,1) [(0,[1]),(1,[0])]" $
+          toGraphKL (fromIntAdjacencyMap (1 * 2 + 2 * 1)) == array (0,1) [(0,[1]),(1,[0])]
+
+    test "map (fromVertexKL h) (vertices $ toGraphKL h) == IntSet.toAscList (vertexIntSet g)"
+      $ \g -> let h = fromIntAdjacencyMap g in
+        map (fromVertexKL h) (KL.vertices $ toGraphKL h) == IntSet.toAscList (IM.vertexIntSet g)
+
+    test "map (\\(x, y) -> (fromVertexKL h x, fromVertexKL h y)) (edges $ toGraphKL h) == edgeList g"
+      $ \g -> let h = fromIntAdjacencyMap g in
+         map (\(x, y) -> (fromVertexKL h x, fromVertexKL h y))
+             (KL.edges $ toGraphKL h) == IM.edgeList g
+
+    putStrLn "\n============ Typed.topSort ============"
+
+    test "topSort (fromAdjacencyMap (1 * 2 + 3 * 1)) == [3,1,2]" $
+          topSort (fromAdjacencyMap (1 * 2 + 3 * 1)) == ([3,1,2] :: [Int])
+
+    test "topSort (fromAdjacencyMap (1 * 2 + 2 * 1)) == [1,2]" $
+          topSort (fromAdjacencyMap (1 * 2 + 2 * 1)) == ([1,2] :: [Int])

--- a/test/Data/Graph/Test/Typed.hs
+++ b/test/Data/Graph/Test/Typed.hs
@@ -1,12 +1,12 @@
 -----------------------------------------------------------------------------
 -- |
--- Module     : Algebra.Graph.Test.IntAdjacencyMap
+-- Module     : Data.Graph.Test.Typed
 -- Copyright  : (c) Andrey Mokhov 2016-2018
 -- License    : MIT (see the file LICENSE)
 -- Maintainer : anfelor@posteo.de, andrey.mokhov@gmail.com
 -- Stability  : experimental
 --
--- Testsuite for "Algebra.Graph.IntAdjacencyMap".
+-- Testsuite for "Data.Graph.Typed".
 -----------------------------------------------------------------------------
 module Data.Graph.Test.Typed (
     -- * Testsuite

--- a/test/Data/Graph/Test/Typed.hs
+++ b/test/Data/Graph/Test/Typed.hs
@@ -18,11 +18,16 @@ import qualified Algebra.Graph.IntAdjacencyMap as IM
 import Algebra.Graph.Test
 import Data.Array (array)
 import Data.Graph.Typed
+import Data.Tree
+import Data.List
 
 import qualified Data.Graph  as KL
 import qualified Data.IntSet as IntSet
 
 type AI = AM.AdjacencyMap Int
+
+(%) :: (GraphKL Int -> a) -> AM.AdjacencyMap Int -> a
+a % g = a $ fromAdjacencyMap g
 
 testTyped :: IO ()
 testTyped = do
@@ -62,10 +67,101 @@ testTyped = do
          map (\(x, y) -> (fromVertexKL h x, fromVertexKL h y))
              (KL.edges $ toGraphKL h) == IM.edgeList g
 
+    putStrLn $ "\n============ Typed.dfsForest ============"
+    test "forest (dfsForest % edge 1 1)         == vertex 1" $
+          AM.forest (dfsForest % AM.edge 1 1)   == AM.vertex 1
+
+    test "forest (dfsForest % edge 1 2)         == edge 1 2" $
+          AM.forest (dfsForest % AM.edge 1 2)   == AM.edge 1 2
+
+    test "forest (dfsForest % edge 2 1)         == vertices [1, 2]" $
+          AM.forest (dfsForest % AM.edge 2 1)   == AM.vertices [1, 2]
+
+    test "isSubgraphOf (forest $ dfsForest % x) x == True" $ \x ->
+          AM.isSubgraphOf (AM.forest $ dfsForest % x) x == True
+
+    test "dfsForest % forest (dfsForest % x)    == dfsForest % x" $ \x ->
+          dfsForest % AM.forest (dfsForest % x) == dfsForest % x
+
+    test "dfsForest % vertices vs               == map (\\v -> Node v []) (nub $ sort vs)" $ \vs ->
+          dfsForest % AM.vertices vs            == map (\v -> Node v []) (nub $ sort vs)
+
+    test "dfsForest % (3 * (1 + 4) * (1 + 5))   == <correct result>" $
+          dfsForest % (3 * (1 + 4) * (1 + 5))   == [ Node { rootLabel = 1
+                                                   , subForest = [ Node { rootLabel = 5
+                                                                        , subForest = [] }]}
+                                                   , Node { rootLabel = 3
+                                                   , subForest = [ Node { rootLabel = 4
+                                                                        , subForest = [] }]}]
+
+    putStrLn $ "\n============ Typed.dfsForestFrom ============"
+    test "forest (dfsForestFrom [1]       % edge 1 1)     == vertex 1" $
+          AM.forest (dfsForestFrom [1]    % AM.edge 1 1)  == AM.vertex 1
+
+    test "forest (dfsForestFrom [1]       % edge 1 2)     == edge 1 2" $
+          AM.forest (dfsForestFrom [1]    % AM.edge 1 2)  == AM.edge 1 2
+
+    test "forest (dfsForestFrom [2]       % edge 1 2)     == vertex 2" $
+          AM.forest (dfsForestFrom [2]    % AM.edge 1 2)  == AM.vertex 2
+
+    test "forest (dfsForestFrom [3]       % edge 1 2)     == empty" $
+          AM.forest (dfsForestFrom [3]    % AM.edge 1 2)  == AM.empty
+
+    test "forest (dfsForestFrom [2, 1]    % edge 1 2)     == vertices [1, 2]" $
+          AM.forest (dfsForestFrom [2, 1] % AM.edge 1 2)  == AM.vertices [1, 2]
+
+    test "isSubgraphOf (forest $ dfsForestFrom vs % x) x  == True" $ \vs x ->
+          AM.isSubgraphOf (AM.forest (dfsForestFrom vs % x)) x == True
+
+    test "dfsForestFrom (vertexList x) % x             == dfsForest % x" $ \x ->
+          dfsForestFrom (AM.vertexList x) % x          == dfsForest % x
+
+    test "dfsForestFrom vs           % (AM.vertices vs)   == map (\\v -> Node v []) (nub vs)" $ \vs ->
+          dfsForestFrom vs           %  AM.vertices vs    == map (\v -> Node v []) (nub vs)
+
+    test "dfsForestFrom []           % x               == []" $ \x ->
+          dfsForestFrom []           % x               == []
+
+    test "dfsForestFrom [1, 4] % 3 * (1 + 4) * (1 + 5) == <correct result>" $
+          dfsForestFrom [1, 4] % (3 * (1 + 4) * (1 + 5)) == [ Node { rootLabel = 1
+                                                                   , subForest = [ Node { rootLabel = 5
+                                                                                        , subForest = [] }]}
+                                                            , Node { rootLabel = 4
+                                                                   , subForest = [] }]
+
+    putStrLn $ "\n============ Typed.dfs ============"
+    test "dfs [1]    % edge 1 1                == [1]" $
+          dfs [1]    % AM.edge 1 1             == [1]
+
+    test "dfs [1]    % edge 1 2                == [1, 2]" $
+          dfs [1]    % AM.edge 1 2             == [1, 2]
+
+    test "dfs [2]    % edge 1 2                == [2]" $
+          dfs [2]    % AM.edge 1 2             == [2]
+
+    test "dfs [3]    % edge 1 2                == []" $
+          dfs [3]    % AM.edge 1 2             == []
+
+    test "dfs [1, 2] % edge 1 2                == [1, 2]" $
+          dfs [1, 2] % AM.edge 1 2             == [1, 2]
+
+    test "dfs [2, 1] % edge 1 2                == [2, 1]" $
+          dfs [2, 1] % AM.edge 1 2             == [2, 1]
+
+    test "dfs []     % x                       == []" $ \x ->
+          dfs []     % x                       == []
+
+    test "dfs [1, 4] % 3 * (1 + 4) * (1 + 5)   == [1, 5, 4]" $
+          dfs [1, 4] % (3 * (1 + 4) * (1 + 5))   == [1, 5, 4]
+
+    test "isSubgraphOf (vertices $ dfs vs % x) x == True" $ \vs x ->
+          AM.isSubgraphOf (AM.vertices $ dfs vs % x) x == True
+
+
     putStrLn "\n============ Typed.topSort ============"
 
-    test "topSort (fromAdjacencyMap (1 * 2 + 3 * 1)) == [3,1,2]" $
-          topSort (fromAdjacencyMap (1 * 2 + 3 * 1)) == ([3,1,2] :: [Int])
+    test "topSort % (1 * 2 + 3 * 1) == [3,1,2]" $
+          topSort % (1 * 2 + 3 * 1) == ([3,1,2] :: [Int])
 
-    test "topSort (fromAdjacencyMap (1 * 2 + 2 * 1)) == [1,2]" $
-          topSort (fromAdjacencyMap (1 * 2 + 2 * 1)) == ([1,2] :: [Int])
+    test "topSort % (1 * 2 + 2 * 1) == [1,2]" $
+          topSort % (1 * 2 + 2 * 1) == ([1,2] :: [Int])

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import Algebra.Graph.Test.IntAdjacencyMap
 import Algebra.Graph.Test.Internal
 import Algebra.Graph.Test.NonEmptyGraph
 import Algebra.Graph.Test.Relation
+import Data.Graph.Test.Typed
 
 main :: IO ()
 main = do
@@ -17,3 +18,4 @@ main = do
     testIntAdjacencyMap
     testInternal
     testRelation
+    testTyped


### PR DESCRIPTION
This removes the `graphKL` field from `AdjacencyMap` as suggested in #54 and makes the `GraphKL` data type publicly available in `Algebra.Graph.KingLaunchbury` instead (similar to the proposal in #24). Changes:

 - Remove `graphKL` and `mkAM` from `AdjacencyMap`
 - Replace `dfs`, `topSort` and `scc` with slightly slower versions operating on pure `AdjacencyMap`s
 - Move the old ones into `Algebra.Graph.KingLaunchbury` and make them (largely) independent of `AdjacencyMap`

Not changed (yet):

 - The `graphKL` field and algorithms of `IntAdjacencyMap`
 - No `Graph a -> GraphKL a` conversion yet.
 - Comments are a mess.

The benefit of this is that the original behaviour of the API can still be recovered by just manually converting to the `GraphKL` type, while the unexpected behaviour of `dfs`, ... is fixed. What do you think of this approach?