### PR TITLE
NonEmpty graphs optimizations

### DIFF
--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -57,12 +57,14 @@ import Control.DeepSeq (NFData (..))
 import Control.Monad.Compat
 import Data.List.NonEmpty (NonEmpty (..))
 
-import qualified Algebra.Graph         as G
-import qualified Algebra.Graph.ToGraph as T
-import qualified Data.IntSet           as IntSet
-import qualified Data.List.NonEmpty    as NonEmpty
-import qualified Data.Set              as Set
-import qualified Data.Tree             as Tree
+import qualified Algebra.Graph                 as G
+import qualified Algebra.Graph.AdjacencyMap    as AM
+import qualified Algebra.Graph.AdjacencyIntMap as AIM
+import qualified Algebra.Graph.ToGraph         as T
+import qualified Data.IntSet                   as IntSet
+import qualified Data.List.NonEmpty            as NonEmpty
+import qualified Data.Set                      as Set
+import qualified Data.Tree                     as Tree
 
 {-| The 'NonEmptyGraph' data type is a deep embedding of the core graph
 construction primitives 'vertex', 'overlay' and 'connect'. As one can guess from

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -466,7 +466,7 @@ vertexIntCount = IntSet.size . vertexIntSet
 -- @
 {-# SPECIALISE edgeCount :: NonEmptyGraph Int -> Int #-}
 edgeCount :: Ord a => NonEmptyGraph a -> Int
-edgeCount = T.edgeCount
+edgeCount = length . edgeList
 
 -- | The sorted list of vertices of a given graph.
 -- Complexity: /O(s * log(n))/ time and /O(n)/ memory.

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -496,7 +496,7 @@ vertexIntList1 = NonEmpty.fromList . IntSet.toAscList . vertexIntSet
 {-# RULES "edgeList/Int" edgeList = edgeIntList #-}
 {-# INLINE[1] edgeList #-}
 edgeList :: Ord a => NonEmptyGraph a -> [(a, a)]
-edgeList = AM.edgeList . foldg1 AM.vertex AM.overlay AM.connect
+edgeList = T.edgeList
 
 -- | Like 'edgeList' but specialised for NonEmptyGraph with vertices of type 'Int'.
 edgeIntList :: NonEmptyGraph Int -> [(Int,Int)]

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -287,9 +287,7 @@ vertices1 (x :| xs) = foldr (Overlay . vertex) (vertex x) xs
 -- 'edgeCount' . edges1   == 'Data.List.NonEmpty.length' . 'Data.List.NonEmpty.nub'
 -- @
 edges1 :: NonEmpty (a, a) -> NonEmptyGraph a
-edges1 (x :| xs) = foldr (Overlay . edgeTuple) (edgeTuple x) xs
-  where
-    edgeTuple = uncurry edge
+edges1 (x :| xs) = foldr (Overlay . uncurry edge) (uncurry edge x) xs
 
 -- | Overlay a given list of graphs.
 -- Complexity: /O(L)/ time and memory, and /O(S)/ size, where /L/ is the length

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -504,8 +504,6 @@ edgeList = AM.edgeList . foldg1 AM.vertex AM.overlay AM.connect
 edgeIntList :: NonEmptyGraph Int -> [(Int,Int)]
 edgeIntList = AIM.edgeList . foldg1 AIM.vertex AIM.overlay AIM.connect
 
--- TODO Apply the optimization
-
 -- | The set of vertices of a given graph.
 -- Complexity: /O(s * log(n))/ time and /O(n)/ memory.
 --

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -140,7 +140,9 @@ instance NFData a => NFData (NonEmptyGraph a) where
 
 instance T.ToGraph (NonEmptyGraph a) where
     type ToVertex (NonEmptyGraph a) = a
-    foldg _ = foldg1
+    foldg _     = foldg1
+    hasEdge     = hasEdge
+    hasSelfLoop = hasSelfLoop
 
 instance Num a => Num (NonEmptyGraph a) where
     fromInteger = Vertex . fromInteger

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -58,7 +58,6 @@ import Control.Monad.Compat
 import Data.List.NonEmpty (NonEmpty (..))
 
 import qualified Algebra.Graph                 as G
-import qualified Algebra.Graph.AdjacencyMap    as AM
 import qualified Algebra.Graph.AdjacencyIntMap as AIM
 import qualified Algebra.Graph.ToGraph         as T
 import qualified Data.IntSet                   as IntSet


### PR DESCRIPTION
Hi,

As discussed in #93 , here are several optimizations to `Algebra.Graph.NonEmpty`.

Mainly with:

* `SPECIALIZE` pragma when possible and useful
* `RULES` when possible and useful
* Previous improvements founds while working on #90

The benchmarks:
```
vertexList1: 0.08 (good)
vertexCount: 0.07 (good)
hasVertex: 3.71 (bad)
edgeCount: 0.36 (good)
edgeList: 0.37 (good)
hasEdge: 0.25 (good)
hasSelfLoop: 1.02 (OK)
addEdge: 1.00 (OK)
addVertex: 1.02 (OK)
removeVertex1: 1.01 (OK)
equality: 0.34 (good)
removeEdge: 0.96 (OK)
transpose: 1.00 (OK)
dff: 1.01 (OK)
topSort: 1.01 (OK)
edges1: 0.83 (good)
``` 

So everything is green, the drop of `hasVertex` as already been documented here: https://github.com/snowleopard/alga/issues/90#issuecomment-403087848