### PR TITLE
Better hasEdge for Algrebra.Graph

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -446,8 +446,6 @@ size = foldg 1 (const 1) (+) (+)
 hasVertex :: Eq a => a -> Graph a -> Bool
 hasVertex x = foldg False (==x) (||) (||)
 
--- TODO: Benchmark to see if this implementation is faster than the default
--- implementation provided by the ToGraph type class.
 -- | Check if a graph contains a given edge.
 -- Complexity: /O(s)/ time.
 --

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -465,11 +465,14 @@ hasEdge s t = hasEdge' . induce'
      hasEdge' g = case foldg e v o c g of (_, _, r) -> r
        where
          e                             = (False   , False   , False                 )
-         v x                           = (x       , not x   , False                 )
+         v (x,y)                       = (x       , y       , False                 )
          o (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt,             xst || yst)
          c (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt, xs && yt || xst || yst)
      induce' = foldg Empty
-                    (\x -> if x == s then Vertex True else if x == t then Vertex False else Empty)
+                    (\x -> let !l = x == s
+                               !r = x == t
+                            in if l || r then Vertex (l,r) else Empty
+                      )
                     (k Overlay)
                     (k Connect)
        where

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -458,19 +458,21 @@ hasVertex x = foldg False (==x) (||) (||)
 -- @
 {-# SPECIALISE hasEdge :: Int -> Int -> Graph Int -> Bool #-}
 hasEdge :: Eq a => a -> a -> Graph a -> Bool
-hasEdge s t = hasEdge' . induce'
-   where
+hasEdge s t = if s == t -- We test if we search for a loop
+                 then hasSelfLoop s
+                 else hasEdge' . induce' -- if not, we convert the supplied @Graph a@ to a @Graph Bool@
+                                         -- where @s@ is @Vertex True@, @v@ is @Vertex False@ and other
+                                         -- vertices are removed.
+                                         -- Then we check if there is an edge from @True@ to @False@
+    where
      hasEdge' g = case foldg e v o c g of (_, _, r) -> r
        where
          e                             = (False   , False   , False                 )
-         v (x,y)                       = (x       , y       , False                 )
+         v x                           = (x       , not x   , False                 )
          o (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt,             xst || yst)
          c (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt, xs && yt || xst || yst)
      induce' = foldg Empty
-                    (\x -> let l = x == s
-                               r = x == t
-                            in if l || r then Vertex (l,r) else Empty
-                      )
+                    (\x -> if x == s then Vertex True else if x == t then Vertex False else Empty)
                     (k Overlay)
                     (k Connect)
        where

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -467,8 +467,8 @@ hasEdge s t = hasEdge' . induce'
          o (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt,             xst || yst)
          c (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt, xs && yt || xst || yst)
      induce' = foldg Empty
-                    (\x -> let !l = x == s
-                               !r = x == t
+                    (\x -> let l = x == s
+                               r = x == t
                             in if l || r then Vertex (l,r) else Empty
                       )
                     (k Overlay)

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -388,20 +388,19 @@ hasEdge s t =
    where
      hasEdge' g = case foldg1 v o c g of (_, _, r) -> r
        where
-         v (x,y)                       = (x       , y       , False                 )
+         v x                           = (x       , not x   , False                 )
          o (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt,             xst || yst)
          c (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt, xs && yt || xst || yst)
-     induce' = foldg1 (\x -> let l = x == s
-                                 r = x == t
-                              in if l || r then Just (Vertex (l,r)) else Nothing
-                      )
-                    (k Overlay)
-                    (k Connect)
+     induce' = foldg1 (\x -> if x == s then Just (Vertex True)
+                                      else if x == t
+                                              then Just (Vertex False)
+                                              else Nothing)
+                     (k Overlay)
+                     (k Connect)
        where
          k _ x     Nothing     = x -- Constant folding to get rid of Empty leaves
          k _ Nothing y         = y
          k f (Just x) (Just y) = Just $ f x y
-
 -- | Check if a graph contains a given loop.
 -- Complexity: /O(s)/ time.
 --

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -378,7 +378,13 @@ hasVertex v = foldg1 (==v) (||) (||)
 -- hasEdge x y                  == 'elem' (x,y) . 'edgeList'
 -- @
 hasEdge :: Eq a => a -> a -> NonEmptyGraph a -> Bool
-hasEdge s t = maybe False hasEdge' . induce'
+hasEdge s t =
+  if s == t -- We test if we search for a loop
+     then hasSelfLoop s
+     else maybe False hasEdge' . induce' -- if not, we convert the supplied @Graph a@ to a @Graph Bool@
+                                         -- where @s@ is @Vertex True@, @v@ is @Vertex False@ and other
+                                         -- vertices are removed.
+                                         -- Then we check if there is an edge from @True@ to @False@
    where
      hasEdge' g = case foldg1 v o c g of (_, _, r) -> r
        where


### PR DESCRIPTION
Hi,

I have played again a bit, but I think I have found a better one this time :)
The boost come from two things:

1. The first one, I had never checked it, but `induce (\x -> elem x [u,v])` was not a great idea. Just replacing it by `induce (\x -> x == u || x == v)` is clearly a better idea:
### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         WithEq
      </TH>
      <TD>
         70.80 ms
      </TD>
   </TR>
   <TR>
      <TH>
         WithElem
      </TH>
      <TD>
         103.4 ms
      </TD>
   </TR>
</TABLE>

2. Then, because the equality test was already done in the "induce", I had the idea to store it and pass it to a modified version from `ToGraph`:
```Haskell
hasEdge :: Eq a => a -> a -> Graph a -> Bool
hasEdge s t = hasEdge' . induce'
    where
     hasEdge' g = case foldg e v o c g of (_, _, r) -> r
       where
         e                             = (False   , False   , False                 )
         v x                           = (x       , not x   , False                 )
         o (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt,             xst || yst)
         c (xs, xt, xst) (ys, yt, yst) = (xs || ys, xt || yt, xs && yt || xst || yst)
     induce' = foldg Empty
                    (\x -> if x == s then Vertex True else if x == t then Vertex False else Empty)
                    (k Overlay)
                    (k Connect)
       where
         k _ x     Empty = x -- Constant folding to get rid of Empty leaves
         k _ Empty y     = y
         k f x     y     = f x y
```

It is a bit more complicated, but it drops the `Ord` instance previously required to an `Eq` one:
### Mesh
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         MoreComplicated
      </TH>
      <TD>
         112.9 μs
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD>
         219.7 μs
      </TD>
   </TR>
</TABLE>

### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         MoreComplicated
      </TH>
      <TD>
         59.75 ms
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD>
         90.81 ms
      </TD>
   </TR>
</TABLE>


SUMMARY:

 * Alga was the fastest 12 times


ABSTRACT:
(Based on an average of the ratio between largest benchmarks)

 * Alga was 1.71 times faster than AlgaOld

And this rocks also with alga's clique:

### Alga's Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         1000
      </TH>
   </TR>
   <TR>
      <TH>
         MoreComplicated
      </TH>
      <TD>
         20.09 μs
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD>
         51.48 μs
      </TD>
   </TR>
</TABLE>