### PR TITLE
Remove foldable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.2.1
+
+* #121: Drop `Foldable` and `Traversable` instances
+
 ## 0.2
 
 * #117: Add `sparsify`.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -132,19 +132,7 @@ be computed as follows:
 m == 'edgeCount' g
 s == 'size' g@
 
-Note that 'size' is slightly different from the 'length' method of the
-'Foldable' type class, as the latter does not count 'empty' leaves of the
-expression:
-
-@'length' 'empty'           == 0
-'size'   'empty'           == 1
-'length' ('vertex' x)      == 1
-'size'   ('vertex' x)      == 1
-'length' ('empty' + 'empty') == 0
-'size'   ('empty' + 'empty') == 2@
-
-The 'size' of any graph is positive, and the difference @('size' g - 'length' g)@
-corresponds to the number of occurrences of 'empty' in an expression @g@.
+Note that 'size' count all leaves of the expression.
 
 Converting a 'Graph' to the corresponding 'AM.AdjacencyMap' takes /O(s + m * log(m))/
 time and /O(s + m)/ memory. This is also the complexity of the graph equality test,
@@ -356,10 +344,9 @@ concatg combine = fromMaybe empty . foldr1Safe combine
 -- @
 -- foldg 'empty' 'vertex'        'overlay' 'connect'        == id
 -- foldg 'empty' 'vertex'        'overlay' (flip 'connect') == 'transpose'
--- foldg []    return        (++)    (++)           == 'Data.Foldable.toList'
--- foldg 0     (const 1)     (+)     (+)            == 'Data.Foldable.length'
 -- foldg 1     (const 1)     (+)     (+)            == 'size'
 -- foldg True  (const False) (&&)    (&&)           == 'isEmpty'
