### PR TITLE
Has loop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,8 @@
 # Change log
 
-## 0.2.1
-
-* #86: Add `hasSelfLoop` into the API.
-
 ## 0.2
 
+* #86: Add `hasSelfLoop` into the API.
 * #79: Improve the API consistency: rename `IntAdjacencyMap` to `AdjacencyIntMap`,
        and then rename the function that extracts its adjacency map to
        `adjacencyIntMap` to avoid the clash with `AdjacencyMap.adjacencyMap`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.2.1
+
+* #86: Add `hasSelfLoop` into the API.
+
 ## 0.2
 
 * #79: Improve the API consistency: rename `IntAdjacencyMap` to `AdjacencyIntMap`,

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -471,7 +471,7 @@ hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
 -- hasLoop x ('edge' x x)       == True
 -- hasLoop x                    == hasEdge x x
 -- hasLoop x . 'removeEdge' x x == const False
--- hasEdge x                    == 'elem' (x,x) . 'edgeList'
+-- hasLoop x                    == 'elem' (x,x) . 'edgeList'
 -- @
 {-# SPECIALISE hasLoop :: Int -> Graph Int -> Bool #-}
 hasLoop :: Eq a => a -> Graph a -> Bool

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -33,7 +33,7 @@ module Algebra.Graph (
     isSubgraphOf, (===),
 
     -- * Graph properties
-    isEmpty, size, hasVertex, hasEdge, hasLoop, vertexCount, edgeCount,
+    isEmpty, size, hasVertex, hasEdge, hasSelfLoop, vertexCount, edgeCount,
     vertexList, edgeList, vertexSet, vertexIntSet, edgeSet, adjacencyList,
 
     -- * Standard families of graphs
@@ -466,20 +466,20 @@ hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
 -- Complexity: /O(s)/ time.
 --
 -- @
--- hasLoop x 'empty'            == False
--- hasLoop x ('vertex' z)       == False
--- hasLoop x ('edge' x x)       == True
--- hasLoop x                    == hasEdge x x
--- hasLoop x . 'removeEdge' x x == const False
--- hasLoop x                    == 'elem' (x,x) . 'edgeList'
+-- hasSelfLoop x 'empty'            == False
+-- hasSelfLoop x ('vertex' z)       == False
+-- hasSelfLoop x ('edge' x x)       == True
+-- hasSelfLoop x                    == hasEdge x x
+-- hasSelfLoop x . 'removeEdge' x x == const False
+-- hasSelfLoop x                    == 'elem' (x,x) . 'edgeList'
 -- @
-{-# SPECIALISE hasLoop :: Int -> Graph Int -> Bool #-}
-hasLoop :: Eq a => a -> Graph a -> Bool
-hasLoop l = hasLoop' . induce (==l)
-  where -- hasLoop' is working because Algebra.Graph.induce is removing empty leaves.
-    hasLoop' (Overlay x y) = hasLoop' x || hasLoop' y
-    hasLoop' Connect{} = True
-    hasLoop' _ = False
+{-# SPECIALISE hasSelfLoop :: Int -> Graph Int -> Bool #-}
+hasSelfLoop :: Eq a => a -> Graph a -> Bool
+hasSelfLoop l = hasSelfLoop' . induce (==l)
+  where -- hasSelfLoop' is working because Algebra.Graph.induce is removing empty leaves.
+    hasSelfLoop' (Overlay x y) = hasSelfLoop' x || hasSelfLoop' y
+    hasSelfLoop' Connect{} = True
+    hasSelfLoop' _ = False
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(s * log(n))/ time.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -33,8 +33,8 @@ module Algebra.Graph (
     isSubgraphOf, (===),
 
     -- * Graph properties
-    isEmpty, size, hasVertex, hasEdge, vertexCount, edgeCount, vertexList,
-    edgeList, vertexSet, vertexIntSet, edgeSet, adjacencyList,
+    isEmpty, size, hasVertex, hasEdge, hasLoop, vertexCount, edgeCount,
+    vertexList, edgeList, vertexSet, vertexIntSet, edgeSet, adjacencyList,
 
     -- * Standard families of graphs
     path, circuit, clique, biclique, star, starTranspose, tree, forest, mesh,
@@ -461,6 +461,25 @@ hasVertex x = foldg False (==x) (||) (||)
 {-# SPECIALISE hasEdge :: Int -> Int -> Graph Int -> Bool #-}
 hasEdge :: Ord a => a -> a -> Graph a -> Bool
 hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
+
+-- | Check if a graph contains a given loop.
+-- Complexity: /O(s)/ time.
+--
+-- @
+-- hasLoop x 'empty'            == False
+-- hasLoop x ('vertex' z)       == False
+-- hasLoop x ('edge' x x)       == True
+-- hasLoop x                    == hasEdge x x
+-- hasLoop x . 'removeEdge' x x == const False
+-- hasEdge x                    == 'elem' (x,x) . 'edgeList'
+-- @
+{-# SPECIALISE hasLoop :: Int -> Graph Int -> Bool #-}
+hasLoop :: Eq a => a -> Graph a -> Bool
+hasLoop l = hasLoop' . induce (==l)
+  where -- hasLoop' is working because induce is removing empty leaves.
+    hasLoop' (Overlay x y) = hasLoop' x || hasLoop' y
+    hasLoop' Connect{} = True
+    hasLoop' _ = False
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(s * log(n))/ time.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -469,7 +469,7 @@ hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
 -- hasSelfLoop x 'empty'            == False
 -- hasSelfLoop x ('vertex' z)       == False
 -- hasSelfLoop x ('edge' x x)       == True
--- hasSelfLoop x                  == hasEdge x x
+-- hasSelfLoop x                  == 'hasEdge' x x
 -- hasSelfLoop x . 'removeEdge' x x == const False
 -- hasSelfLoop x                  == 'elem' (x,x) . 'edgeList'
 -- @

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -469,9 +469,9 @@ hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
 -- hasSelfLoop x 'empty'            == False
 -- hasSelfLoop x ('vertex' z)       == False
 -- hasSelfLoop x ('edge' x x)       == True
--- hasSelfLoop x                    == hasEdge x x
+-- hasSelfLoop x                  == hasEdge x x
 -- hasSelfLoop x . 'removeEdge' x x == const False
--- hasSelfLoop x                    == 'elem' (x,x) . 'edgeList'
+-- hasSelfLoop x                  == 'elem' (x,x) . 'edgeList'
 -- @
 {-# SPECIALISE hasSelfLoop :: Int -> Graph Int -> Bool #-}
 hasSelfLoop :: Eq a => a -> Graph a -> Bool

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -476,7 +476,7 @@ hasEdge u v = (edge u v `isSubgraphOf`) . induce (`elem` [u, v])
 {-# SPECIALISE hasLoop :: Int -> Graph Int -> Bool #-}
 hasLoop :: Eq a => a -> Graph a -> Bool
 hasLoop l = hasLoop' . induce (==l)
-  where -- hasLoop' is working because induce is removing empty leaves.
+  where -- hasLoop' is working because Algebra.Graph.induce is removing empty leaves.
     hasLoop' (Overlay x y) = hasLoop' x || hasLoop' y
     hasLoop' Connect{} = True
     hasLoop' _ = False

--- a/src/Algebra/Graph/AdjacencyIntMap.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap.hs
@@ -28,8 +28,8 @@ module Algebra.Graph.AdjacencyIntMap (
     isSubgraphOf,
 
     -- * Graph properties
-    isEmpty, hasVertex, hasEdge, vertexCount, edgeCount, vertexList, edgeList,
-    adjacencyList, vertexIntSet, edgeSet, preIntSet, postIntSet,
+    isEmpty, hasVertex, hasEdge, hasSelfLoop, vertexCount, edgeCount, vertexList,
+    edgeList, adjacencyList, vertexIntSet, edgeSet, preIntSet, postIntSet,
 
     -- * Standard families of graphs
     path, circuit, clique, biclique, star, starTranspose, tree, forest,
@@ -184,6 +184,20 @@ hasEdge :: Int -> Int -> AdjacencyIntMap -> Bool
 hasEdge u v a = case IntMap.lookup u (adjacencyIntMap a) of
     Nothing -> False
     Just vs -> IntSet.member v vs
+
+-- | Check if a graph contains a given loop.
+-- Complexity: /O(s)/ time.
+--
+-- @
+-- hasSelfLoop x 'empty'            == False
+-- hasSelfLoop x ('vertex' z)       == False
+-- hasSelfLoop x ('edge' x x)       == True
+-- hasSelfLoop x                  == 'hasEdge' x x
+-- hasSelfLoop x . 'removeEdge' x x == const False
+-- hasSelfLoop x                  == 'elem' (x,x) . 'edgeList'
+-- @
+hasSelfLoop :: Int -> AdjacencyIntMap -> Bool
+hasSelfLoop x = hasEdge x x
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(1)/ time.

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -28,8 +28,8 @@ module Algebra.Graph.AdjacencyMap (
     isSubgraphOf,
 
     -- * Graph properties
-    isEmpty, hasVertex, hasEdge, vertexCount, edgeCount, vertexList, edgeList,
-    adjacencyList, vertexSet, vertexIntSet, edgeSet, preSet, postSet,
+    isEmpty, hasVertex, hasEdge, hasSelfLoop, vertexCount, edgeCount, vertexList,
+    edgeList, adjacencyList, vertexSet, vertexIntSet, edgeSet, preSet, postSet,
 
     -- * Standard families of graphs
     path, circuit, clique, biclique, star, starTranspose, tree, forest,
@@ -185,6 +185,20 @@ hasEdge :: Ord a => a -> a -> AdjacencyMap a -> Bool
 hasEdge u v a = case Map.lookup u (adjacencyMap a) of
     Nothing -> False
     Just vs -> Set.member v vs
+
+-- | Check if a graph contains a given loop.
+-- Complexity: /O(s)/ time.
+--
+-- @
+-- hasSelfLoop x 'empty'            == False
+-- hasSelfLoop x ('vertex' z)       == False
+-- hasSelfLoop x ('edge' x x)       == True
+-- hasSelfLoop x                  == 'hasEdge' x x
+-- hasSelfLoop x . 'removeEdge' x x == const False
+-- hasSelfLoop x                  == 'elem' (x,x) . 'edgeList'
+-- @
+hasSelfLoop :: Ord a => a -> AdjacencyMap a -> Bool
+hasSelfLoop x = hasEdge x x
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(1)/ time.

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -32,8 +32,8 @@ module Algebra.Graph.Fold (
     isSubgraphOf,
 
     -- * Graph properties
-    isEmpty, size, hasVertex, hasEdge, vertexCount, edgeCount, vertexList,
-    edgeList, vertexSet, vertexIntSet, edgeSet, adjacencyList,
+    isEmpty, size, hasVertex, hasEdge, hasSelfLoop, vertexCount, edgeCount,
+    vertexList, edgeList, vertexSet, vertexIntSet, edgeSet, adjacencyList,
 
     -- * Standard families of graphs
     path, circuit, clique, biclique, star, starTranspose,
@@ -402,8 +402,22 @@ hasVertex = T.hasVertex
 -- hasEdge x y . 'removeEdge' x y == const False
 -- hasEdge x y                  == 'elem' (x,y) . 'edgeList'
 -- @
-hasEdge :: Ord a => a -> a -> Fold a -> Bool
+hasEdge :: Eq a => a -> a -> Fold a -> Bool
 hasEdge = T.hasEdge
+
+-- | Check if a graph contains a given loop.
+-- Complexity: /O(s)/ time.
+--
+-- @
+-- hasSelfLoop x 'empty'            == False
+-- hasSelfLoop x ('vertex' z)       == False
+-- hasSelfLoop x ('edge' x x)       == True
+-- hasSelfLoop x                  == 'hasEdge' x x
+-- hasSelfLoop x . 'removeEdge' x x == const False
+-- hasSelfLoop x                  == 'elem' (x,x) . 'edgeList'
+-- @
+hasSelfLoop :: Eq a => a -> Fold a -> Bool
+hasSelfLoop = T.hasSelfLoop
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(s * log(n))/ time.

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -386,7 +386,7 @@ hasEdge = T.hasEdge
 -- @
 -- hasSelfLoop x ('vertex' y)       == False
 -- hasSelfLoop x ('edge' x y)       == True
--- hasSelfLoop x                    == hasEdge x x
+-- hasSelfLoop x                  == hasEdge x x
 -- hasSelfLoop x . 'removeEdge' x x == const False
 -- @
 hasSelfLoop :: Eq a => a -> NonEmptyGraph a -> Bool

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -32,7 +32,7 @@ module Algebra.Graph.NonEmpty (
     isSubgraphOf, (===),
 
     -- * Graph properties
-    size, hasVertex, hasEdge, hasLoop, vertexCount, edgeCount, vertexList1,
+    size, hasVertex, hasEdge, hasSelfLoop, vertexCount, edgeCount, vertexList1,
     edgeList, vertexSet, vertexIntSet, edgeSet,
 
     -- * Standard families of graphs
@@ -384,17 +384,17 @@ hasEdge = T.hasEdge
 -- Complexity: /O(s)/ time.
 --
 -- @
--- hasLoop x ('vertex' y)       == False
--- hasLoop x ('edge' x y)       == True
--- hasLoop x                    == hasEdge x x
--- hasLoop x . 'removeEdge' x x == const False
+-- hasSelfLoop x ('vertex' y)       == False
+-- hasSelfLoop x ('edge' x y)       == True
+-- hasSelfLoop x                    == hasEdge x x
+-- hasSelfLoop x . 'removeEdge' x x == const False
 -- @
-hasLoop :: Eq a => a -> NonEmptyGraph a -> Bool
-hasLoop l = maybe False hasLoop' . induce1 (==l)
+hasSelfLoop :: Eq a => a -> NonEmptyGraph a -> Bool
+hasSelfLoop l = maybe False hasSelfLoop' . induce1 (==l)
   where
-    hasLoop' (Overlay x y) = hasLoop' x || hasLoop' y
-    hasLoop' Connect{} = True
-    hasLoop' _ = False
+    hasSelfLoop' (Overlay x y) = hasSelfLoop' x || hasSelfLoop' y
+    hasSelfLoop' Connect{} = True
+    hasSelfLoop' _ = False
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(s * log(n))/ time.

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -384,16 +384,14 @@ hasEdge = T.hasEdge
 -- Complexity: /O(s)/ time.
 --
 -- @
--- hasLoop x 'empty'            == False
--- hasLoop x ('vertex' z)       == False
--- hasLoop x ('edge' x x)       == True
+-- hasLoop x ('vertex' y)       == False
+-- hasLoop x ('edge' x y)       == True
 -- hasLoop x                    == hasEdge x x
 -- hasLoop x . 'removeEdge' x x == const False
--- hasEdge x                    == 'elem' (x,x) . 'edgeList'
 -- @
 hasLoop :: Eq a => a -> NonEmptyGraph a -> Bool
 hasLoop l = maybe False hasLoop' . induce1 (==l)
-  where -- hasLoop' is working because induce is removing empty leaves.
+  where
     hasLoop' (Overlay x y) = hasLoop' x || hasLoop' y
     hasLoop' Connect{} = True
     hasLoop' _ = False

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -386,7 +386,7 @@ hasEdge = T.hasEdge
 -- @
 -- hasSelfLoop x ('vertex' y)       == False
 -- hasSelfLoop x ('edge' x y)       == True
--- hasSelfLoop x                  == hasEdge x x
+-- hasSelfLoop x                  == 'hasEdge' x x
 -- hasSelfLoop x . 'removeEdge' x x == const False
 -- @
 hasSelfLoop :: Eq a => a -> NonEmptyGraph a -> Bool

--- a/src/Algebra/Graph/Relation.hs
+++ b/src/Algebra/Graph/Relation.hs
@@ -26,8 +26,8 @@ module Algebra.Graph.Relation (
     isSubgraphOf,
 
     -- * Graph properties
-    isEmpty, hasVertex, hasEdge, vertexCount, edgeCount, vertexList, edgeList,
-    adjacencyList, vertexSet, vertexIntSet, edgeSet, preSet, postSet,
+    isEmpty, hasVertex, hasEdge, hasSelfLoop, vertexCount, edgeCount, vertexList,
+    edgeList, adjacencyList, vertexSet, vertexIntSet, edgeSet, preSet, postSet,
 
     -- * Standard families of graphs
     path, circuit, clique, biclique, star, starTranspose, tree, forest,
@@ -181,6 +181,20 @@ hasVertex x = Set.member x . domain
 -- @
 hasEdge :: Ord a => a -> a -> Relation a -> Bool
 hasEdge x y = Set.member (x, y) . relation
+
+-- | Check if a graph contains a given loop.
+-- Complexity: /O(s)/ time.
+--
+-- @
+-- hasSelfLoop x 'empty'            == False
+-- hasSelfLoop x ('vertex' z)       == False
+-- hasSelfLoop x ('edge' x x)       == True
+-- hasSelfLoop x                  == 'hasEdge' x x
+-- hasSelfLoop x . 'removeEdge' x x == const False
+-- hasSelfLoop x                  == 'elem' (x,x) . 'edgeList'
+-- @
+hasSelfLoop :: Ord a => a -> Relation a -> Bool
+hasSelfLoop x = hasEdge x x
 
 -- | The number of vertices in a graph.
 -- Complexity: /O(1)/ time.

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -103,7 +103,7 @@ class ToGraph t where
     -- | Check if a graph contains a given lopp.
     --
     -- @
-    -- hasEdge x == hasEdge x x'
+    -- hasEdge x == hasEdge x x
     -- @
     hasLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
     hasLoop x = hasEdge x x

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -103,7 +103,7 @@ class ToGraph t where
     -- | Check if a graph contains a given lopp.
     --
     -- @
-    -- hasSelfLoop x == hasEdge x x
+    -- hasSelfLoop x == 'hasEdge' x x
     -- @
     hasSelfLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
     hasSelfLoop x = hasEdge x x

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -103,7 +103,7 @@ class ToGraph t where
     -- | Check if a graph contains a given lopp.
     --
     -- @
-    -- hasEdge x == hasEdge x x
+    -- hasLoop x == hasLoop x x
     -- @
     hasLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
     hasLoop x = hasEdge x x

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -100,6 +100,14 @@ class ToGraph t where
         o (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt,             xst || yst)
         c (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt, xs && yt || xst || yst)
 
+    -- | Check if a graph contains a given lopp.
+    --
+    -- @
+    -- hasEdge x == hasEdge x x'
+    -- @
+    hasLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
+    hasLoop x = hasEdge x x
+
     -- | The number of vertices in a graph.
     --
     -- @

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -103,7 +103,7 @@ class ToGraph t where
     -- | Check if a graph contains a given lopp.
     --
     -- @
-    -- hasSelfLoop x == hasSelfLoop x x
+    -- hasSelfLoop x == hasEdge x x
     -- @
     hasSelfLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
     hasSelfLoop x = hasEdge x x

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -103,10 +103,10 @@ class ToGraph t where
     -- | Check if a graph contains a given lopp.
     --
     -- @
-    -- hasLoop x == hasLoop x x
+    -- hasSelfLoop x == hasSelfLoop x x
     -- @
-    hasLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
-    hasLoop x = hasEdge x x
+    hasSelfLoop :: Eq (ToVertex t) => ToVertex t -> t -> Bool
+    hasSelfLoop x = hasEdge x x
 
     -- | The number of vertices in a graph.
     --

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -66,7 +66,7 @@ testToGraph = mconcat [ testToGraphDefault
                       , testIsEmpty
                       , testHasVertex
                       , testHasEdge
-                      , testHasLoop
+                      , testHasSelfLoop
                       , testVertexCount
                       , testEdgeCount
                       , testVertexList
@@ -523,8 +523,8 @@ testHasEdge (Testsuite prefix (%)) = do
         (u, v) <- elements ((x, y) : edgeList z)
         return $ hasEdge u v z == elem (u, v) (edgeList % z)
 
-testHasLoop :: Testsuite -> IO ()
-testHasLoop (Testsuite prefix (%)) = do
+testHasSelfLoop :: Testsuite -> IO ()
+testHasSelfLoop (Testsuite prefix (%)) = do
     putStrLn $ "\n============ " ++ prefix ++ "hasSelfLoop ============"
     test "hasSelfLoop x empty            == False" $ \x ->
           hasSelfLoop x % empty          == False
@@ -538,9 +538,8 @@ testHasLoop (Testsuite prefix (%)) = do
     test "hasSelfLoop x . removeEdge x x == const False" $ \x y ->
          (hasSelfLoop x . removeEdge x x) y == const False % y
 
-    test "hasSelfLoop x                  == elem (x,x) . edgeList" $ \x y -> do
-        (u, _) <- elements ((x, x) : edgeList y)
-        return $ hasSelfLoop u y == elem (u, u) (edgeList % y)
+    test "hasSelfLoop x                  == hasEdge x x" $ \x y ->
+         hasSelfLoop x % y               == hasEdge x x % y
 
 testVertexCount :: Testsuite -> IO ()
 testVertexCount (Testsuite prefix (%)) = do

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -529,18 +529,18 @@ testHasLoop (Testsuite prefix (%)) = do
     test "hasLoop x empty            == False" $ \x ->
           hasLoop x % empty          == False
 
-    test "hasLoop x (vertex z)       == False" $ \x z ->
-          hasLoop x % vertex z       == False
+    test "hasLoop x (vertex y)       == False" $ \x y ->
+          hasLoop x % vertex y       == False
 
     test "hasLoop x (edge x x)       == True" $ \x ->
           hasLoop x % edge x x       == True
 
-    test "hasLoop x . removeEdge x x == const False" $ \x z ->
-         (hasLoop x . removeEdge x x) z == const False % z
+    test "hasLoop x . removeEdge x x == const False" $ \x y ->
+         (hasLoop x . removeEdge x x) y == const False % y
 
-    test "hasLoop x                  == elem (x,x) . edgeList" $ \x z -> do
-        (u, _) <- elements ((x, x) : edgeList z)
-        return $ hasLoop u z == elem (u, u) (edgeList % z)
+    test "hasLoop x                  == elem (x,x) . edgeList" $ \x y -> do
+        (u, _) <- elements ((x, x) : edgeList y)
+        return $ hasLoop u y == elem (u, u) (edgeList % y)
 
 testVertexCount :: Testsuite -> IO ()
 testVertexCount (Testsuite prefix (%)) = do

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -522,6 +522,25 @@ testHasEdge (Testsuite prefix (%)) = do
         (u, v) <- elements ((x, y) : edgeList z)
         return $ hasEdge u v z == elem (u, v) (edgeList % z)
 
+testHasLoop :: Testsuite -> IO ()
+testHasLoop (Testsuite prefix (%)) = do
+    putStrLn $ "\n============ " ++ prefix ++ "hasEdge ============"
+    test "hasLoop x empty            == False" $ \x ->
+          hasLoop x % empty          == False
+
+    test "hasLoop x (vertex z)       == False" $ \x z ->
+          hasLoop x % vertex z       == False
+
+    test "hasLoop x (edge x x)       == True" $ \x ->
+          hasLoop x % edge x x       == True
+
+    test "hasLoop x . removeEdge x x == const False" $ \x z ->
+         (hasLoop x . removeEdge x x) z == const False % z
+
+    test "hasLoop x                  == elem (x,x) . edgeList" $ \x z -> do
+        (u, _) <- elements ((x, x) : edgeList z)
+        return $ hasLoop u z == elem (u, u) (edgeList % z)
+
 testVertexCount :: Testsuite -> IO ()
 testVertexCount (Testsuite prefix (%)) = do
     putStrLn $ "\n============ " ++ prefix ++ "vertexCount ============"

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -524,7 +524,7 @@ testHasEdge (Testsuite prefix (%)) = do
 
 testHasLoop :: Testsuite -> IO ()
 testHasLoop (Testsuite prefix (%)) = do
-    putStrLn $ "\n============ " ++ prefix ++ "hasEdge ============"
+    putStrLn $ "\n============ " ++ prefix ++ "hasLoop ============"
     test "hasLoop x empty            == False" $ \x ->
           hasLoop x % empty          == False
 

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -525,22 +525,22 @@ testHasEdge (Testsuite prefix (%)) = do
 
 testHasLoop :: Testsuite -> IO ()
 testHasLoop (Testsuite prefix (%)) = do
-    putStrLn $ "\n============ " ++ prefix ++ "hasLoop ============"
-    test "hasLoop x empty            == False" $ \x ->
-          hasLoop x % empty          == False
+    putStrLn $ "\n============ " ++ prefix ++ "hasSelfLoop ============"
+    test "hasSelfLoop x empty            == False" $ \x ->
+          hasSelfLoop x % empty          == False
 
-    test "hasLoop x (vertex y)       == False" $ \x y ->
-          hasLoop x % vertex y       == False
+    test "hasSelfLoop x (vertex y)       == False" $ \x y ->
+          hasSelfLoop x % vertex y       == False
 
-    test "hasLoop x (edge x x)       == True" $ \x ->
-          hasLoop x % edge x x       == True
+    test "hasSelfLoop x (edge x x)       == True" $ \x ->
+          hasSelfLoop x % edge x x       == True
 
-    test "hasLoop x . removeEdge x x == const False" $ \x y ->
-         (hasLoop x . removeEdge x x) y == const False % y
+    test "hasSelfLoop x . removeEdge x x == const False" $ \x y ->
+         (hasSelfLoop x . removeEdge x x) y == const False % y
 
-    test "hasLoop x                  == elem (x,x) . edgeList" $ \x y -> do
+    test "hasSelfLoop x                  == elem (x,x) . edgeList" $ \x y -> do
         (u, _) <- elements ((x, x) : edgeList y)
-        return $ hasLoop u y == elem (u, u) (edgeList % y)
+        return $ hasSelfLoop u y == elem (u, u) (edgeList % y)
 
 testVertexCount :: Testsuite -> IO ()
 testVertexCount (Testsuite prefix (%)) = do

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -66,6 +66,7 @@ testToGraph = mconcat [ testToGraphDefault
                       , testIsEmpty
                       , testHasVertex
                       , testHasEdge
+                      , testHasLoop
                       , testVertexCount
                       , testEdgeCount
                       , testVertexList


### PR DESCRIPTION
This is related to #84 

Here is the `hasLoop` implemented, with default implementation in `ToGraph` and a better one for `Algebra.Graph` and `Algebra.Graph.NonEmpty`.

I have also sneaked a little improvement in `Algebra.Graph.NonEmpty` concerning `foldg1` which `Maybe` directly. A bench of `removeVertex` for this improvement:

### Mesh
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH>
         100
      </TH>
   </TR>
   <TR>
      <TH>
         NonEmpty
      </TH>
      <TD CLASS = "thinright">
         34.78 ns
      </TD>
      <TD CLASS = "thinright">
         1.080 μs
      </TD>
      <TD>
         14.85 μs
      </TD>
   </TR>
   <TR>
      <TH>
         NonEmptyOld
      </TH>
      <TD CLASS = "thinright">
         44.27 ns
      </TD>
      <TD CLASS = "thinright">
         1.853 μs
      </TD>
      <TD>
         27.71 μs
      </TD>
   </TR>
</TABLE>

### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH CLASS = "thinright">
         1
      </TH>
      <TH CLASS = "thinright">
         10
      </TH>
      <TH>
         100
      </TH>
   </TR>
   <TR>
      <TH>
         NonEmpty
      </TH>
      <TD CLASS = "thinright">
         34.70 ns
      </TD>
      <TD CLASS = "thinright">
         3.589 μs
      </TD>
      <TD>
         520.5 μs
      </TD>
   </TR>
   <TR>
      <TH>
         NonEmptyOld
      </TH>
      <TD CLASS = "thinright">
         46.32 ns
      </TD>
      <TD CLASS = "thinright">
         6.523 μs
      </TD>
      <TD>
         1.404 ms
      </TD>
   </TR>
</TABLE>


SUMMARY:

 * NonEmpty was the fastest 12 times


ABSTRACT:
(Based on an average of the ratio between largest benchmarks)

 * NonEmpty was 2.21 times faster than NonEmptyOld