### PR TITLE
Replace vertexCount by its Set.size alternative

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -445,7 +445,7 @@ hasEdge = H.hasEdge
 -- @
 -- vertexCount 'empty'      == 0
 -- vertexCount ('vertex' x) == 1
--- vertexCount            == 'Set.size' . 'vertexSet'
+-- vertexCount            == 'length' . 'vertexList'
 -- @
 vertexCount :: Ord a => Graph a -> Int
 vertexCount = Set.size . vertexSet

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -445,10 +445,10 @@ hasEdge = H.hasEdge
 -- @
 -- vertexCount 'empty'      == 0
 -- vertexCount ('vertex' x) == 1
--- vertexCount            == 'length' . 'vertexList'
+-- vertexCount            == 'Data.Set.size' . 'vertexSet'
 -- @
 vertexCount :: Ord a => Graph a -> Int
-vertexCount = length . vertexList
+vertexCount = Set.size . vertexSet
 
 -- | The number of edges in a graph.
 -- Complexity: /O(s + m * log(m))/ time. Note that the number of edges /m/ of a

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -445,7 +445,7 @@ hasEdge = H.hasEdge
 -- @
 -- vertexCount 'empty'      == 0
 -- vertexCount ('vertex' x) == 1
--- vertexCount            == 'Data.Set.size' . 'vertexSet'
+-- vertexCount            == 'Set.size' . 'vertexSet'
 -- @
 vertexCount :: Ord a => Graph a -> Int
 vertexCount = Set.size . vertexSet


### PR DESCRIPTION
Using the set alternative is a bit quicker and use la bit less memory :)
Benchmarks:
```
## vertexCount
### Path
#### 1

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) ||  7.292685126584078e-8 |
|       Alga (Algebra.Graph) || 1.8151521274477894e-7 |
+----------------------------++-----------------------+

#### 10

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 1.4376476714566372e-6 |
|       Alga (Algebra.Graph) ||  2.637610519434279e-6 |
+----------------------------++-----------------------+

#### 100

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 2.9660452809678954e-5 |
|       Alga (Algebra.Graph) ||  4.944463117837148e-5 |
+----------------------------++-----------------------+

#### 1000

+----------------------------++----------------------+
|                            ||       Seconds (Mean) |
+============================++======================+
| SetBasedOp (Algebra.Graph) ||  5.28054249617104e-4 |
|       Alga (Algebra.Graph) || 8.453731540639559e-4 |
+----------------------------++----------------------+

#### 10000

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 3.2818272356479224e-2 |
|       Alga (Algebra.Graph) ||  3.396615315036348e-2 |
+----------------------------++-----------------------+

#### 100000

+----------------------------++--------------------+
|                            ||     Seconds (Mean) |
+============================++====================+
| SetBasedOp (Algebra.Graph) || 0.5459610307084025 |
|       Alga (Algebra.Graph) || 0.6253314759377039 |
+----------------------------++--------------------+

### Circuit
#### 1

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 1.3894099527786308e-7 |
|       Alga (Algebra.Graph) ||  2.900137283033191e-7 |
+----------------------------++-----------------------+

#### 10

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 1.5002514946265321e-6 |
|       Alga (Algebra.Graph) || 2.8605648826927134e-6 |
+----------------------------++-----------------------+

#### 100

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 3.0021988929777863e-5 |
|       Alga (Algebra.Graph) || 5.0136469180686174e-5 |
+----------------------------++-----------------------+

#### 1000

+----------------------------++----------------------+
|                            ||       Seconds (Mean) |
+============================++======================+
| SetBasedOp (Algebra.Graph) || 5.211402286800027e-4 |
|       Alga (Algebra.Graph) || 8.517386225944353e-4 |
+----------------------------++----------------------+

#### 10000

+----------------------------++----------------------+
|                            ||       Seconds (Mean) |
+============================++======================+
| SetBasedOp (Algebra.Graph) ||   3.8766015276277e-2 |
|       Alga (Algebra.Graph) || 4.266431434698696e-2 |
+----------------------------++----------------------+

#### 100000

+----------------------------++--------------------+
|                            ||     Seconds (Mean) |
+============================++====================+
| SetBasedOp (Algebra.Graph) || 0.5432677978541088 |
|       Alga (Algebra.Graph) ||  0.610748267812293 |
+----------------------------++--------------------+

### Complete
#### 1

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 2.5469425422268214e-7 |
|       Alga (Algebra.Graph) ||  4.892668061635039e-7 |
+----------------------------++-----------------------+

#### 10

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 1.4461541057882543e-5 |
|       Alga (Algebra.Graph) ||   2.39477400652758e-5 |
+----------------------------++-----------------------+

#### 100

+----------------------------++-----------------------+
|                            ||        Seconds (Mean) |
+============================++=======================+
| SetBasedOp (Algebra.Graph) || 2.8174270559504265e-3 |
|       Alga (Algebra.Graph) ||  5.251910174881515e-3 |
+----------------------------++-----------------------+

#### 1000

+----------------------------++--------------------+
|                            ||     Seconds (Mean) |
+============================++====================+
| SetBasedOp (Algebra.Graph) || 0.6407744952499002 |
|       Alga (Algebra.Graph) || 0.9115686293750779 |
+----------------------------++--------------------+


SUMMARY:

 * SetBasedOp (Algebra.Graph) was the fastest 15 times
There was 1 ex-aequo


ABSTRACT:

 * SetBasedOp (Algebra.Graph) was 1.63 times faster than Alga (Algebra.Graph)


## vertexCount
### Path
#### 1
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||            176 |   0 |
|       Alga (Algebra.Graph) ||            304 |   0 |
+----------------------------++----------------+-----+

#### 10
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||           2816 |   0 |
|       Alga (Algebra.Graph) ||           3520 |   0 |
+----------------------------++----------------+-----+

#### 100
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||          63856 |   0 |
|       Alga (Algebra.Graph) ||          70320 |   0 |
+----------------------------++----------------+-----+

#### 1000
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||        1132592 |   1 |
|       Alga (Algebra.Graph) ||        1229424 |   1 |
+----------------------------++----------------+-----+

### Circuit
#### 1
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||            376 |   0 |
|       Alga (Algebra.Graph) ||            504 |   0 |
+----------------------------++----------------+-----+

#### 10
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||           3216 |   0 |
|       Alga (Algebra.Graph) ||           3920 |   0 |
+----------------------------++----------------+-----+

#### 100
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||          64936 |   0 |
|       Alga (Algebra.Graph) ||          71400 |   0 |
+----------------------------++----------------+-----+

#### 1000
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||        1134152 |   1 |
|       Alga (Algebra.Graph) ||        1230984 |   1 |
+----------------------------++----------------+-----+

### Complete
#### 1
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||            416 |   0 |
|       Alga (Algebra.Graph) ||            544 |   0 |
+----------------------------++----------------+-----+

#### 10
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||          11536 |   0 |
|       Alga (Algebra.Graph) ||          12240 |   0 |
+----------------------------++----------------+-----+

#### 100
+----------------------------++----------------+-----+
|                            || AllocatedBytes | GCs |
+============================++================+=====+
| SetBasedOp (Algebra.Graph) ||        1745096 |   0 |
|       Alga (Algebra.Graph) ||        1948168 |   0 |
+----------------------------++----------------+-----+


SUMMARY:

 * SetBasedOp (Algebra.Graph) used the least amount of memory 7 times
There was 4 ex-aequo


ABSTRACT:

 * SetBasedOp (Algebra.Graph) was 1.19 times lighter than Alga (Algebra.Graph)
```