+-- foldg False ((==) v)      (||)    (||)           == 'hasVertex v'
 -- @
 foldg :: b -> (a -> b) -> (b -> b -> b) -> (b -> b -> b) -> Graph a -> b
 foldg e v o c = go

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -52,7 +52,7 @@ module Algebra.Graph (
   ) where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Applicative (Alternative)
 import Control.DeepSeq (NFData (..))

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
+{-# LANGUAGE DeriveFunctor #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph
@@ -155,7 +155,7 @@ data Graph a = Empty
              | Vertex a
              | Overlay (Graph a) (Graph a)
              | Connect (Graph a) (Graph a)
-             deriving (Foldable, Functor, Show, Traversable)
+             deriving (Functor, Show)
 
 instance NFData a => NFData (Graph a) where
     rnf Empty         = ()
@@ -844,7 +844,6 @@ removeVertex v = induce (/= v)
 removeEdge :: Eq a => a -> a -> Graph a -> Graph a
 removeEdge s t = filterContext s (/=s) (/=t)
 
-
 -- TODO: Export
 -- | Filter vertices in a subgraph context.
 {-# SPECIALISE filterContext :: Int -> (Int -> Bool) -> (Int -> Bool) -> Graph Int -> Graph Int #-}
@@ -1000,8 +999,9 @@ simple op x y
 box :: Graph a -> Graph b -> Graph (a, b)
 box x y = overlays $ xs ++ ys
   where
-    xs = map (\b -> fmap (,b) x) $ toList y
-    ys = map (\a -> fmap (a,) y) $ toList x
+    xs = map (\b -> fmap (,b) x) $ toListGr y
+    ys = map (\a -> fmap (a,) y) $ toListGr x
+    toListGr = foldg [] pure (++) (++)
 
 -- | 'Focus' on a specified subgraph.
 focus :: (a -> Bool) -> Graph a -> Focus a

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -132,7 +132,14 @@ be computed as follows:
 m == 'edgeCount' g
 s == 'size' g@
 
-Note that 'size' count all leaves of the expression.
+Note that 'size' counts all leaves of the expression:
+
+@'vertexCount' 'empty'           == 0
+'size'        'empty'           == 1
+'vertexCount' ('vertex' x)      == 1
+'size'        ('vertex' x)      == 1
+'vertexCount' ('empty' + 'empty') == 0
+'size'        ('empty' + 'empty') == 2@
 
 Converting a 'Graph' to the corresponding 'AM.AdjacencyMap' takes /O(s + m * log(m))/
 time and /O(s + m)/ memory. This is also the complexity of the graph equality test,

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -346,7 +346,7 @@ concatg combine = fromMaybe empty . foldr1Safe combine
 -- foldg 'empty' 'vertex'        'overlay' (flip 'connect') == 'transpose'
 -- foldg 1     (const 1)     (+)     (+)            == 'size'
 -- foldg True  (const False) (&&)    (&&)           == 'isEmpty'
--- foldg False ((==) v)      (||)    (||)           == 'hasVertex v'
+-- foldg False ((==) x)      (||)    (||)           == 'hasVertex x'
 -- @
 foldg :: b -> (a -> b) -> (b -> b -> b) -> (b -> b -> b) -> Graph a -> b
 foldg e v o c = go

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -986,9 +986,10 @@ simple op x y
 box :: Graph a -> Graph b -> Graph (a, b)
 box x y = overlays $ xs ++ ys
   where
-    xs = map (\b -> fmap (,b) x) $ toListGr y
-    ys = map (\a -> fmap (a,) y) $ toListGr x
-    toListGr = foldg [] pure (++) (++)
+    xs = map (\b -> fmap (,b) x) $ toList $ toListGr y
+    ys = map (\a -> fmap (a,) y) $ toList $ toListGr x
+    toListGr :: Graph a -> List a
+    toListGr = foldg mempty pure (<>) (<>)
 
 -- | 'Focus' on a specified subgraph.
 focus :: (a -> Bool) -> Graph a -> Focus a

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -59,6 +59,7 @@ import Control.DeepSeq (NFData (..))
 import Control.Monad.Compat
 import Control.Monad.State (runState, get, put)
 import Data.Foldable (toList)
+import Data.Monoid ((<>))
 import Data.Maybe (fromMaybe)
 import Data.Tree
 

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -125,7 +125,14 @@ computed as follows:
 m == 'edgeCount' g
 s == 'size' g@
 
-Note that 'size' count all leaves of the expression.
+Note that 'size' counts all leaves of the expression:
+
+@'vertexCount' 'empty'           == 0
+'size'        'empty'           == 1
+'vertexCount' ('vertex' x)      == 1
+'size'        ('vertex' x)      == 1
+'vertexCount' ('empty' + 'empty') == 0
+'size'        ('empty' + 'empty') == 2@
 
 Converting a 'Fold' to the corresponding 'AM.AdjacencyMap' takes /O(s + m * log(m))/
 time and /O(s + m)/ memory. This is also the complexity of the graph equality test,

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -125,19 +125,7 @@ computed as follows:
 m == 'edgeCount' g
 s == 'size' g@
 
-Note that 'size' is slightly different from the 'length' method of the
-'Foldable' type class, as the latter does not count 'empty' leaves of the
-expression:
-
-@'length' 'empty'           == 0
-'size'   'empty'           == 1
-'length' ('vertex' x)      == 1
-'size'   ('vertex' x)      == 1
-'length' ('empty' + 'empty') == 0
-'size'   ('empty' + 'empty') == 2@
-
-The 'size' of any graph is positive, and the difference @('size' g - 'length' g)@
-corresponds to the number of occurrences of 'empty' in an expression @g@.
+Note that 'size' count all leaves of the expression.
 
 Converting a 'Fold' to the corresponding 'AM.AdjacencyMap' takes /O(s + m * log(m))/
 time and /O(s + m)/ memory. This is also the complexity of the graph equality test,
@@ -335,10 +323,9 @@ connects = foldr connect empty
 -- @
 -- foldg 'empty' 'vertex'        'overlay' 'connect'        == id
 -- foldg 'empty' 'vertex'        'overlay' (flip 'connect') == 'transpose'
--- foldg []    return        (++)    (++)           == 'Data.Foldable.toList'
--- foldg 0     (const 1)     (+)     (+)            == 'Data.Foldable.length'
 -- foldg 1     (const 1)     (+)     (+)            == 'size'
 -- foldg True  (const False) (&&)    (&&)           == 'isEmpty'
+-- foldg False ((==) v)      (||)    (||)           == 'hasVertex v'
 -- @
 foldg :: b -> (a -> b) -> (b -> b -> b) -> (b -> b -> b) -> Fold a -> b
 foldg e v o c g = runFold g e v o c

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -325,7 +325,7 @@ connects = foldr connect empty
 -- foldg 'empty' 'vertex'        'overlay' (flip 'connect') == 'transpose'
 -- foldg 1     (const 1)     (+)     (+)            == 'size'
 -- foldg True  (const False) (&&)    (&&)           == 'isEmpty'
--- foldg False ((==) v)      (||)    (||)           == 'hasVertex v'
+-- foldg False ((==) x)      (||)    (||)           == 'hasVertex x'
 -- @
 foldg :: b -> (a -> b) -> (b -> b -> b) -> (b -> b -> b) -> Fold a -> b
 foldg e v o c g = runFold g e v o c

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -182,12 +182,6 @@ instance Monad Fold where
     return = vertex
     g >>=f = foldg empty f overlay connect g
 
-instance Foldable Fold where
-    foldMap f = foldg mempty f mappend mappend
-
-instance Traversable Fold where
-    traverse f = foldg (pure empty) (fmap vertex . f) (liftA2 overlay) (liftA2 connect)
-
 instance ToGraph (Fold a) where
     type ToVertex (Fold a) = a
     foldg = foldg

--- a/src/Algebra/Graph/Fold.hs
+++ b/src/Algebra/Graph/Fold.hs
@@ -45,7 +45,7 @@ module Algebra.Graph.Fold (
 import Prelude ()
 import Prelude.Compat
 
-import Control.Applicative (Alternative, liftA2)
+import Control.Applicative (Alternative)
 import Control.Monad.Compat (MonadPlus (..), ap)
 import Data.Function
 

--- a/src/Algebra/Graph/HigherKinded/Class.hs
+++ b/src/Algebra/Graph/HigherKinded/Class.hs
@@ -57,14 +57,11 @@ import Prelude ()
 import Prelude.Compat
 
 import Control.Applicative (Alternative(empty, (<|>)))
-import Control.Monad.Compat (MonadPlus, msum, mfilter)
-import Data.Foldable (toList)
+import Control.Monad.Compat (MonadPlus, mfilter)
 import Data.Tree
 
 import qualified Algebra.Graph      as G
 import qualified Algebra.Graph.Fold as F
-import qualified Data.IntSet        as IntSet
-import qualified Data.Set           as Set
 
 {-|
 The core type class for constructing algebraic graphs is defined by introducing

--- a/src/Algebra/Graph/Labelled.hs
+++ b/src/Algebra/Graph/Labelled.hs
@@ -112,6 +112,18 @@ instance Dioid e => C.Graph (Graph e a) where
     overlay = overlay
     connect = connect
 
+-- | Generalised 'Graph' folding: recursively collapse a 'Graph' by applying
+-- the provided functions to the leaves and internal nodes of the expression,
+-- without any distinction between @overlay@ and @connect@
+-- The order of arguments is: empty, vertex, overlay and connect.
+-- Complexity: /O(s)/ applications of given functions. As an example, the
+-- complexity of 'size' is /O(s)/, since all functions have cost /O(1)/.
+--
+-- @
+-- foldgUnDiff 1     (const 1)     (+)  == 'size'
+-- foldgUnDiff True  (const False) (&&) == 'isEmpty'
+-- foldgUnDiff False ((==) v)      (||) == 'hasVertex v'
+-- @
 foldgUnDiff :: b -> (a -> b) -> (b -> b -> b) ->  Graph e a -> b
 foldgUnDiff e v o = go
   where

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -122,7 +122,14 @@ if @g@ is a 'NonEmptyGraph' then /n/, /m/ and /s/ can be computed as follows:
 m == 'edgeCount' g
 s == 'size' g@
 
-Note that 'size' count all leaves of the expression.
+Note that 'size' counts all leaves of the expression:
+
+@'vertexCount' 'empty'           == 0
+'size'        'empty'           == 1
+'vertexCount' ('vertex' x)      == 1
+'size'        ('vertex' x)      == 1
+'vertexCount' ('empty' + 'empty') == 0
+'size'        ('empty' + 'empty') == 2@
 
 Converting a 'NonEmptyGraph' to the corresponding 'AM.AdjacencyMap' takes
 /O(s + m * log(m))/ time and /O(s + m)/ memory. This is also the complexity of

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
+{-# LANGUAGE CPP, DeriveFunctor #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.NonEmpty
@@ -134,7 +134,7 @@ expressions to canonical representations based on adjacency maps.
 data NonEmptyGraph a = Vertex a
                      | Overlay (NonEmptyGraph a) (NonEmptyGraph a)
                      | Connect (NonEmptyGraph a) (NonEmptyGraph a)
-                     deriving (Foldable, Functor, Show, Traversable)
+                     deriving (Functor, Show)
 
 instance NFData a => NFData (NonEmptyGraph a) where
     rnf (Vertex  x  ) = rnf x

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -122,9 +122,7 @@ if @g@ is a 'NonEmptyGraph' then /n/, /m/ and /s/ can be computed as follows:
 m == 'edgeCount' g
 s == 'size' g@
 
-The 'size' of any graph is positive and coincides with the result of 'length'
-method of the 'Foldable' type class. We define 'size' only for the consistency
-with the API of other graph representations, such as "Algebra.Graph".
+Note that 'size' count all leaves of the expression.
 
 Converting a 'NonEmptyGraph' to the corresponding 'AM.AdjacencyMap' takes
 /O(s + m * log(m))/ time and /O(s + m)/ memory. This is also the complexity of
@@ -886,6 +884,5 @@ sparsify graph = res
         put (m + 1)
         overlay <$> s `x` m <*> m `y` t
 
--- Shall we export this? I suggest to wait for Foldable1 type class instead.
 toNonEmpty :: NonEmptyGraph a -> NonEmpty a
 toNonEmpty = foldg1 (:| []) (<>) (<>)

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -17,6 +17,26 @@
 -- access to many other useful methods for free. This type class is similar to
 -- the standard "Data.Foldable" defined for lists.
 --
+-- It is in fact so similar to "Data.Foldable" that one can define 'foldMap' using
+-- 'foldg':
+--
+-- @
+-- foldMap f = foldg mempty f (<>) (<>)
+-- @
+--
+-- This allow to define a valable "Data.Foldable" instance but it leads to some
+-- problems because this instance can show the internal structure of a graph.
+-- For example:
+--
+-- @
+-- toList (overlay (vertex 0) (vertex 0)) \/= toList (vertex 0)
+-- @
+--
+-- BUT
+--
+-- @
+-- overlay (vertex 0) (vertex 0) == vertex 0
+-- @
 -----------------------------------------------------------------------------
 module Algebra.Graph.ToGraph (ToGraph (..)) where
 

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -24,7 +24,7 @@
 -- foldMap f = foldg mempty f (<>) (<>)
 -- @
 --
--- This allow to define a valable "Data.Foldable" instance but it leads to some
+-- This allow to define a valid "Data.Foldable" instance but it leads to some
 -- problems because this instance can show the internal structure of a graph.
 -- For example:
 --

--- a/test/Algebra/Graph/Test/API.hs
+++ b/test/Algebra/Graph/Test/API.hs
@@ -148,7 +148,6 @@ instance Ord a => GraphAPI (Fold.Fold a) where
     induce        = Fold.induce
     bind          = (>>=)
     simplify      = Fold.simplify
-    box           = HClass.box
 
 instance Ord a => GraphAPI (Graph.Graph a) where
     edge          = Graph.edge


### PR DESCRIPTION
This is related to #95 

So:

* It removes `Foldable` and `Traversable` instance from concerned Graph data-types.
* It removes comments related to `Foldable` instances.
* It drops `isEmpty`, `hasVertex`, `vertexCount`, `vertexList`, `vertexSet`, `vertexIntSet` and `box` from `Algebra.Graph.HigherKinded.Class` because of the removal of the `Foldable` constraint. `mesh` and ` torus` were rewrited without `box`.
* I don't really know what is happening in `Algebra.Graph.Labelled` but I had to add a `foldgUnDiff` and a real `hasVertex` (because `elem` was used previously).
* I added a comment related to the `Foldable` instance in `Algebra.Graph.ToGraph` (I don't know if it is in the right module).
