### PR TITLE
Graph int speedup

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -48,7 +48,7 @@ module Algebra.Graph (
     box,
 
     -- * Conversion to graphs
-    toAdjacencyMap, Context (..), context
+    toAdjacencyMap, toIntAdjacencyMap, Context (..), context
   ) where
 
 import Prelude ()

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -464,6 +464,13 @@ hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
 -- @
 vertexCount :: Ord a => Graph a -> Int
 vertexCount = Set.size . vertexSet
+{-# INLINE[1] vertexCount #-}
+
+{-# RULES "vertexCount/Int" vertexCount = vertexIntCount #-}
+
+-- | Specialized version of 'vertexcount' for graphs with vertices of type 'Int'.
+vertexIntCount :: Graph Int -> Int
+vertexIntCount = IntSet.size . vertexIntSet
 
 -- | The number of edges in a graph.
 -- Complexity: /O(s + m * log(m))/ time. Note that the number of edges /m/ of a
@@ -488,6 +495,13 @@ edgeCount = length . edgeList
 -- @
 vertexList :: Ord a => Graph a -> [a]
 vertexList = Set.toAscList . vertexSet
+{-# INLINE[1] vertexList #-}
+
+{-# RULES "vertexList/Int" vertexList = vertexIntList #-}
+
+-- | Specialized version of vertexIntList for graphs with vertices of type 'Int'.
+vertexIntList :: Graph Int -> [Int]
+vertexIntList = IntSet.toList . vertexIntSet
 
 -- | The sorted list of edges of a graph.
 -- Complexity: /O(s + m * log(m))/ time and /O(m)/ memory. Note that the number of

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -62,11 +62,12 @@ import Data.Tree
 
 import Algebra.Graph.Internal
 
-import qualified Algebra.Graph.AdjacencyMap as AM
-import qualified Control.Applicative        as Ap
-import qualified Data.IntSet                as IntSet
-import qualified Data.Set                   as Set
-import qualified Data.Tree                  as Tree
+import qualified Algebra.Graph.AdjacencyMap    as AM
+import qualified Algebra.Graph.IntAdjacencyMap as IAM
+import qualified Control.Applicative           as Ap
+import qualified Data.IntSet                   as IntSet
+import qualified Data.Set                      as Set
+import qualified Data.Tree                     as Tree
 
 {-| The 'Graph' data type is a deep embedding of the core graph construction
 primitives 'empty', 'vertex', 'overlay' and 'connect'. We define a 'Num'
@@ -172,8 +173,22 @@ instance Num a => Num (Graph a) where
 toAdjacencyMap :: Ord a => Graph a -> AM.AdjacencyMap a
 toAdjacencyMap = foldg AM.empty AM.vertex AM.overlay AM.connect
 
+toIntAdjacencyMap :: Graph Int -> IAM.IntAdjacencyMap
+toIntAdjacencyMap = foldg IAM.empty IAM.vertex IAM.overlay IAM.connect
+
+
 instance Ord a => Eq (Graph a) where
-    x == y = toAdjacencyMap x == toAdjacencyMap y
+  (==) = eqG
+
+eqG :: Ord a => Graph a -> Graph a -> Bool
+eqG x y = toAdjacencyMap x == toAdjacencyMap y
+{-# NOINLINE [1] eqG #-}
+
+
+{-# RULES "eqGInt" eqG = eqGInt #-}
+
+eqGInt :: Graph Int -> Graph Int -> Bool
+eqGInt x y = toIntAdjacencyMap x == toIntAdjacencyMap y
 
 instance Applicative Graph where
     pure  = Vertex

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -234,20 +234,21 @@ class ToGraph t where
 
 instance Ord a => ToGraph (G.Graph a) where
     type ToVertex (G.Graph a) = a
-    toGraph        = id
-    foldg          = G.foldg
-    isEmpty        = G.isEmpty
-    hasVertex      = G.hasVertex
-    hasEdge        = G.hasEdge
-    vertexCount    = G.vertexCount
-    edgeCount      = G.edgeCount
-    vertexList     = G.vertexList
-    vertexSet      = G.vertexSet
-    vertexIntSet   = G.vertexIntSet
-    edgeList       = G.edgeList
-    edgeSet        = G.edgeSet
-    adjacencyList  = G.adjacencyList
-    toAdjacencyMap = G.toAdjacencyMap
+    toGraph           = id
+    foldg             = G.foldg
+    isEmpty           = G.isEmpty
+    hasVertex         = G.hasVertex
+    hasEdge           = G.hasEdge
+    vertexCount       = G.vertexCount
+    edgeCount         = G.edgeCount
+    vertexList        = G.vertexList
+    vertexSet         = G.vertexSet
+    vertexIntSet      = G.vertexIntSet
+    edgeList          = G.edgeList
+    edgeSet           = G.edgeSet
+    adjacencyList     = G.adjacencyList
+    toAdjacencyMap    = G.toAdjacencyMap
+    toIntAdjacencyMap = G.toIntAdjacencyMap
 
 instance Ord a => ToGraph (AM.AdjacencyMap a) where
     type ToVertex (AM.AdjacencyMap a) = a


### PR DESCRIPTION
Related to #75 

Please note that the speeded-up Eq instance needed some tweaks as described [here](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#how-rules-interact-with-class-methods)

The benchs:

## vertexList

Descritpion: Produce a list of the vertices in the graph

### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH CLASS = "thinright">
         100
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD CLASS = "thinright">
         45.11 ns
      </TD>
      <TD CLASS = "thinright">
         1.722 μs
      </TD>
      <TD CLASS = "thinright">
         359.0 μs
      </TD>
      <TD>
         85.77 ms
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD CLASS = "thinright">
         44.79 ns
      </TD>
      <TD CLASS = "thinright">
         17.41 μs
      </TD>
      <TD CLASS = "thinright">
         3.755 ms
      </TD>
      <TD>
         604.7 ms
      </TD>
   </TR>
</TABLE>

### Mesh
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH CLASS = "thinright">
         100
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD CLASS = "thinright">
         45.16 ns
      </TD>
      <TD CLASS = "thinright">
         614.0 ns
      </TD>
      <TD CLASS = "thinright">
         11.15 μs
      </TD>
      <TD>
         165.8 μs
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD CLASS = "thinright">
         45.11 ns
      </TD>
      <TD CLASS = "thinright">
         4.809 μs
      </TD>
      <TD CLASS = "thinright">
         123.6 μs
      </TD>
      <TD>
         2.046 ms
      </TD>
   </TR>
</TABLE>


SUMMARY:

 * Alga was the fastest 6 times
There was 2 ex-aequo


ABSTRACT:

 * Alga was 3.03 times faster than AlgaOld

## vertexCount

Descritpion: Count the vertices of the graph

### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH CLASS = "thinright">
         100
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD CLASS = "thinright">
         33.24 ns
      </TD>
      <TD CLASS = "thinright">
         1.595 μs
      </TD>
      <TD CLASS = "thinright">
         392.6 μs
      </TD>
      <TD>
         104.9 ms
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD CLASS = "thinright">
         29.33 ns
      </TD>
      <TD CLASS = "thinright">
         16.29 μs
      </TD>
      <TD CLASS = "thinright">
         3.709 ms
      </TD>
      <TD>
         583.3 ms
      </TD>
   </TR>
</TABLE>

### Mesh
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH CLASS = "thinright">
         100
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD CLASS = "thinright">
         32.93 ns
      </TD>
      <TD CLASS = "thinright">
         487.6 ns
      </TD>
      <TD CLASS = "thinright">
         9.710 μs
      </TD>
      <TD>
         151.4 μs
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD CLASS = "thinright">
         29.38 ns
      </TD>
      <TD CLASS = "thinright">
         4.693 μs
      </TD>
      <TD CLASS = "thinright">
         117.0 μs
      </TD>
      <TD>
         2.032 ms
      </TD>
   </TR>
</TABLE>


SUMMARY:

 * Alga was the fastest 6 times
 * AlgaOld was the fastest 2 times


ABSTRACT:

 * Alga was 2.76 times faster than AlgaOld

## equality

Descritpion: Test if two graphs are equals

### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH CLASS = "thinright">
         100
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD CLASS = "thinright">
         122.4 ns
      </TD>
      <TD CLASS = "thinright">
         23.01 μs
      </TD>
      <TD CLASS = "thinright">
         3.643 ms
      </TD>
      <TD>
         515.5 ms
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD CLASS = "thinright">
         192.9 ns
      </TD>
      <TD CLASS = "thinright">
         56.93 μs
      </TD>
      <TD CLASS = "thinright">
         11.22 ms
      </TD>
      <TD>
         1.686 s
      </TD>
   </TR>
</TABLE>

### Mesh
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH CLASS = "thinright">
         100
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD CLASS = "thinright">
         123.3 ns
      </TD>
      <TD CLASS = "thinright">
         6.468 μs
      </TD>
      <TD CLASS = "thinright">
         110.5 μs
      </TD>
      <TD>
         1.648 ms
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD CLASS = "thinright">
         190.9 ns
      </TD>
      <TD CLASS = "thinright">
         15.36 μs
      </TD>
      <TD CLASS = "thinright">
         302.1 μs
      </TD>
      <TD>
         4.904 ms
      </TD>
   </TR>
</TABLE>


SUMMARY:

 * Alga was the fastest 16 times


ABSTRACT:

 * Alga was 2.38 times faster than AlgaOld

