### PR TITLE
Bench on commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
 
   # Benchmark
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii $(if [ $TRAVIS_PULL_REQUEST = "false" ]; then "HEAD^1" else "HEAD" ); fi;
+  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii $(if [ $TRAVIS_PULL_REQUEST = "false" ]; then "HEAD^1"; else "HEAD";fi; ); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
 
   # Benchmark
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii $(if [ $TRAVIS_PULL_REQUEST = "false" ]; then "HEAD^1"; else "HEAD";fi; ); fi;
+  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
 
   # Benchmark
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii; fi;
+  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii $(if [ $TRAVIS_PULL_REQUEST = "false" ]; then "HEAD^1" else "HEAD" ); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 #
 # For more information, see https://github.com/hvr/multi-ghc-travis
 #
+# This is not true, some parts where added by hand. Please see below
+#
 language: c
 sudo: false
 
@@ -44,7 +46,7 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: DOBENCH=0
+      env: DOBENCH=0 # Added by hand, will enable benchmarks.
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
@@ -83,6 +85,7 @@ install:
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
+    # Added by hand. If we required benchmarks, then we will download the right script.
   - if [ $DOBENCH ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
@@ -112,7 +115,8 @@ script:
   - rm -rf ./dist-newstyle
   - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
 
-  # Benchmark
+  # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
+  # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
   - if [ $DOBENCH ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      env: DOBENCH=0
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
@@ -82,6 +83,7 @@ install:
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
+  - if [ $DOBENCH ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -109,6 +111,10 @@ script:
   # haddock
   - rm -rf ./dist-newstyle
   - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
+
+  # Benchmark
+  - cd $TRAVIS_BUILD_DIR
+  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii; fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
 
   # Benchmark
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ Ascii $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); fi;
+  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF


### PR DESCRIPTION
Hi,

As you requested, here is the .travis.yml updated to bench alga against an older version of itself.

It basically calls a script I made here: https://github.com/nobrakal/benchAlgaPr/blob/master/compare.sh

It is (very) tricky, here is some explanation:

This script will clone alga, and reset it to `HEAD^1" if it is a direct push, or leave it as "HEAD" if it is a PR (so PR will be benchmarked against HEAD, and direct push against HEAD^1). (The script itself can be parametrized to use an other commit id)

Then I rename the algebraic-graph package to "old", renaming the "Algebra.Graph" module to "Algebra.GraphOld".

Then it will clone and modify https://github.com/haskell-perf/graphs/ to match this.

And then it will run the benchmarks.
I disabled the output, so only the ABSTRACT and SUMMARY sections are displayed

Please note that the script can both using `cabal new-*` and `stack`, and can be forced to bench only some functions.

The output can be seen here: https://travis-ci.com/nobrakal/alga/jobs/129609679