### PR TITLE
Add regression suite for NonEmpty and update current one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,21 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.1"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env:
-      - TEST="" DOBENCH=0 # Added by hand
-      - TEST=--disable-tests DOBENCH=1 # Added by hand, will enable benchmarks.
-      - TEST=--disable-tests DOBENCH=2 # Added by hand, will enable benchmarks.
-
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
       os: osx
+
+# Added by hand
+    - compiler: "ghc-8.4.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      env: DOBENCH=0
+    - compiler: "ghc-8.4.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      env: TEST=--disable-tests DOBENCH=1
+    - compiler: "ghc-8.4.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
+      env: TEST=--disable-tests DOBENCH=2
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - if [ "$DOBENCH" = "" ]; then
+  - if [ "$DOBENCH" = "" ]; then # Added by hand, will not build anything if we are runnning bench, else download the script
       cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all ;
       cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all ;
     else curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ install:
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
     # Added by hand. If we required benchmarks, then we will download the right script.
-  - if [ ! $DOBENCH ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
+  - if [ $DOBENCH != 0 ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: TEST=--disable-tests HADDOCK=false DOBENCH="1"
+      env: DOBENCH="Graph" TEST=--disable-tests HADDOCK=false
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: TEST=--disable-tests HADDOCK=false DOBENCH="2"
+      env: DOBENCH="Graph.NonEmpty" TEST=--disable-tests HADDOCK=false
 
 before_install:
   - HC=${CC}
@@ -92,7 +92,7 @@ install:
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
     # Added by hand. If we required benchmarks, then we will download the right script.
-  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
+  - if [ "$DOBENCH" != "" ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -124,7 +124,7 @@ script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
+  - if [ "$DOBENCH" != "" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ "$DOBENCH" = "Graph.NonEmpty" ]; then echo "True"; else echo ""; fi;); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ install:
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
     # Added by hand. If we required benchmarks, then we will download the right script.
-  - if [ $DOBENCH -ne 0 ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
+  - if [ ! $DOBENCH ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -125,7 +125,7 @@ script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH -ne 0]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); $(if [ $DOBENCH -eq 2 ]; then echo "True"; else echo ""; fi;) fi;
+  - if [ $DOBENCH != 0 ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,17 @@ matrix:
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       env: DOBENCH="Graph" TEST=--disable-tests HADDOCK=false
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - if [ "$DOBENCH" != "" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ "$DOBENCH" = "Graph.NonEmpty" ]; then echo "True"; else echo ""; fi;); fi;
+
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       env: DOBENCH="Graph.NonEmpty" TEST=--disable-tests HADDOCK=false
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - if [ "$DOBENCH" != "" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ "$DOBENCH" = "Graph.NonEmpty" ]; then echo "True"; else echo ""; fi;); fi;
+
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ script:
   - rm -rf ./dist-newstyle
   - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
 
+after_script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,14 +90,14 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - if [ "$DOBENCH" = "" ]; then # Added by hand, will not build anything if we are runnning bench, else download the script
+  # Added by hand, will not build anything if we are runnning bench, else download the script
+  - if [ "$DOBENCH" = "" ]; then
       cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all ;
       cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all ;
     else curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh ;
     fi
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
-    # Added by hand. If we required benchmarks, then we will download the right script.
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,11 +121,10 @@ script:
   - rm -rf ./dist-newstyle
   - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
 
-after_script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
+  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then timeout 45m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH -ne 0]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); $(if [ $DOBENCH -eq 2 ]; then "True" else ""; fi;) fi;
+  - if [ $DOBENCH -ne 0]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); $(if [ $DOBENCH -eq 2 ]; then echo "True"; else echo ""; fi;) fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       env: DOBENCH="Graph.NonEmpty"
-      script: timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); "True"
+      script: timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) "True" ;
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: TEST=--disable-tests DOBENCH="1"
+      env: TEST=--disable-tests HADDOCK=false DOBENCH="1"
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: TEST=--disable-tests DOBENCH="2"
+      env: TEST=--disable-tests HADDOCK=false DOBENCH="2"
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,12 @@ matrix:
 # Added by hand
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: DOBENCH=0
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: TEST=--disable-tests DOBENCH=1
+      env: TEST=--disable-tests DOBENCH="1"
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: TEST=--disable-tests DOBENCH=2
+      env: TEST=--disable-tests DOBENCH="2"
 
 before_install:
   - HC=${CC}
