### PR TITLE
Use rewrite rules instead of some specialization

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -541,9 +541,14 @@ vertexIntList = IntSet.toList . vertexIntSet
 -- edgeList . 'edges'        == 'Data.List.nub' . 'Data.List.sort'
 -- edgeList . 'transpose'    == 'Data.List.sort' . map 'Data.Tuple.swap' . edgeList
 -- @
-{-# SPECIALISE edgeList :: Graph Int -> [(Int,Int)] #-}
 edgeList :: Ord a => Graph a -> [(a, a)]
 edgeList = AM.edgeList . fromGraphAM
+{-# INLINE[1] edgeList #-}
+{-# RULES "edgeList/Int" edgeList = edgeIntList #-}
+
+-- | Like 'edgeList' but specialised for graphs with vertices of type 'Int'.
+edgeIntList :: Graph Int -> [(Int,Int)]
+edgeIntList = AIM.edgeList . fromGraphAIM
 
 -- | The set of vertices of a given graph.
 -- Complexity: /O(s * log(n))/ time and /O(n)/ memory.
@@ -579,9 +584,14 @@ vertexIntSet = foldg IntSet.empty IntSet.singleton IntSet.union IntSet.union
 -- edgeSet ('edge' x y) == Set.'Set.singleton' (x,y)
 -- edgeSet . 'edges'    == Set.'Set.fromList'
 -- @
-{-# SPECIALISE edgeSet :: Graph Int -> Set.Set (Int,Int) #-}
 edgeSet :: Ord a => Graph a -> Set.Set (a, a)
 edgeSet = AM.edgeSet . fromGraphAM
+{-# INLINE[1] edgeSet #-}
+{-# RULES "edgeSet/Int" edgeSet = edgeIntSet #-}
+
+-- | Like 'edgeIntSet' but specialised for graphs with vertices of type 'Int'.
+edgeIntSet :: Graph Int -> Set.Set (Int,Int)
+edgeIntSet = AIM.edgeSet . fromGraphAIM
 
 -- | The sorted /adjacency list/ of a graph.
 -- Complexity: /O(n + m)/ time and /O(m)/ memory.
@@ -614,7 +624,11 @@ fromGraphAM = foldg AM.empty AM.vertex AM.overlay AM.connect
 
 -- | Like 'adjacencyMap' but specialised for graphs with vertices of type 'Int'.
 adjacencyIntMap :: Graph Int -> IntMap IntSet
-adjacencyIntMap = AIM.adjacencyIntMap . foldg AIM.empty AIM.vertex AIM.overlay AIM.connect
+adjacencyIntMap = AIM.adjacencyIntMap . fromGraphAIM
+
+-- | Like 'fromGraphAM' but specialised for graphs with vertices of type 'Int'.
+fromGraphAIM :: Graph Int -> AIM.AdjacencyIntMap
+fromGraphAIM = foldg AIM.empty AIM.vertex AIM.overlay AIM.connect
 
 -- | The /path/ on a list of vertices.
 -- Complexity: /O(L)/ time, memory and size, where /L/ is the length of the


### PR DESCRIPTION
Hi,

Trying to improve the `MaybeNonEmpty` version, I discovered that the rewrite rules are very powerful for `edgeList` (it comes from the quickness of AdjacencyIntMap):

## edgeList

Description: Produce a list of the edges in the graph

### Mesh
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         100
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD>
         77.91 μs
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD>
         206.3 μs
      </TD>
   </TR>
</TABLE>

### Clique
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         100
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD>
         2.347 ms
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD>
         7.619 ms
      </TD>
   </TR>
</TABLE>

### Circuit
<TABLE>
   <TR>
      <TH>
      </TH>
      <TH>
         100
      </TH>
   </TR>
   <TR>
      <TH>
         Alga
      </TH>
      <TD>
         39.63 μs
      </TD>
   </TR>
   <TR>
      <TH>
         AlgaOld
      </TH>
      <TD>
         118.9 μs
      </TD>
   </TR>
</TABLE>


SUMMARY:

 * Alga was the fastest 3 times


ABSTRACT:
(Based on an average of the ratio between largest benchmarks)

 * Alga was 2.94 times faster than AlgaOld


