### PR TITLE
Add a draft implementation of new SCC algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 0.3
 
+* #128, #130: Modify the SCC algorithm to return non-empty graph components.
+* #130: Move adjacency map algorithms to separate modules.
+* #130: Export `fromAdjacencySets` and `fromAdjacencyIntSets`.
 * #138: Do not require `Eq` instance on the string type when exporting graphs.
 * #136: Rename `Algebra.Graph.NonEmpty.NonEmptyGraph` to `Algebra.Graph.NonEmpty.Graph`.
 * #136: Add `Algebra.Graph.NonEmpty.AdjacencyMap`.

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -60,6 +60,7 @@ library
     hs-source-dirs:     src
     exposed-modules:    Algebra.Graph,
                         Algebra.Graph.AdjacencyIntMap,
+                        Algebra.Graph.AdjacencyIntMap.Algorithm,
                         Algebra.Graph.AdjacencyIntMap.Internal,
                         Algebra.Graph.AdjacencyMap,
                         Algebra.Graph.AdjacencyMap.Algorithm,

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -62,6 +62,7 @@ library
                         Algebra.Graph.AdjacencyIntMap,
                         Algebra.Graph.AdjacencyIntMap.Internal,
                         Algebra.Graph.AdjacencyMap,
+                        Algebra.Graph.AdjacencyMap.Algorithm,
                         Algebra.Graph.AdjacencyMap.Internal,
                         Algebra.Graph.Class,
                         Algebra.Graph.Export,

--- a/src/Algebra/Graph/AdjacencyIntMap.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap.hs
@@ -10,11 +10,11 @@
 -- in Haskell. See <https://github.com/snowleopard/alga-paper this paper> for the
 -- motivation behind the library, the underlying theory, and implementation details.
 --
--- This module defines the 'AdjacencyIntMap' data type, as well as associated
--- operations and algorithms. 'AdjacencyIntMap' is an instance of the 'C.Graph'
--- type class, which can be used for polymorphic graph construction
--- and manipulation. See "Algebra.Graph.AdjacencyMap" for graphs with
--- non-@Int@ vertices.
+-- This module defines the 'AdjacencyIntMap' data type and associated functions.
+-- See "Algebra.Graph.AdjacencyIntMap.Algorithm" for implementations of basic
+-- graph algorithms. 'AdjacencyIntMap' is an instance of the 'C.Graph' type
+-- class, which can be used for polymorphic graph construction and manipulation.
+-- See "Algebra.Graph.AdjacencyMap" for graphs with non-@Int@ vertices.
 -----------------------------------------------------------------------------
 module Algebra.Graph.AdjacencyIntMap (
     -- * Data structure
@@ -31,33 +31,51 @@ module Algebra.Graph.AdjacencyIntMap (
     adjacencyList, vertexIntSet, edgeSet, preIntSet, postIntSet,
 
     -- * Standard families of graphs
-    path, circuit, clique, biclique, star, stars, tree, forest,
+    path, circuit, clique, biclique, star, stars, fromAdjacencyIntSets, tree,
+    forest,
 
     -- * Graph transformation
     removeVertex, removeEdge, replaceVertex, mergeVertices, transpose, gmap,
-    induce,
+    induce
+    ) where
 
-    -- * Algorithms
-    dfsForest, dfsForestFrom, dfs, reachable, topSort, isAcyclic,
-
-    -- * Correctness properties
-    isDfsForestOf, isTopSortOf
-  ) where
-
-import Control.Monad
 import Data.Foldable (foldMap)
 import Data.IntSet (IntSet)
-import Data.Maybe
 import Data.Monoid
 import Data.Set (Set)
 import Data.Tree
 
 import Algebra.Graph.AdjacencyIntMap.Internal
 
-import qualified Data.Graph.Typed   as Typed
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.IntSet        as IntSet
 import qualified Data.Set           as Set
