### PR TITLE
concat two map for edges

### DIFF
--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -22,7 +22,7 @@ module Algebra.Graph.AdjacencyMap (
 
     -- * Basic graph construction primitives
     empty, vertex, edge, overlay, connect, vertices, edges, overlays, connects,
-    fromAdjacencyList,
+    fromAdjacencyList, fromAdjacencySets,
 
     -- * Relations on graphs
     isSubgraphOf,
@@ -152,7 +152,7 @@ vertices = mkAM . Map.fromList . map (\x -> (x, Set.empty))
 -- 'edgeList' . edges  == 'Data.List.nub' . 'Data.List.sort'
 -- @
 edges :: Ord a => [(a, a)] -> AdjacencyMap a
-edges = fromAdjacencyList' . map (fmap Set.singleton)
+edges = fromAdjacencySets . map (fmap Set.singleton)
 
 -- | Overlay a given list of graphs.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
@@ -191,10 +191,20 @@ connects = C.connects
 -- 'overlay' (fromAdjacencyList xs) (fromAdjacencyList ys) == fromAdjacencyList (xs ++ ys)
 -- @
 fromAdjacencyList :: Ord a => [(a, [a])] -> AdjacencyMap a
-fromAdjacencyList = fromAdjacencyList' . map (fmap Set.fromList)
+fromAdjacencyList = fromAdjacencySets . map (fmap Set.fromList)
 
-fromAdjacencyList' :: Ord a => [(a, Set a)] -> AdjacencyMap a
-fromAdjacencyList' ss = mkAM $ Map.unionWith Set.union vs es
+-- | Construct a graph from an adjacency list.
+-- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
+--
+-- @
+-- fromAdjacencySets []                                        == 'empty'
+-- fromAdjacencySets [(x, Set.'Set.empty')]                          == 'vertex' x
+-- fromAdjacencySets [(x, Set.'Set.singleton' y)]                    == 'edge' x y
+-- fromAdjacencySets . map (fmap Set.'Set.fromList') . 'adjacencyList' == id
+-- 'overlay' (fromAdjacencySets xs) (fromAdjacencySets ys)       == fromAdjacencySets (xs ++ ys)
+-- @
+fromAdjacencySets :: Ord a => [(a, Set a)] -> AdjacencyMap a
+fromAdjacencySets ss = mkAM $ Map.unionWith Set.union vs es
   where
     vs = Map.fromSet (const Set.empty) . Set.unions $ map snd ss
     es = Map.fromListWith Set.union ss

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -152,7 +152,7 @@ vertices = mkAM . Map.fromList . map (\x -> (x, Set.empty))
 -- 'edgeList' . edges  == 'Data.List.nub' . 'Data.List.sort'
 -- @
 edges :: Ord a => [(a, a)] -> AdjacencyMap a
-edges = fromAdjacencyList . map (fmap return)
+edges = fromAdjacencyList' . map (fmap Set.singleton)
 
 -- | Overlay a given list of graphs.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
@@ -191,9 +191,11 @@ connects = C.connects
 -- 'overlay' (fromAdjacencyList xs) (fromAdjacencyList ys) == fromAdjacencyList (xs ++ ys)
 -- @
 fromAdjacencyList :: Ord a => [(a, [a])] -> AdjacencyMap a
-fromAdjacencyList as = mkAM $ Map.unionWith Set.union vs es
+fromAdjacencyList = fromAdjacencyList' . map (fmap Set.fromList)
+
+fromAdjacencyList' :: Ord a => [(a, Set a)] -> AdjacencyMap a
+fromAdjacencyList' ss = mkAM $ Map.unionWith Set.union vs es
   where
-    ss = map (fmap Set.fromList) as
     vs = Map.fromSet (const Set.empty) . Set.unions $ map snd ss
     es = Map.fromListWith Set.union ss
 

--- a/test/Algebra/Graph/Test/API.hs
+++ b/test/Algebra/Graph/Test/API.hs
@@ -42,6 +42,8 @@ class Graph g => GraphAPI g where
     connects          = notImplemented
     fromAdjacencyList :: [(Vertex g, [Vertex g])] -> g
     fromAdjacencyList = notImplemented
+    fromAdjacencySets :: [(Vertex g, Set.Set (Vertex g))] -> g
+    fromAdjacencySets = notImplemented
     toGraph           :: (Graph h, Vertex g ~ Vertex h) => g -> h
     toGraph           = notImplemented
     foldg             :: r -> (Vertex g -> r) -> (r -> r -> r) -> (r -> r -> r) -> g -> r
@@ -145,6 +147,7 @@ instance Ord a => GraphAPI (AdjacencyMap.AdjacencyMap a) where
     overlays          = AdjacencyMap.overlays
     connects          = AdjacencyMap.connects
     fromAdjacencyList = AdjacencyMap.fromAdjacencyList
+    fromAdjacencySets = AdjacencyMap.fromAdjacencySets
     isSubgraphOf      = AdjacencyMap.isSubgraphOf
     isEmpty           = AdjacencyMap.isEmpty
     hasVertex         = AdjacencyMap.hasVertex

--- a/test/Algebra/Graph/Test/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/AdjacencyMap.hs
@@ -40,6 +40,7 @@ testAdjacencyMap = do
     testShow              t
     testBasicPrimitives   t
     testFromAdjacencyList t
+    testFromAdjacencySets t
     testIsSubgraphOf      t
     testProperties        t
     testAdjacencyList     t

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -311,7 +311,7 @@ testFromAdjacencyList (Testsuite prefix (%)) = do
 
 testFromAdjacencySets :: Testsuite -> IO ()
 testFromAdjacencySets (Testsuite prefix (%)) = do
-    putStrLn "\n============ " ++ prefix ++ "fromAdjacencySets ============"
+    putStrLn $ "\n============ " ++ prefix ++ "fromAdjacencySets ============"
     test "fromAdjacencySets []                                  == empty" $
           fromAdjacencySets []                                  == id % empty
 

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -12,10 +12,10 @@
 module Algebra.Graph.Test.Generic (
     -- * Generic tests
     Testsuite, testsuite, HTestsuite, hTestsuite, testShow, testFromAdjacencyList,
-    testBasicPrimitives, testToGraph, testIsSubgraphOf, testSize, testProperties,
-    testAdjacencyList, testPreSet, testPostSet, testPostIntSet, testGraphFamilies,
-    testTransformations, testDfsForest, testDfsForestFrom, testDfs, testTopSort,
-    testIsTopSort, testSplitVertex, testBind, testSimplify
+    testFromAdjacencySets, testBasicPrimitives, testToGraph, testIsSubgraphOf, testSize,
+    testProperties, testAdjacencyList, testPreSet, testPostSet, testPostIntSet,
+    testGraphFamilies, testTransformations, testDfsForest, testDfsForestFrom, testDfs,
+    testTopSort, testIsTopSort, testSplitVertex, testBind, testSimplify
   ) where
 
 import Prelude ()
@@ -308,6 +308,24 @@ testFromAdjacencyList (Testsuite prefix (%)) = do
 
     test "overlay (fromAdjacencyList xs) (fromAdjacencyList ys) == fromAdjacencyList (xs ++ ys)" $ \xs ys ->
           overlay (fromAdjacencyList xs) % fromAdjacencyList ys == fromAdjacencyList (xs ++ ys)
+
+testFromAdjacencySets :: Testsuite -> IO ()
+testFromAdjacencySets (Testsuite prefix (%)) = do
+    putStrLn "\n============ " ++ prefix ++ "fromAdjacencySets ============"
+    test "fromAdjacencySets []                                  == empty" $
+          fromAdjacencySets []                                  == id % empty
+
+    test "fromAdjacencySets [(x, Set.empty)]                           == vertex x" $ \x ->
+          fromAdjacencySets [(x, Set.empty)]                           == id % vertex x
+
+    test "fromAdjacencySets [(x, Set.singleton y)]                          == edge x y" $ \x y ->
+          fromAdjacencySets [(x, Set.singleton y)]                          == id % edge x y
+
+    test "fromAdjacencySets . map (fmap Set.fromList) . adjacencyList       == id" $ \x ->
+         (fromAdjacencySets . map (fmap Set.fromList) . adjacencyList) % x  == x
+
+    test "overlay (fromAdjacencySets xs) (fromAdjacencySets ys)  == fromAdjacencySets (xs ++ ys)" $ \xs ys ->
+          overlay (fromAdjacencySets xs) % fromAdjacencySets ys  == fromAdjacencySets (xs ++ ys)
 
 testToGraph :: HTestsuite -> IO ()
 testToGraph (HTestsuite prefix (%)) = do


### PR DESCRIPTION
The actual implementation of `edges` for `AdjacencyMap` used two successive `map`. Here is a reduced version :)