@@ -93,7 +92,7 @@ install:
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
     # Added by hand. If we required benchmarks, then we will download the right script.
-  - if [ $DOBENCH != 0 ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
+  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -125,7 +124,7 @@ script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH != 0 ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
+  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,17 +53,12 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: DOBENCH="Graph" TEST=--disable-tests HADDOCK=false
-      script:
-        - cd $TRAVIS_BUILD_DIR
-        - if [ "$DOBENCH" != "" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ "$DOBENCH" = "Graph.NonEmpty" ]; then echo "True"; else echo ""; fi;); fi;
-
+      env: DOBENCH="Graph"
+      script: timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; );
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: DOBENCH="Graph.NonEmpty" TEST=--disable-tests HADDOCK=false
-      script:
-        - cd $TRAVIS_BUILD_DIR
-        - if [ "$DOBENCH" != "" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ "$DOBENCH" = "Graph.NonEmpty" ]; then echo "True"; else echo ""; fi;); fi;
+      env: DOBENCH="Graph.NonEmpty"
+      script: timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); "True"
 
 
 before_install:
@@ -95,12 +90,14 @@ install:
       (cd "." && autoreconf -i);
     fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
+  - if [ "$DOBENCH" = "" ]; then
+      cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all ;
+      cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all ;
+    else curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh ;
+    fi
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
     # Added by hand. If we required benchmarks, then we will download the right script.
-  - if [ "$DOBENCH" != "" ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -128,11 +125,6 @@ script:
   # haddock
   - rm -rf ./dist-newstyle
   - if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
-
-  # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
-  # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
-  - cd $TRAVIS_BUILD_DIR
-  - if [ "$DOBENCH" != "" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ "$DOBENCH" = "Graph.NonEmpty" ]; then echo "True"; else echo ""; fi;); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,11 @@ matrix:
     - compiler: "ghc-8.4.1"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-      env: DOBENCH=0 # Added by hand, will enable benchmarks.
+      env:
+      - TEST="" DOBENCH=0 # Added by hand
+      - TEST=--disable-tests DOBENCH=1 # Added by hand, will enable benchmarks.
+      - TEST=--disable-tests DOBENCH=2 # Added by hand, will enable benchmarks.
+
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
@@ -86,7 +90,7 @@ install:
   - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
     # Added by hand. If we required benchmarks, then we will download the right script.
-  - if [ $DOBENCH ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
+  - if [ $DOBENCH -ne 0 ]; then curl https://raw.githubusercontent.com/nobrakal/benchAlgaPr/master/compare.sh -o $TRAVIS_BUILD_DIR/compare.sh; chmod +x compare.sh; fi;
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -118,7 +122,7 @@ script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ $DOBENCH ]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); fi;
+  - if [ $DOBENCH -ne 0]; then ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); $(if [ $DOBENCH -eq 2 ]; then "True" else ""; fi;) fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
@@ -51,15 +54,12 @@ matrix:
 # Added by hand
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.4.1"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       env: DOBENCH="Graph"
       script: timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; );
     - compiler: "ghc-8.4.1"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
       env: DOBENCH="Graph.NonEmpty"
       script: timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ); "True"
-
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ script:
   # Added by hand. If we required benchmarks, then we will run them using the downloaded script.
   # If the benchmarked commit is not a Pull Request, then use HEAD^1 else use HEAD.
   - cd $TRAVIS_BUILD_DIR
-  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then timeout 45m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
+  - if [ "$DOBENCH" = "1" -o "$DOBENCH" = "2" ]; then timeout 40m ./compare.sh Cabal ./ QuickComparison $(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "HEAD^1"; else echo "HEAD";fi; ) $(if [ $DOBENCH = 2 ]; then echo "True"; else echo ""; fi;); fi;
 
 # REGENDATA ["--osx=8.2.2","algebraic-graphs.cabal","-o",".travis.yml"]
 # EOF


### PR DESCRIPTION
Hi,

I have updated the script to support the benchmarks of NonEmpty graphs and created two Travis jobs dedicated to the benchmark of the `Algebra.Graph` and `Algebra.Graph.NonEmpty` module.

The tricky part is that the benchmark suite need criterion which need many dependencies. I needed to set a timeout for the action, so it fail before the Travis time limit and allow caching these dependencies (if the time limit is reached, the is no caching).

So if the build first fail, it certainly due to benchamrks dependencies, so re-run it and, as they have been cached, the build should pass.

Example here: https://travis-ci.com/nobrakal/alga/builds/78616254