+
+-- | Construct the /empty graph/.
+-- Complexity: /O(1)/ time and memory.
+--
+-- @
+-- 'isEmpty'     empty == True
+-- 'hasVertex' x empty == False
+-- 'vertexCount' empty == 0
+-- 'edgeCount'   empty == 0
+-- @
+empty :: AdjacencyIntMap
+empty = AM IntMap.empty
+{-# NOINLINE [1] empty #-}
+
+-- | Construct the graph comprising /a single isolated vertex/.
+-- Complexity: /O(1)/ time and memory.
+--
+-- @
+-- 'isEmpty'     (vertex x) == False
+-- 'hasVertex' x (vertex x) == True
+-- 'vertexCount' (vertex x) == 1
+-- 'edgeCount'   (vertex x) == 0
+-- @
+vertex :: Int -> AdjacencyIntMap
+vertex x = AM $ IntMap.singleton x IntSet.empty
+{-# NOINLINE [1] vertex #-}
 
 -- | Construct the graph comprising /a single edge/.
 -- Complexity: /O(1)/ time, memory.
@@ -72,6 +90,47 @@ import qualified Data.Set           as Set
 edge :: Int -> Int -> AdjacencyIntMap
 edge x y | x == y    = AM $ IntMap.singleton x (IntSet.singleton y)
          | otherwise = AM $ IntMap.fromList [(x, IntSet.singleton y), (y, IntSet.empty)]
+
+-- | /Overlay/ two graphs. This is a commutative, associative and idempotent
+-- operation with the identity 'empty'.
+-- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
+--
+-- @
+-- 'isEmpty'     (overlay x y) == 'isEmpty'   x   && 'isEmpty'   y
+-- 'hasVertex' z (overlay x y) == 'hasVertex' z x || 'hasVertex' z y
+-- 'vertexCount' (overlay x y) >= 'vertexCount' x
+-- 'vertexCount' (overlay x y) <= 'vertexCount' x + 'vertexCount' y
+-- 'edgeCount'   (overlay x y) >= 'edgeCount' x
+-- 'edgeCount'   (overlay x y) <= 'edgeCount' x   + 'edgeCount' y
+-- 'vertexCount' (overlay 1 2) == 2
+-- 'edgeCount'   (overlay 1 2) == 0
+-- @
+overlay :: AdjacencyIntMap -> AdjacencyIntMap -> AdjacencyIntMap
+overlay x y = AM $ IntMap.unionWith IntSet.union (adjacencyIntMap x) (adjacencyIntMap y)
+{-# NOINLINE [1] overlay #-}
+
+-- | /Connect/ two graphs. This is an associative operation with the identity
+-- 'empty', which distributes over 'overlay' and obeys the decomposition axiom.
+-- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory. Note that the
+-- number of edges in the resulting graph is quadratic with respect to the number
+-- of vertices of the arguments: /m = O(m1 + m2 + n1 * n2)/.
+--
+-- @
+-- 'isEmpty'     (connect x y) == 'isEmpty'   x   && 'isEmpty'   y
+-- 'hasVertex' z (connect x y) == 'hasVertex' z x || 'hasVertex' z y
+-- 'vertexCount' (connect x y) >= 'vertexCount' x
+-- 'vertexCount' (connect x y) <= 'vertexCount' x + 'vertexCount' y
+-- 'edgeCount'   (connect x y) >= 'edgeCount' x
+-- 'edgeCount'   (connect x y) >= 'edgeCount' y
+-- 'edgeCount'   (connect x y) >= 'vertexCount' x * 'vertexCount' y
+-- 'edgeCount'   (connect x y) <= 'vertexCount' x * 'vertexCount' y + 'edgeCount' x + 'edgeCount' y
+-- 'vertexCount' (connect 1 2) == 2
+-- 'edgeCount'   (connect 1 2) == 1
+-- @
+connect :: AdjacencyIntMap -> AdjacencyIntMap -> AdjacencyIntMap
+connect x y = AM $ IntMap.unionsWith IntSet.union [ adjacencyIntMap x, adjacencyIntMap y,
+    IntMap.fromSet (const . IntMap.keysSet $ adjacencyIntMap y) (IntMap.keysSet $ adjacencyIntMap x) ]
+{-# NOINLINE [1] connect #-}
 
 -- | Construct the graph comprising a given list of isolated vertices.
 -- Complexity: /O(L * log(L))/ time and /O(L)/ memory, where /L/ is the length
@@ -390,6 +449,22 @@ star x ys = connect (vertex x) (vertices ys)
 stars :: [(Int, [Int])] -> AdjacencyIntMap
 stars = fromAdjacencyIntSets . map (fmap IntSet.fromList)
 
+-- | Construct a graph from a list of adjacency sets; a variation of 'stars'.
+-- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
+--
+-- @
+-- fromAdjacencyIntSets []                                     == 'empty'
+-- fromAdjacencyIntSets [(x, IntSet.'IntSet.empty')]                    == 'vertex' x
+-- fromAdjacencyIntSets [(x, IntSet.'IntSet.singleton' y)]              == 'edge' x y
+-- fromAdjacencyIntSets . 'map' ('fmap' IntSet.'IntSet.fromList')           == 'stars'
+-- 'overlay' (fromAdjacencyIntSets xs) (fromAdjacencyIntSets ys) == fromAdjacencyIntSets (xs ++ ys)
+-- @
+fromAdjacencyIntSets :: [(Int, IntSet)] -> AdjacencyIntMap
+fromAdjacencyIntSets ss = AM $ IntMap.unionWith IntSet.union vs es
+  where
+    vs = IntMap.fromSet (const IntSet.empty) . IntSet.unions $ map snd ss
+    es = IntMap.fromListWith IntSet.union ss
+
 -- | The /tree graph/ constructed from a given 'Tree' data structure.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
 --
@@ -526,169 +601,3 @@ gmap f = AM . IntMap.map (IntSet.map f) . IntMap.mapKeysWith IntSet.union f . ad
 -- @
 induce :: (Int -> Bool) -> AdjacencyIntMap -> AdjacencyIntMap
 induce p = AM . IntMap.map (IntSet.filter p) . IntMap.filterWithKey (\k _ -> p k) . adjacencyIntMap
-
--- | Compute the /depth-first search/ forest of a graph that corresponds to
--- searching from each of the graph vertices in the 'Ord' @a@ order.
---
--- @
--- dfsForest 'empty'                       == []
--- 'forest' (dfsForest $ 'edge' 1 1)         == 'vertex' 1
--- 'forest' (dfsForest $ 'edge' 1 2)         == 'edge' 1 2
--- 'forest' (dfsForest $ 'edge' 2 1)         == 'vertices' [1,2]
--- 'isSubgraphOf' ('forest' $ dfsForest x) x == True
--- 'isDfsForestOf' (dfsForest x) x         == True
--- dfsForest . 'forest' . dfsForest        == dfsForest
--- dfsForest ('vertices' vs)               == map (\\v -> Node v []) ('Data.List.nub' $ 'Data.List.sort' vs)
--- 'dfsForestFrom' ('vertexList' x) x        == dfsForest x
--- dfsForest $ 3 * (1 + 4) * (1 + 5)     == [ Node { rootLabel = 1
---                                                 , subForest = [ Node { rootLabel = 5
---                                                                      , subForest = [] }]}
---                                          , Node { rootLabel = 3
---                                                 , subForest = [ Node { rootLabel = 4
---                                                                      , subForest = [] }]}]
--- @
-dfsForest :: AdjacencyIntMap -> Forest Int
-dfsForest = Typed.dfsForest . Typed.fromAdjacencyIntMap
-
--- | Compute the /depth-first search/ forest of a graph, searching from each of
--- the given vertices in order. Note that the resulting forest does not
--- necessarily span the whole graph, as some vertices may be unreachable.
---
--- @
--- dfsForestFrom vs 'empty'                           == []
--- 'forest' (dfsForestFrom [1]   $ 'edge' 1 1)          == 'vertex' 1
--- 'forest' (dfsForestFrom [1]   $ 'edge' 1 2)          == 'edge' 1 2
--- 'forest' (dfsForestFrom [2]   $ 'edge' 1 2)          == 'vertex' 2
--- 'forest' (dfsForestFrom [3]   $ 'edge' 1 2)          == 'empty'
--- 'forest' (dfsForestFrom [2,1] $ 'edge' 1 2)          == 'vertices' [1,2]
--- 'isSubgraphOf' ('forest' $ dfsForestFrom vs x) x     == True
--- 'isDfsForestOf' (dfsForestFrom ('vertexList' x) x) x == True
--- dfsForestFrom ('vertexList' x) x                   == 'dfsForest' x
--- dfsForestFrom vs             ('vertices' vs)       == map (\\v -> Node v []) ('Data.List.nub' vs)
--- dfsForestFrom []             x                   == []
--- dfsForestFrom [1,4] $ 3 * (1 + 4) * (1 + 5)      == [ Node { rootLabel = 1
---                                                            , subForest = [ Node { rootLabel = 5
---                                                                                 , subForest = [] }
---                                                     , Node { rootLabel = 4
---                                                            , subForest = [] }]
--- @
-dfsForestFrom :: [Int] -> AdjacencyIntMap -> Forest Int
-dfsForestFrom vs = Typed.dfsForestFrom vs . Typed.fromAdjacencyIntMap
-
--- | Compute the list of vertices visited by the /depth-first search/ in a graph,
--- when searching from each of the given vertices in order.
---
--- @
--- dfs vs    $ 'empty'                    == []
--- dfs [1]   $ 'edge' 1 1                 == [1]
--- dfs [1]   $ 'edge' 1 2                 == [1,2]
--- dfs [2]   $ 'edge' 1 2                 == [2]
--- dfs [3]   $ 'edge' 1 2                 == []
--- dfs [1,2] $ 'edge' 1 2                 == [1,2]
--- dfs [2,1] $ 'edge' 1 2                 == [2,1]
--- dfs []    $ x                        == []
--- dfs [1,4] $ 3 * (1 + 4) * (1 + 5)    == [1,5,4]
--- 'isSubgraphOf' ('vertices' $ dfs vs x) x == True
--- @
-dfs :: [Int] -> AdjacencyIntMap -> [Int]
-dfs vs = concatMap flatten . dfsForestFrom vs
-
--- | Compute the list of vertices that are /reachable/ from a given source
--- vertex in a graph. The vertices in the resulting list appear in the
--- /depth-first order/.
---
--- @
--- reachable x $ 'empty'                       == []
--- reachable 1 $ 'vertex' 1                    == [1]
--- reachable 1 $ 'vertex' 2                    == []
--- reachable 1 $ 'edge' 1 1                    == [1]
--- reachable 1 $ 'edge' 1 2                    == [1,2]
--- reachable 4 $ 'path'    [1..8]              == [4..8]
--- reachable 4 $ 'circuit' [1..8]              == [4..8] ++ [1..3]
--- reachable 8 $ 'clique'  [8,7..1]            == [8] ++ [1..7]
--- 'isSubgraphOf' ('vertices' $ reachable x y) y == True
--- @
-reachable :: Int -> AdjacencyIntMap -> [Int]
-reachable x = dfs [x]
-
--- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph
--- is cyclic.
---
--- @
--- topSort (1 * 2 + 3 * 1)               == Just [3,1,2]
--- topSort (1 * 2 + 2 * 1)               == Nothing
--- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
--- 'isJust' . topSort                      == 'isAcyclic'
--- @
-topSort :: AdjacencyIntMap -> Maybe [Int]
-topSort m = if isTopSortOf result m then Just result else Nothing
-  where
-    result = Typed.topSort (Typed.fromAdjacencyIntMap m)
-
--- | Check if a given graph is /acyclic/.
---
--- @
--- isAcyclic (1 * 2 + 3 * 1) == True
--- isAcyclic (1 * 2 + 2 * 1) == False
--- isAcyclic . 'circuit'       == 'null'
--- isAcyclic                 == 'isJust' . 'topSort'
--- @
-isAcyclic :: AdjacencyIntMap -> Bool
-isAcyclic = isJust . topSort
-
--- | Check if a given forest is a correct /depth-first search/ forest of a graph.
--- The implementation is based on the paper "Depth-First Search and Strong
--- Connectivity in Coq" by François Pottier.
---
--- @
--- isDfsForestOf []                              'empty'            == True
--- isDfsForestOf []                              ('vertex' 1)       == False
--- isDfsForestOf [Node 1 []]                     ('vertex' 1)       == True
--- isDfsForestOf [Node 1 []]                     ('vertex' 2)       == False
--- isDfsForestOf [Node 1 [], Node 1 []]          ('vertex' 1)       == False
--- isDfsForestOf [Node 1 []]                     ('edge' 1 1)       == True
--- isDfsForestOf [Node 1 []]                     ('edge' 1 2)       == False
--- isDfsForestOf [Node 1 [], Node 2 []]          ('edge' 1 2)       == False
--- isDfsForestOf [Node 2 [], Node 1 []]          ('edge' 1 2)       == True
--- isDfsForestOf [Node 1 [Node 2 []]]            ('edge' 1 2)       == True
--- isDfsForestOf [Node 1 [], Node 2 []]          ('vertices' [1,2]) == True
--- isDfsForestOf [Node 2 [], Node 1 []]          ('vertices' [1,2]) == True
--- isDfsForestOf [Node 1 [Node 2 []]]            ('vertices' [1,2]) == False
--- isDfsForestOf [Node 1 [Node 2 [Node 3 []]]]   ('path' [1,2,3])   == True
--- isDfsForestOf [Node 1 [Node 3 [Node 2 []]]]   ('path' [1,2,3])   == False
--- isDfsForestOf [Node 3 [], Node 1 [Node 2 []]] ('path' [1,2,3])   == True
--- isDfsForestOf [Node 2 [Node 3 []], Node 1 []] ('path' [1,2,3])   == True
--- isDfsForestOf [Node 1 [], Node 2 [Node 3 []]] ('path' [1,2,3])   == False
--- @
-isDfsForestOf :: Forest Int -> AdjacencyIntMap -> Bool
-isDfsForestOf f am = case go IntSet.empty f of
-    Just seen -> seen == vertexIntSet am
-    Nothing   -> False
-  where
-    go seen []     = Just seen
-    go seen (t:ts) = do
-        let root = rootLabel t
-        guard $ root `IntSet.notMember` seen
-        guard $ and [ hasEdge root (rootLabel subTree) am | subTree <- subForest t ]
-        newSeen <- go (IntSet.insert root seen) (subForest t)
-        guard $ postIntSet root am `IntSet.isSubsetOf` newSeen
-        go newSeen ts
-
--- | Check if a given list of vertices is a correct /topological sort/ of a graph.
---
--- @
--- isTopSortOf [3,1,2] (1 * 2 + 3 * 1) == True
--- isTopSortOf [1,2,3] (1 * 2 + 3 * 1) == False
--- isTopSortOf []      (1 * 2 + 3 * 1) == False
--- isTopSortOf []      'empty'           == True
--- isTopSortOf [x]     ('vertex' x)      == True
--- isTopSortOf [x]     ('edge' x x)      == False
--- @
-isTopSortOf :: [Int] -> AdjacencyIntMap -> Bool
-isTopSortOf xs m = go IntSet.empty xs
-  where
-    go seen []     = seen == IntMap.keysSet (adjacencyIntMap m)
-    go seen (v:vs) = postIntSet v m `IntSet.intersection` newSeen == IntSet.empty
-                  && go newSeen vs
-      where
-        newSeen = IntSet.insert v seen

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------
 -- |
--- Module     : Algebra.Graph.AdjacencyMap.Algorithm
+-- Module     : Algebra.Graph.AdjacencyIntMap.Algorithm
 -- Copyright  : (c) Andrey Mokhov 2016-2018
 -- License    : MIT (see the file LICENSE)
 -- Maintainer : andrey.mokhov@gmail.com
@@ -11,55 +11,25 @@
 -- motivation behind the library, the underlying theory, and implementation details.
 --
 -- This module provides basic graph algorithms, such as /depth-first search/,
--- implemented for the "Algebra.Graph.AdjacencyMap" data type.
+-- implemented for the "Algebra.Graph.AdjacencyIntMap" data type.
 -----------------------------------------------------------------------------
-module Algebra.Graph.AdjacencyMap.Algorithm (
+module Algebra.Graph.AdjacencyIntMap.Algorithm (
     -- * Algorithms
-    dfsForest, dfsForestFrom, dfs, reachable, topSort, isAcyclic, scc,
+    dfsForest, dfsForestFrom, dfs, reachable, topSort, isAcyclic,
 
     -- * Correctness properties
     isDfsForestOf, isTopSortOf
     ) where
 
 import Control.Monad
-import Data.Foldable (toList)
 import Data.Maybe
 import Data.Tree
 
-import Algebra.Graph.AdjacencyMap
+import Algebra.Graph.AdjacencyIntMap
 
-import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NonEmpty
-import qualified Data.Graph                          as KL
-import qualified Data.Graph.Typed                    as Typed
-import qualified Data.Map.Strict                     as Map
-import qualified Data.Set                            as Set
-
--- | Compute the /condensation/ of a graph, where each vertex corresponds to a
--- /strongly-connected component/ of the original graph. Note that component
--- graphs are non-empty, and are therefore of type
--- "Algebra.Graph.NonEmpty.AdjacencyMap".
---
--- @
--- scc 'empty'               == 'empty'
--- scc ('vertex' x)          == 'vertex' (NonEmpty.'NonEmpty.vertex' x)
--- scc ('edge' 1 1)          == 'vertex' (NonEmpty.'NonEmpty.edge' 1 1)
--- scc ('edge' 1 2)          == 'edge'   (NonEmpty.'NonEmpty.vertex' 1) (NonEmpty.'NonEmpty.vertex' 2)
--- scc ('circuit' (1:xs))    == 'vertex' (NonEmpty.'NonEmpty.circuit1' (1 'Data.List.NonEmpty.:|' xs))
--- scc (3 * 1 * 4 * 1 * 5) == 'edges'  [ (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.vertex'  5      )
---                                   , (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.clique1' [1,4,1])
---                                   , (NonEmpty.'NonEmpty.clique1' [1,4,1], NonEmpty.'NonEmpty.vertex'  5      ) ]
--- @
-scc :: Ord a => AdjacencyMap a -> AdjacencyMap (NonEmpty.AdjacencyMap a)
-scc m = fromAdjacencySets
-    [ (v', Set.delete v' $ Set.map (components Map.!) us)
-    | (v, us) <- Map.toList (adjacencyMap m), let v' = components Map.! v ]
-  where
-    Typed.GraphKL g r _ = Typed.fromAdjacencyMap m
-    components = Map.fromList $ concatMap (expand . fmap r . toList) (KL.scc g)
-    expand xs  = map (\x -> (x, c)) xs
-      where
-        s = Set.fromList xs
-        c = fromJust . NonEmpty.toNonEmpty $ induce (`Set.member` s) m
+import qualified Data.Graph.Typed   as Typed
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.IntSet        as IntSet
 
 -- | Compute the /depth-first search/ forest of a graph that corresponds to
 -- searching from each of the graph vertices in the 'Ord' @a@ order.
@@ -81,8 +51,8 @@ scc m = fromAdjacencySets
 --                                                 , subForest = [ Node { rootLabel = 4
 --                                                                      , subForest = [] }]}]
 -- @
-dfsForest :: Ord a => AdjacencyMap a -> Forest a
-dfsForest g = dfsForestFrom (vertexList g) g
+dfsForest :: AdjacencyIntMap -> Forest Int
+dfsForest = Typed.dfsForest . Typed.fromAdjacencyIntMap
 
 -- | Compute the /depth-first search/ forest of a graph, searching from each of
 -- the given vertices in order. Note that the resulting forest does not
@@ -106,11 +76,11 @@ dfsForest g = dfsForestFrom (vertexList g) g
 --                                                     , Node { rootLabel = 4
 --                                                            , subForest = [] }]
 -- @
-dfsForestFrom :: Ord a => [a] -> AdjacencyMap a -> Forest a
-dfsForestFrom vs = Typed.dfsForestFrom vs . Typed.fromAdjacencyMap
+dfsForestFrom :: [Int] -> AdjacencyIntMap -> Forest Int
+dfsForestFrom vs = Typed.dfsForestFrom vs . Typed.fromAdjacencyIntMap
 
--- | Compute the list of vertices visited by the /depth-first search/ in a
--- graph, when searching from each of the given vertices in order.
+-- | Compute the list of vertices visited by the /depth-first search/ in a graph,
+-- when searching from each of the given vertices in order.
 --
 -- @
 -- dfs vs    $ 'empty'                    == []
@@ -124,7 +94,7 @@ dfsForestFrom vs = Typed.dfsForestFrom vs . Typed.fromAdjacencyMap
 -- dfs [1,4] $ 3 * (1 + 4) * (1 + 5)    == [1,5,4]
 -- 'isSubgraphOf' ('vertices' $ dfs vs x) x == True
 -- @
-dfs :: Ord a => [a] -> AdjacencyMap a -> [a]
+dfs :: [Int] -> AdjacencyIntMap -> [Int]
 dfs vs = concatMap flatten . dfsForestFrom vs
 
 -- | Compute the list of vertices that are /reachable/ from a given source
@@ -142,7 +112,7 @@ dfs vs = concatMap flatten . dfsForestFrom vs
 -- reachable 8 $ 'clique'  [8,7..1]            == [8] ++ [1..7]
 -- 'isSubgraphOf' ('vertices' $ reachable x y) y == True
 -- @
-reachable :: Ord a => a -> AdjacencyMap a -> [a]
+reachable :: Int -> AdjacencyIntMap -> [Int]
 reachable x = dfs [x]
 
 -- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph
@@ -154,10 +124,10 @@ reachable x = dfs [x]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isJust' . topSort                      == 'isAcyclic'
 -- @
-topSort :: Ord a => AdjacencyMap a -> Maybe [a]
+topSort :: AdjacencyIntMap -> Maybe [Int]
 topSort m = if isTopSortOf result m then Just result else Nothing
   where
-    result = Typed.topSort (Typed.fromAdjacencyMap m)
+    result = Typed.topSort (Typed.fromAdjacencyIntMap m)
 
 -- | Check if a given graph is /acyclic/.
 --
@@ -167,7 +137,7 @@ topSort m = if isTopSortOf result m then Just result else Nothing
 -- isAcyclic . 'circuit'       == 'null'
 -- isAcyclic                 == 'isJust' . 'topSort'
 -- @
-isAcyclic :: Ord a => AdjacencyMap a -> Bool
+isAcyclic :: AdjacencyIntMap -> Bool
 isAcyclic = isJust . topSort
 
 -- | Check if a given forest is a correct /depth-first search/ forest of a graph.
@@ -194,18 +164,18 @@ isAcyclic = isJust . topSort
 -- isDfsForestOf [Node 2 [Node 3 []], Node 1 []] ('path' [1,2,3])   == True
 -- isDfsForestOf [Node 1 [], Node 2 [Node 3 []]] ('path' [1,2,3])   == False
 -- @
-isDfsForestOf :: Ord a => Forest a -> AdjacencyMap a -> Bool
-isDfsForestOf f am = case go Set.empty f of
-    Just seen -> seen == vertexSet am
+isDfsForestOf :: Forest Int -> AdjacencyIntMap -> Bool
+isDfsForestOf f am = case go IntSet.empty f of
+    Just seen -> seen == vertexIntSet am
     Nothing   -> False
   where
     go seen []     = Just seen
     go seen (t:ts) = do
         let root = rootLabel t
-        guard $ root `Set.notMember` seen
+        guard $ root `IntSet.notMember` seen
         guard $ and [ hasEdge root (rootLabel subTree) am | subTree <- subForest t ]
-        newSeen <- go (Set.insert root seen) (subForest t)
-        guard $ postSet root am `Set.isSubsetOf` newSeen
+        newSeen <- go (IntSet.insert root seen) (subForest t)
+        guard $ postIntSet root am `IntSet.isSubsetOf` newSeen
         go newSeen ts
 
 -- | Check if a given list of vertices is a correct /topological sort/ of a graph.
@@ -218,11 +188,11 @@ isDfsForestOf f am = case go Set.empty f of
 -- isTopSortOf [x]     ('vertex' x)      == True
 -- isTopSortOf [x]     ('edge' x x)      == False
 -- @
-isTopSortOf :: Ord a => [a] -> AdjacencyMap a -> Bool
-isTopSortOf xs m = go Set.empty xs
+isTopSortOf :: [Int] -> AdjacencyIntMap -> Bool
+isTopSortOf xs m = go IntSet.empty xs
   where
-    go seen []     = seen == Map.keysSet (adjacencyMap m)
-    go seen (v:vs) = postSet v m `Set.intersection` newSeen == Set.empty
+    go seen []     = seen == IntMap.keysSet (adjacencyIntMap m)
+    go seen (v:vs) = postIntSet v m `IntSet.intersection` newSeen == IntSet.empty
                   && go newSeen vs
       where
-        newSeen = Set.insert v seen
+        newSeen = IntSet.insert v seen

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -38,7 +38,7 @@ module Algebra.Graph.AdjacencyMap (
     induce,
 
     -- * Algorithms
-    dfsForest, dfsForestFrom, dfs, reachable, topSort, isAcyclic, scc,
+    dfsForest, dfsForestFrom, dfs, reachable, topSort, isAcyclic,
 
     -- * Correctness properties
     isDfsForestOf, isTopSortOf
@@ -633,26 +633,6 @@ topSort m = if isTopSortOf result m then Just result else Nothing
 -- @
 isAcyclic :: Ord a => AdjacencyMap a -> Bool
 isAcyclic = isJust . topSort
-
--- | Compute the /condensation/ of a graph, where each vertex corresponds to a
--- /strongly-connected component/ of the original graph.
---
--- @
--- scc 'empty'               == 'empty'
--- scc ('vertex' x)          == 'vertex' (Set.'Set.singleton' x)
--- scc ('edge' x y)          == 'edge' (Set.'Set.singleton' x) (Set.'Set.singleton' y)
--- scc ('circuit' (1:xs))    == 'edge' (Set.'Set.fromList' (1:xs)) (Set.'Set.fromList' (1:xs))
--- scc (3 * 1 * 4 * 1 * 5) == 'edges' [ (Set.'Set.fromList' [1,4], Set.'Set.fromList' [1,4])
---                                  , (Set.'Set.fromList' [1,4], Set.'Set.fromList' [5]  )
---                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [1,4])
---                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [5]  )]
--- @
-scc :: Ord a => AdjacencyMap a -> AdjacencyMap (Set a)
-scc m = gmap (\v -> Map.findWithDefault Set.empty v components) m
-  where
-    (Typed.GraphKL g r _) = Typed.fromAdjacencyMap m
-    components = Map.fromList $ concatMap (expand . fmap r . toList) (KL.scc g)
-    expand xs  = let s = Set.fromList xs in map (\x -> (x, s)) xs
 
 -- | Check if a given forest is a correct /depth-first search/ forest of a graph.
 -- The implementation is based on the paper "Depth-First Search and Strong

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -45,7 +45,7 @@ module Algebra.Graph.AdjacencyMap (
   ) where
 
 import Control.Monad
-import Data.Foldable (foldMap, toList)
+import Data.Foldable (foldMap)
 import Data.Maybe
 import Data.Monoid
 import Data.Set (Set)
@@ -54,7 +54,6 @@ import Data.Tree
 import Algebra.Graph.AdjacencyMap.Internal
 
 import qualified Data.Graph.Typed as Typed
-import qualified Data.Graph       as KL
 import qualified Data.Map.Strict  as Map
 import qualified Data.Set         as Set
 

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -1,0 +1,51 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module     : Algebra.Graph.AdjacencyMap.Algorithm
+-- Copyright  : (c) Andrey Mokhov 2016-2018
+-- License    : MIT (see the file LICENSE)
+-- Maintainer : andrey.mokhov@gmail.com
+-- Stability  : unstable
+--
+-----------------------------------------------------------------------------
+module Algebra.Graph.AdjacencyMap.Algorithm (
+    -- * Algorithms
+    scc
+  ) where
+
+import Data.Foldable (toList)
+import Data.Maybe
+
+import Algebra.Graph.AdjacencyMap
+import Algebra.Graph.AdjacencyMap.Internal
+
+import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NonEmpty
+import qualified Data.Graph                          as KL
+import qualified Data.Graph.Typed                    as Typed
+import qualified Data.Map.Strict                     as Map
+import qualified Data.Set                            as Set
+
+-- TODO: Update docs.
+-- | Compute the /condensation/ of a graph, where each vertex corresponds to a
+-- /strongly-connected component/ of the original graph.
+--
+-- @
+-- scc 'empty'               == 'empty'
+-- scc ('vertex' x)          == 'vertex' (Set.'Set.singleton' x)
+-- scc ('edge' x y)          == 'edge' (Set.'Set.singleton' x) (Set.'Set.singleton' y)
+-- scc ('circuit' (1:xs))    == 'edge' (Set.'Set.fromList' (1:xs)) (Set.'Set.fromList' (1:xs))
+-- scc (3 * 1 * 4 * 1 * 5) == 'edges' [ (Set.'Set.fromList' [1,4], Set.'Set.fromList' [1,4])
+--                                  , (Set.'Set.fromList' [1,4], Set.'Set.fromList' [5]  )
+--                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [1,4])
+--                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [5]  )]
+-- @
+scc :: Ord a => AdjacencyMap a -> AdjacencyMap (NonEmpty.AdjacencyMap a)
+scc m = fromAdjacencySets
+    [ (v', Set.delete v' $ Set.map (components Map.!) us)
+    | (v, us) <- Map.toList (adjacencyMap m), let v' = components Map.! v ]
+  where
+    Typed.GraphKL g r _ = Typed.fromAdjacencyMap m
+    components = Map.fromList $ concatMap (expand . fmap r . toList) (KL.scc g)
+    expand xs  = map (\x -> (x, c)) xs
+      where
+        s = Set.fromList xs
+        c = fromJust . NonEmpty.toNonEmpty $ induce (`Set.member` s) m

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -30,13 +30,13 @@ import qualified Data.Set                            as Set
 --
 -- @
 -- scc 'empty'               == 'empty'
--- scc ('vertex' x)          == 'vertex' (Set.'Set.singleton' x)
--- scc ('edge' x y)          == 'edge' (Set.'Set.singleton' x) (Set.'Set.singleton' y)
--- scc ('circuit' (1:xs))    == 'edge' (Set.'Set.fromList' (1:xs)) (Set.'Set.fromList' (1:xs))
--- scc (3 * 1 * 4 * 1 * 5) == 'edges' [ (Set.'Set.fromList' [1,4], Set.'Set.fromList' [1,4])
---                                  , (Set.'Set.fromList' [1,4], Set.'Set.fromList' [5]  )
---                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [1,4])
---                                  , (Set.'Set.fromList' [3]  , Set.'Set.fromList' [5]  )]
+-- scc ('vertex' x)          == 'vertex' (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex' x)
+-- scc ('edge' 1 1)          == 'vertex' (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.edge' 1 1)
+-- scc ('edge' 1 2)          == 'edge'   (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex' 1) (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex' 2)
+-- scc ('circuit' (1:xs))    == 'vertex' (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.circuit1' (1 'Data.List.NonEmpty.:|' xs))
+-- scc (3 * 1 * 4 * 1 * 5) == 'edges'  [ (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex'  3      , NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex'  5      )
+--                                   , (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex'  3      , NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.clique1' [1,4,1])
+--                                   , (NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.clique1' [1,4,1], NonEmpty.'Algebra.Graph.NonEmpty.AdjacencyMap.vertex'  5      ) ]
 -- @
 scc :: Ord a => AdjacencyMap a -> AdjacencyMap (NonEmpty.AdjacencyMap a)
 scc m = fromAdjacencySets

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -159,6 +159,8 @@ isAcyclic = isJust . topSort
 -- scc (3 * 1 * 4 * 1 * 5) == 'edges'  [ (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.vertex'  5      )
 --                                   , (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.clique1' [1,4,1])
 --                                   , (NonEmpty.'NonEmpty.clique1' [1,4,1], NonEmpty.'NonEmpty.vertex'  5      ) ]
+-- 'isAcyclic' . scc == 'const' True
+-- 'isAcyclic' x     == (scc x == 'gmap' NonEmpty.'NonEmpty.vertex' x)
 -- @
 scc :: Ord a => AdjacencyMap a -> AdjacencyMap (NonEmpty.AdjacencyMap a)
 scc m = gmap (component Map.!) $ removeSelfLoops $ gmap (leader Map.!) m

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -28,38 +28,12 @@ import Data.Tree
 
 import Algebra.Graph.AdjacencyMap
 
+import qualified Algebra.Graph.AdjacencyMap.Internal as AM
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NonEmpty
 import qualified Data.Graph                          as KL
 import qualified Data.Graph.Typed                    as Typed
 import qualified Data.Map.Strict                     as Map
 import qualified Data.Set                            as Set
-
--- | Compute the /condensation/ of a graph, where each vertex corresponds to a
--- /strongly-connected component/ of the original graph. Note that component
--- graphs are non-empty, and are therefore of type
--- "Algebra.Graph.NonEmpty.AdjacencyMap".
---
--- @
--- scc 'empty'               == 'empty'
--- scc ('vertex' x)          == 'vertex' (NonEmpty.'NonEmpty.vertex' x)
--- scc ('edge' 1 1)          == 'vertex' (NonEmpty.'NonEmpty.edge' 1 1)
--- scc ('edge' 1 2)          == 'edge'   (NonEmpty.'NonEmpty.vertex' 1) (NonEmpty.'NonEmpty.vertex' 2)
--- scc ('circuit' (1:xs))    == 'vertex' (NonEmpty.'NonEmpty.circuit1' (1 'Data.List.NonEmpty.:|' xs))
--- scc (3 * 1 * 4 * 1 * 5) == 'edges'  [ (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.vertex'  5      )
---                                   , (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.clique1' [1,4,1])
---                                   , (NonEmpty.'NonEmpty.clique1' [1,4,1], NonEmpty.'NonEmpty.vertex'  5      ) ]
--- @
-scc :: Ord a => AdjacencyMap a -> AdjacencyMap (NonEmpty.AdjacencyMap a)
-scc m = fromAdjacencySets
-    [ (v', Set.delete v' $ Set.map (components Map.!) us)
-    | (v, us) <- Map.toList (adjacencyMap m), let v' = components Map.! v ]
-  where
-    Typed.GraphKL g r _ = Typed.fromAdjacencyMap m
-    components = Map.fromList $ concatMap (expand . fmap r . toList) (KL.scc g)
-    expand xs  = map (\x -> (x, c)) xs
-      where
-        s = Set.fromList xs
-        c = fromJust . NonEmpty.toNonEmpty $ induce (`Set.member` s) m
 
 -- | Compute the /depth-first search/ forest of a graph that corresponds to
 -- searching from each of the graph vertices in the 'Ord' @a@ order.
@@ -169,6 +143,37 @@ topSort m = if isTopSortOf result m then Just result else Nothing
 -- @
 isAcyclic :: Ord a => AdjacencyMap a -> Bool
 isAcyclic = isJust . topSort
+
+-- TODO: Benchmark and optimise.
+-- | Compute the /condensation/ of a graph, where each vertex corresponds to a
+-- /strongly-connected component/ of the original graph. Note that component
+-- graphs are non-empty, and are therefore of type
+-- "Algebra.Graph.NonEmpty.AdjacencyMap".
+--
+-- @
+-- scc 'empty'               == 'empty'
+-- scc ('vertex' x)          == 'vertex' (NonEmpty.'NonEmpty.vertex' x)
+-- scc ('edge' 1 1)          == 'vertex' (NonEmpty.'NonEmpty.edge' 1 1)
+-- scc ('edge' 1 2)          == 'edge'   (NonEmpty.'NonEmpty.vertex' 1) (NonEmpty.'NonEmpty.vertex' 2)
+-- scc ('circuit' (1:xs))    == 'vertex' (NonEmpty.'NonEmpty.circuit1' (1 'Data.List.NonEmpty.:|' xs))
+-- scc (3 * 1 * 4 * 1 * 5) == 'edges'  [ (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.vertex'  5      )
+--                                   , (NonEmpty.'NonEmpty.vertex'  3      , NonEmpty.'NonEmpty.clique1' [1,4,1])
+--                                   , (NonEmpty.'NonEmpty.clique1' [1,4,1], NonEmpty.'NonEmpty.vertex'  5      ) ]
+-- @
+scc :: Ord a => AdjacencyMap a -> AdjacencyMap (NonEmpty.AdjacencyMap a)
+scc m = gmap (component Map.!) $ removeSelfLoops $ gmap (leader Map.!) m
+  where
+    Typed.GraphKL g decode _ = Typed.fromAdjacencyMap m
+    sccs      = map toList (KL.scc g)
+    leader    = Map.fromList [ (decode y, x)      | x:xs <- sccs, y <- x:xs ]
+    component = Map.fromList [ (x, expand (x:xs)) | x:xs <- sccs ]
+    expand xs = fromJust $ NonEmpty.toNonEmpty $ induce (`Set.member` s) m
+      where
+        s = Set.fromList (map decode xs)
+
+-- Remove all self loops from a graph.
+removeSelfLoops :: Ord a => AdjacencyMap a -> AdjacencyMap a
+removeSelfLoops (AM.AM m) = AM.AM (Map.mapWithKey Set.delete m)
 
 -- | Check if a given forest is a correct /depth-first search/ forest of a graph.
 -- The implementation is based on the paper "Depth-First Search and Strong

--- a/src/Algebra/Graph/AdjacencyMap/Internal.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Internal.hs
@@ -12,8 +12,7 @@
 -----------------------------------------------------------------------------
 module Algebra.Graph.AdjacencyMap.Internal (
     -- * Adjacency map implementation
-    AdjacencyMap (..), empty, vertex, overlay, connect, fromAdjacencySets,
-    consistent, internalEdgeList, referredToVertexSet
+    AdjacencyMap (..), consistent, internalEdgeList, referredToVertexSet
   ) where
 
 import Prelude ()
@@ -106,19 +105,20 @@ The total order on graphs is defined using /size-lexicographic/ comparison:
 
 Here are a few examples:
 
-@'vertex' 1 < 'vertex' 2
-'vertex' 3 < 'Algebra.Graph.AdjacencyMap.edge' 1 2
-'vertex' 1 < 'Algebra.Graph.AdjacencyMap.edge' 1 1
+@'Algebra.Graph.AdjacencyMap.vertex' 1 < 'Algebra.Graph.AdjacencyMap.vertex' 2
+'Algebra.Graph.AdjacencyMap.vertex' 3 < 'Algebra.Graph.AdjacencyMap.edge' 1 2
+'Algebra.Graph.AdjacencyMap.vertex' 1 < 'Algebra.Graph.AdjacencyMap.edge' 1 1
 'Algebra.Graph.AdjacencyMap.edge' 1 1 < 'Algebra.Graph.AdjacencyMap.edge' 1 2
 'Algebra.Graph.AdjacencyMap.edge' 1 2 < 'Algebra.Graph.AdjacencyMap.edge' 1 1 + 'Algebra.Graph.AdjacencyMap.edge' 2 2
 'Algebra.Graph.AdjacencyMap.edge' 1 2 < 'Algebra.Graph.AdjacencyMap.edge' 1 3@
 
-Note that the resulting order refines the 'isSubgraphOf' relation and is
-compatible with 'overlay' and 'connect' operations:
+Note that the resulting order refines the 'Algebra.Graph.AdjacencyMap.isSubgraphOf'
+relation and is compatible with 'Algebra.Graph.AdjacencyMap.overlay' and
+'Algebra.Graph.AdjacencyMap.connect' operations:
 
 @'Algebra.Graph.AdjacencyMap.isSubgraphOf' x y ==> x <= y@
 
-@'empty' <= x
+@'Algebra.Graph.AdjacencyMap.empty' <= x
 x     <= x + y
 x + y <= x * y@
 -}
@@ -127,8 +127,8 @@ newtype AdjacencyMap a = AM {
     -- its direct successors. Complexity: /O(1)/ time and memory.
     --
     -- @
-    -- adjacencyMap 'empty'      == Map.'Map.empty'
-    -- adjacencyMap ('vertex' x) == Map.'Map.singleton' x Set.'Set.empty'
+    -- adjacencyMap 'Algebra.Graph.AdjacencyMap.empty'      == Map.'Map.empty'
+    -- adjacencyMap ('Algebra.Graph.AdjacencyMap.vertex' x) == Map.'Map.singleton' x Set.'Set.empty'
     -- adjacencyMap ('Algebra.Graph.AdjacencyMap.edge' 1 1) == Map.'Map.singleton' 1 (Set.'Set.singleton' 1)
     -- adjacencyMap ('Algebra.Graph.AdjacencyMap.edge' 1 2) == Map.'Map.fromList' [(1,Set.'Set.singleton' 2), (2,Set.'Set.empty')]
     -- @
@@ -160,101 +160,19 @@ instance (Ord a, Show a) => Show (AdjacencyMap a) where
         eshow xs       = "edges "    ++ show xs
         used           = Set.toAscList (referredToVertexSet m)
 
--- | Construct the /empty graph/.
--- Complexity: /O(1)/ time and memory.
---
--- @
--- 'Algebra.Graph.AdjacencyMap.isEmpty'     empty == True
--- 'Algebra.Graph.AdjacencyMap.hasVertex' x empty == False
--- 'Algebra.Graph.AdjacencyMap.vertexCount' empty == 0
--- 'Algebra.Graph.AdjacencyMap.edgeCount'   empty == 0
--- @
-empty :: AdjacencyMap a
-empty = AM Map.empty
-{-# NOINLINE [1] empty #-}
-
--- | Construct the graph comprising /a single isolated vertex/.
--- Complexity: /O(1)/ time and memory.
---
--- @
--- 'Algebra.Graph.AdjacencyMap.isEmpty'     (vertex x) == False
--- 'Algebra.Graph.AdjacencyMap.hasVertex' x (vertex x) == True
--- 'Algebra.Graph.AdjacencyMap.vertexCount' (vertex x) == 1
--- 'Algebra.Graph.AdjacencyMap.edgeCount'   (vertex x) == 0
--- @
-vertex :: a -> AdjacencyMap a
-vertex x = AM $ Map.singleton x Set.empty
-{-# NOINLINE [1] vertex #-}
-
--- | /Overlay/ two graphs. This is a commutative, associative and idempotent
--- operation with the identity 'empty'.
--- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
---
--- @
--- 'Algebra.Graph.AdjacencyMap.isEmpty'     (overlay x y) == 'Algebra.Graph.AdjacencyMap.isEmpty'   x   && 'Algebra.Graph.AdjacencyMap.isEmpty'   y
--- 'Algebra.Graph.AdjacencyMap.hasVertex' z (overlay x y) == 'Algebra.Graph.AdjacencyMap.hasVertex' z x || 'Algebra.Graph.AdjacencyMap.hasVertex' z y
--- 'Algebra.Graph.AdjacencyMap.vertexCount' (overlay x y) >= 'Algebra.Graph.AdjacencyMap.vertexCount' x
--- 'Algebra.Graph.AdjacencyMap.vertexCount' (overlay x y) <= 'Algebra.Graph.AdjacencyMap.vertexCount' x + 'Algebra.Graph.AdjacencyMap.vertexCount' y
--- 'Algebra.Graph.AdjacencyMap.edgeCount'   (overlay x y) >= 'Algebra.Graph.AdjacencyMap.edgeCount' x
--- 'Algebra.Graph.AdjacencyMap.edgeCount'   (overlay x y) <= 'Algebra.Graph.AdjacencyMap.edgeCount' x   + 'Algebra.Graph.AdjacencyMap.edgeCount' y
--- 'Algebra.Graph.AdjacencyMap.vertexCount' (overlay 1 2) == 2
--- 'Algebra.Graph.AdjacencyMap.edgeCount'   (overlay 1 2) == 0
--- @
-overlay :: Ord a => AdjacencyMap a -> AdjacencyMap a -> AdjacencyMap a
-overlay x y = AM $ Map.unionWith Set.union (adjacencyMap x) (adjacencyMap y)
-{-# NOINLINE [1] overlay #-}
-
--- | /Connect/ two graphs. This is an associative operation with the identity
--- 'empty', which distributes over 'overlay' and obeys the decomposition axiom.
--- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory. Note that the
--- number of edges in the resulting graph is quadratic with respect to the number
--- of vertices of the arguments: /m = O(m1 + m2 + n1 * n2)/.
---
--- @
--- 'isEmpty'     (connect x y) == 'isEmpty'   x   && 'Algebra.Graph.AdjacencyMap.isEmpty'   y
--- 'hasVertex' z (connect x y) == 'hasVertex' z x || 'Algebra.Graph.AdjacencyMap.hasVertex' z y
--- 'vertexCount' (connect x y) >= 'vertexCount' x
--- 'vertexCount' (connect x y) <= 'vertexCount' x + 'Algebra.Graph.AdjacencyMap.vertexCount' y
--- 'edgeCount'   (connect x y) >= 'edgeCount' x
--- 'edgeCount'   (connect x y) >= 'edgeCount' y
--- 'edgeCount'   (connect x y) >= 'vertexCount' x * 'Algebra.Graph.AdjacencyMap.vertexCount' y
--- 'edgeCount'   (connect x y) <= 'vertexCount' x * 'Algebra.Graph.AdjacencyMap.vertexCount' y + 'Algebra.Graph.AdjacencyMap.edgeCount' x + 'Algebra.Graph.AdjacencyMap.edgeCount' y
--- 'vertexCount' (connect 1 2) == 2
--- 'edgeCount'   (connect 1 2) == 1
--- @
-connect :: Ord a => AdjacencyMap a -> AdjacencyMap a -> AdjacencyMap a
-connect x y = AM $ Map.unionsWith Set.union [ adjacencyMap x, adjacencyMap y,
-    fromSet (const . keysSet $ adjacencyMap y) (keysSet $ adjacencyMap x) ]
-{-# NOINLINE [1] connect #-}
-
 -- | __Note:__ this does not satisfy the usual ring laws; see 'AdjacencyMap'
 -- for more details.
 instance (Ord a, Num a) => Num (AdjacencyMap a) where
-    fromInteger = vertex . fromInteger
-    (+)         = overlay
-    (*)         = connect
-    signum      = const empty
-    abs         = id
-    negate      = id
+    fromInteger x = AM $ Map.singleton (fromInteger x) Set.empty
+    x + y  = AM $ Map.unionWith Set.union (adjacencyMap x) (adjacencyMap y)
+    x * y  = AM $ Map.unionsWith Set.union [ adjacencyMap x, adjacencyMap y,
+        fromSet (const . keysSet $ adjacencyMap y) (keysSet $ adjacencyMap x) ]
+    signum = const (AM Map.empty)
+    abs    = id
+    negate = id
 
 instance NFData a => NFData (AdjacencyMap a) where
     rnf (AM a) = rnf a
-
--- | Construct a graph from a list of adjacency sets.
--- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
---
--- @
--- fromAdjacencySets []                                        == 'Algebra.Graph.AdjacencyMap.empty'
--- fromAdjacencySets [(x, Set.'Set.empty')]                          == 'Algebra.Graph.AdjacencyMap.vertex' x
--- fromAdjacencySets [(x, Set.'Set.singleton' y)]                    == 'Algebra.Graph.AdjacencyMap.edge' x y
--- fromAdjacencySets . map (fmap Set.'Set.fromList') . 'Algebra.Graph.AdjacencyMap.adjacencyList' == id
--- 'Algebra.Graph.AdjacencyMap.overlay' (fromAdjacencySets xs) (fromAdjacencySets ys)       == fromAdjacencySets (xs ++ ys)
--- @
-fromAdjacencySets :: Ord a => [(a, Set a)] -> AdjacencyMap a
-fromAdjacencySets ss = AM $ Map.unionWith Set.union vs es
-  where
-    vs = Map.fromSet (const Set.empty) . Set.unions $ map snd ss
-    es = Map.fromListWith Set.union ss
 
 -- | Check if the internal graph representation is consistent, i.e. that all
 -- edges refer to existing vertices. It should be impossible to create an

--- a/src/Algebra/Graph/NonEmpty/AdjacencyMap.hs
+++ b/src/Algebra/Graph/NonEmpty/AdjacencyMap.hs
@@ -82,6 +82,56 @@ toNonEmpty :: AM.AdjacencyMap a -> Maybe (AdjacencyMap a)
 toNonEmpty x | AM.isEmpty x = Nothing
              | otherwise    = Just (NAM x)
 
+-- | Construct the graph comprising /a single isolated vertex/.
+-- Complexity: /O(1)/ time and memory.
+--
+-- @
+-- 'AdjacencyMap.hasVertex' x (vertex x) == True
+-- 'AdjacencyMap.vertexCount' (vertex x) == 1
+-- 'AdjacencyMap.edgeCount'   (vertex x) == 0
+-- @
+vertex :: a -> AdjacencyMap a
+vertex = NAM . AM.vertex
+{-# NOINLINE [1] vertex #-}
+
+-- | /Overlay/ two graphs. This is a commutative, associative and idempotent
+-- operation with the identity 'empty'.
+-- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
+--
+-- @
+-- 'hasVertex' z (overlay x y) == 'hasVertex' z x || 'hasVertex' z y
+-- 'vertexCount' (overlay x y) >= 'vertexCount' x
+-- 'vertexCount' (overlay x y) <= 'vertexCount' x + 'vertexCount' y
+-- 'edgeCount'   (overlay x y) >= 'edgeCount' x
+-- 'edgeCount'   (overlay x y) <= 'edgeCount' x   + 'edgeCount' y
+-- 'vertexCount' (overlay 1 2) == 2
+-- 'edgeCount'   (overlay 1 2) == 0
+-- @
+overlay :: Ord a => AdjacencyMap a -> AdjacencyMap a -> AdjacencyMap a
+overlay (NAM x) (NAM y) = NAM (AM.overlay x y)
+{-# NOINLINE [1] overlay #-}
+
+-- | /Connect/ two graphs. This is an associative operation with the identity
+-- 'empty', which distributes over 'overlay' and obeys the decomposition axiom.
+-- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory. Note that the
+-- number of edges in the resulting graph is quadratic with respect to the number
+-- of vertices of the arguments: /m = O(m1 + m2 + n1 * n2)/.
+--
+-- @
+-- 'hasVertex' z (connect x y) == 'hasVertex' z x || 'hasVertex' z y
+-- 'vertexCount' (connect x y) >= 'vertexCount' x
+-- 'vertexCount' (connect x y) <= 'vertexCount' x + 'vertexCount' y
+-- 'edgeCount'   (connect x y) >= 'edgeCount' x
+-- 'edgeCount'   (connect x y) >= 'edgeCount' y
+-- 'edgeCount'   (connect x y) >= 'vertexCount' x * 'vertexCount' y
+-- 'edgeCount'   (connect x y) <= 'vertexCount' x * 'vertexCount' y + 'edgeCount' x + 'edgeCount' y
+-- 'vertexCount' (connect 1 2) == 2
+-- 'edgeCount'   (connect 1 2) == 1
+-- @
+connect :: Ord a => AdjacencyMap a -> AdjacencyMap a -> AdjacencyMap a
+connect (NAM x) (NAM y) = NAM (AM.connect x y)
+{-# NOINLINE [1] connect #-}
+
 -- | Construct the graph comprising /a single edge/.
 -- Complexity: /O(1)/ time, memory.
 --

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -53,10 +53,12 @@ import Data.Tree
 
 import qualified Algebra.Graph                                as G
 import qualified Algebra.Graph.AdjacencyMap                   as AM
+import qualified Algebra.Graph.AdjacencyMap.Algorithm         as AM
 import qualified Algebra.Graph.AdjacencyMap.Internal          as AM
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap          as NAM
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap.Internal as NAM
 import qualified Algebra.Graph.AdjacencyIntMap                as AIM
+import qualified Algebra.Graph.AdjacencyIntMap.Algorithm      as AIM
 import qualified Algebra.Graph.AdjacencyIntMap.Internal       as AIM
 import qualified Algebra.Graph.Relation                       as R
 import qualified Data.IntMap                                  as IntMap

--- a/src/Data/Graph/Typed.hs
+++ b/src/Data/Graph/Typed.hs
@@ -96,7 +96,7 @@ fromAdjacencyIntMap (AIM.AM m) = GraphKL
 -- 'Algebra.Graph.AdjacencyMap.forest' (dfsForest % 'Algebra.Graph.AdjacencyMap.edge' 2 1)           == 'AM.vertices' [1, 2]
 -- 'AM.isSubgraphOf' ('Algebra.Graph.AdjacencyMap.forest' $ dfsForest % x) x == True
 -- dfsForest % 'Algebra.Graph.AdjacencyMap.forest' (dfsForest % x)      == dfsForest % x
--- dfsForest % 'AM.vertices' vs                 == map (\\v -> Node v []) ('Data.List.nub' $ 'Data.List.sort' vs)
+-- dfsForest % 'AM.vertices' vs                 == 'map' (\\v -> Node v []) ('Data.List.nub' $ 'Data.List.sort' vs)
 -- 'Algebra.Graph.AdjacencyMap.dfsForestFrom' ('Algebra.Graph.AdjacencyMap.vertexList' x) % x        == dfsForest % x
 -- dfsForest % (3 * (1 + 4) * (1 + 5))     == [ Node { rootLabel = 1
 --                                                   , subForest = [ Node { rootLabel = 5
@@ -120,7 +120,7 @@ dfsForest (GraphKL g r _) = fmap (fmap r) (KL.dff g)
 -- 'Algebra.Graph.AdjacencyMap.forest' (dfsForestFrom [2, 1] % 'Algebra.Graph.AdjacencyMap.edge' 1 2)       == 'Algebra.Graph.AdjacencyMap.vertices' [1, 2]
 -- 'Algebra.Graph.AdjacencyMap.isSubgraphOf' ('Algebra.Graph.AdjacencyMap.forest' $ dfsForestFrom vs % x) x == True
 -- dfsForestFrom ('Algebra.Graph.AdjacencyMap.vertexList' x) % x               == 'dfsForest' % x
--- dfsForestFrom vs               % 'Algebra.Graph.AdjacencyMap.vertices' vs   == map (\\v -> Node v []) ('Data.List.nub' vs)
+-- dfsForestFrom vs               % 'Algebra.Graph.AdjacencyMap.vertices' vs   == 'map' (\\v -> Node v []) ('Data.List.nub' vs)
 -- dfsForestFrom []               % x             == []
 -- dfsForestFrom [1, 4] % (3 * (1 + 4) * (1 + 5)) == [ Node { rootLabel = 1
 --                                                          , subForest = [ Node { rootLabel = 5

--- a/test/Algebra/Graph/Test/API.hs
+++ b/test/Algebra/Graph/Test/API.hs
@@ -18,16 +18,14 @@ import Data.Tree
 
 import Algebra.Graph.Class (Graph (..))
 
-import qualified Algebra.Graph                          as Graph
-import qualified Algebra.Graph.AdjacencyMap             as AM
-import qualified Algebra.Graph.AdjacencyMap.Internal    as AM
-import qualified Algebra.Graph.Fold                     as Fold
-import qualified Algebra.Graph.HigherKinded.Class       as HClass
-import qualified Algebra.Graph.AdjacencyIntMap          as AIM
-import qualified Algebra.Graph.AdjacencyIntMap.Internal as AIM
-import qualified Algebra.Graph.Relation                 as R
-import qualified Data.Set                               as Set
-import qualified Data.IntSet                            as IntSet
+import qualified Algebra.Graph                    as Graph
+import qualified Algebra.Graph.AdjacencyMap       as AM
+import qualified Algebra.Graph.Fold               as Fold
+import qualified Algebra.Graph.HigherKinded.Class as HClass
+import qualified Algebra.Graph.AdjacencyIntMap    as AIM
+import qualified Algebra.Graph.Relation           as R
+import qualified Data.Set                         as Set
+import qualified Data.IntSet                      as IntSet
 
 class Graph g => GraphAPI g where
     edge                 :: Vertex g -> Vertex g -> g

--- a/test/Algebra/Graph/Test/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/AdjacencyMap.hs
@@ -73,3 +73,9 @@ testAdjacencyMap = do
           scc (3 * 1 * 4 * 1 * 5) == edges [ (NonEmpty.vertex 3       , NonEmpty.vertex  5      )
                                            , (NonEmpty.vertex 3       , NonEmpty.clique1 [1,4,1])
                                            , (NonEmpty.clique1 [1,4,1], NonEmpty.vertex  (5 :: Int)) ]
+
+    test "isAcyclic . scc == const True" $ \(x :: AI) ->
+          (isAcyclic . scc) x == (const True) x
+
+    test "isAcyclic x     == (scc x == gmap NonEmpty.vertex x)" $ \(x :: AI) ->
+          isAcyclic x     == (scc x == gmap NonEmpty.vertex x)

--- a/test/Algebra/Graph/Test/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/AdjacencyMap.hs
@@ -63,11 +63,11 @@ testAdjacencyMap = do
     test "scc (edge 1 1)          == vertex (NonEmpty.edge 1 1)" $
           scc (edge 1 1 :: AI)    == vertex (NonEmpty.edge 1 1)
 
-    test "scc (edge 1 2)          == edge (NonEmpty.vertex 1) (NonEmpty.vertex 2)" $
-          scc (edge 1 2 :: AI)    == edge (NonEmpty.vertex 1) (NonEmpty.vertex 2)
+    test "scc (edge 1 2)          == edge   (NonEmpty.vertex 1) (NonEmpty.vertex 2)" $
+          scc (edge 1 2 :: AI)    == edge   (NonEmpty.vertex 1) (NonEmpty.vertex 2)
 
-    test "scc (circuit (1:xs))    == vertex (NonEmpty.circuit1 (1:|xs))" $ \(xs :: [Int]) ->
-          scc (circuit (1:xs))    == vertex (NonEmpty.circuit1 (1:|xs))
+    test "scc (circuit (1:xs))    == vertex (NonEmpty.circuit1 (1 :| xs))" $ \(xs :: [Int]) ->
+          scc (circuit (1:xs))    == vertex (NonEmpty.circuit1 (1 :| xs))
 
     test "scc (3 * 1 * 4 * 1 * 5) == <correct result>" $
           scc (3 * 1 * 4 * 1 * 5) == edges [ (NonEmpty.vertex 3       , NonEmpty.vertex  5      )

--- a/test/Algebra/Graph/Test/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/AdjacencyMap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Test.AdjacencyMap
@@ -13,12 +14,15 @@ module Algebra.Graph.Test.AdjacencyMap (
     testAdjacencyMap
   ) where
 
+import Data.List.NonEmpty
+
 import Algebra.Graph.AdjacencyMap
+import Algebra.Graph.AdjacencyMap.Algorithm
 import Algebra.Graph.AdjacencyMap.Internal
 import Algebra.Graph.Test
 import Algebra.Graph.Test.Generic
 
-import qualified Data.Set as Set
+import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NonEmpty
 
 t :: Testsuite
 t = testsuite "AdjacencyMap." empty
@@ -51,19 +55,21 @@ testAdjacencyMap = do
 
     putStrLn "\n============ AdjacencyMap.scc ============"
     test "scc empty               == empty" $
-          scc(empty :: AI)        == empty
+          scc (empty :: AI)       == empty
 
-    test "scc (vertex x)          == vertex (Set.singleton x)" $ \(x :: Int) ->
-          scc (vertex x)          == vertex (Set.singleton x)
+    test "scc (vertex x)          == vertex (NonEmpty.vertex x)" $ \(x :: Int) ->
+          scc (vertex x)          == vertex (NonEmpty.vertex x)
 
-    test "scc (edge x y)          == edge (Set.singleton x) (Set.singleton y)" $ \(x :: Int) y ->
-          scc (edge x y)          == edge (Set.singleton x) (Set.singleton y)
+    test "scc (edge 1 1)          == vertex (NonEmpty.edge 1 1)" $
+          scc (edge 1 1 :: AI)    == vertex (NonEmpty.edge 1 1)
 
-    test "scc (circuit (1:xs))    == edge (Set.fromList (1:xs)) (Set.fromList (1:xs))" $ \(xs :: [Int]) ->
-          scc (circuit (1:xs))    == edge (Set.fromList (1:xs)) (Set.fromList (1:xs))
+    test "scc (edge 1 2)          == edge (NonEmpty.vertex 1) (NonEmpty.vertex 2)" $
+          scc (edge 1 2 :: AI)    == edge (NonEmpty.vertex 1) (NonEmpty.vertex 2)
+
+    test "scc (circuit (1:xs))    == vertex (NonEmpty.circuit1 (1:|xs))" $ \(xs :: [Int]) ->
+          scc (circuit (1:xs))    == vertex (NonEmpty.circuit1 (1:|xs))
 
     test "scc (3 * 1 * 4 * 1 * 5) == <correct result>" $
-          scc (3 * 1 * 4 * 1 * 5) == edges [ (Set.fromList [1,4], Set.fromList [1,4])
-                                           , (Set.fromList [1,4], Set.fromList [5]  )
-                                           , (Set.fromList [3]  , Set.fromList [1,4])
-                                           , (Set.fromList [3]  , Set.fromList [5 :: Int])]
+          scc (3 * 1 * 4 * 1 * 5) == edges [ (NonEmpty.vertex 3       , NonEmpty.vertex  5      )
+                                           , (NonEmpty.vertex 3       , NonEmpty.clique1 [1,4,1])
+                                           , (NonEmpty.clique1 [1,4,1], NonEmpty.vertex  (5 :: Int)) ]

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -36,11 +36,12 @@ import Algebra.Graph.ToGraph (ToGraph (..))
 import Algebra.Graph.Test
 import Algebra.Graph.Test.API
 
-import qualified Algebra.Graph                 as G
-import qualified Algebra.Graph.AdjacencyMap    as AM
-import qualified Algebra.Graph.AdjacencyIntMap as AIM
-import qualified Data.Set                      as Set
-import qualified Data.IntSet                   as IntSet
+import qualified Algebra.Graph                        as G
+import qualified Algebra.Graph.AdjacencyMap           as AM
+import qualified Algebra.Graph.AdjacencyMap.Algorithm as AM
+import qualified Algebra.Graph.AdjacencyIntMap        as AIM
+import qualified Data.Set                             as Set
+import qualified Data.IntSet                          as IntSet
 
 data Testsuite where
     Testsuite :: (Arbitrary g, GraphAPI g, Num g, Ord g, Show g, ToGraph g, ToVertex g ~ Int, Vertex g ~ Int)
@@ -349,38 +350,38 @@ testStars (Testsuite prefix (%)) = do
 testFromAdjacencySets :: Testsuite -> IO ()
 testFromAdjacencySets (Testsuite prefix (%)) = do
     putStrLn $ "\n============ " ++ prefix ++ "fromAdjacencySets ============"
-    test "fromAdjacencySets []                                        == empty" $
-          fromAdjacencySets []                                        == id % empty
+    test "fromAdjacencySets []                                  == empty" $
+          fromAdjacencySets []                                  == id % empty
 
-    test "fromAdjacencySets [(x, Set.empty)]                          == vertex x" $ \x ->
-          fromAdjacencySets [(x, Set.empty)]                          == id % vertex x
+    test "fromAdjacencySets [(x, Set.empty)]                    == vertex x" $ \x ->
+          fromAdjacencySets [(x, Set.empty)]                    == id % vertex x
 
-    test "fromAdjacencySets [(x, Set.singleton y)]                    == edge x y" $ \x y ->
-          fromAdjacencySets [(x, Set.singleton y)]                    == id % edge x y
+    test "fromAdjacencySets [(x, Set.singleton y)]              == edge x y" $ \x y ->
+          fromAdjacencySets [(x, Set.singleton y)]              == id % edge x y
 
-    test "fromAdjacencySets . map (fmap Set.fromList) . adjacencyList == id" $ \x ->
-         (fromAdjacencySets . map (fmap Set.fromList) . adjacencyList) % x == x
+    test "fromAdjacencySets . map (fmap Set.fromList)           == stars" $ \x ->
+         (fromAdjacencySets . map (fmap Set.fromList)) x        == id % stars x
 
-    test "overlay (fromAdjacencySets xs) (fromAdjacencySets ys)       == fromAdjacencySets (xs ++ ys)" $ \xs ys ->
-          overlay (fromAdjacencySets xs) % fromAdjacencySets ys       == fromAdjacencySets (xs ++ ys)
+    test "overlay (fromAdjacencySets xs) (fromAdjacencySets ys) == fromAdjacencySets (xs ++ ys)" $ \xs ys ->
+          overlay (fromAdjacencySets xs) % fromAdjacencySets ys == fromAdjacencySets (xs ++ ys)
 
 testFromAdjacencyIntSets :: Testsuite -> IO ()
 testFromAdjacencyIntSets (Testsuite prefix (%)) = do
     putStrLn $ "\n============ " ++ prefix ++ "fromAdjacencyIntSets ============"
-    test "fromAdjacencyIntSets []                                           == empty" $
-          fromAdjacencyIntSets []                                           == id % empty
+    test "fromAdjacencyIntSets []                                     == empty" $
+          fromAdjacencyIntSets []                                     == id % empty
 
-    test "fromAdjacencyIntSets [(x, IntSet.empty)]                          == vertex x" $ \x ->
-          fromAdjacencyIntSets [(x, IntSet.empty)]                          == id % vertex x
+    test "fromAdjacencyIntSets [(x, IntSet.empty)]                    == vertex x" $ \x ->
+          fromAdjacencyIntSets [(x, IntSet.empty)]                    == id % vertex x
 
-    test "fromAdjacencyIntSets [(x, IntSet.singleton y)]                    == edge x y" $ \x y ->
-          fromAdjacencyIntSets [(x, IntSet.singleton y)]                    == id % edge x y
+    test "fromAdjacencyIntSets [(x, IntSet.singleton y)]              == edge x y" $ \x y ->
+          fromAdjacencyIntSets [(x, IntSet.singleton y)]              == id % edge x y
 
-    test "fromAdjacencyIntSets . map (fmap IntSet.fromList) . adjacencyList == id" $ \x ->
-         (fromAdjacencyIntSets . map (fmap IntSet.fromList) . adjacencyList) % x == x
+    test "fromAdjacencyIntSets . map (fmap IntSet.fromList)           == stars" $ \x ->
+         (fromAdjacencyIntSets . map (fmap IntSet.fromList)) x        == id % stars x
 
-    test "overlay (fromAdjacencyIntSets xs) (fromAdjacencyIntSets ys)       == fromAdjacencyIntSets (xs ++ ys)" $ \xs ys ->
-          overlay (fromAdjacencyIntSets xs) % fromAdjacencyIntSets ys       == fromAdjacencyIntSets (xs ++ ys)
+    test "overlay (fromAdjacencyIntSets xs) (fromAdjacencyIntSets ys) == fromAdjacencyIntSets (xs ++ ys)" $ \xs ys ->
+          overlay (fromAdjacencyIntSets xs) % fromAdjacencyIntSets ys == fromAdjacencyIntSets (xs ++ ys)
 
 testIsSubgraphOf :: Testsuite -> IO ()
 testIsSubgraphOf (Testsuite prefix (%)) = do


### PR DESCRIPTION
See #128.

The draft implementation seems to work correctly, but I need to add tests and documentation.

For example, given a graph `edges [(1,2), (2,3), (3,4), (4,3), (2,1)]`, the new `scc` finds a graph with two vertices `1*2 + 2*1` and `3*4 + 4*3` of type `NonEmptyGraph Int` and one edge between them.

Before merging this PR, I will need to address #126 (since we need an `Ord` instance for `NonEmptyGraph`s to store them inside an `AdjacencyMap`). 