### PR TITLE
Add rewrite tests

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -131,6 +131,8 @@ test-suite test-alga
                         Algebra.Graph.Test.NonEmptyGraph,
                         Algebra.Graph.Test.Relation,
                         Data.Graph.Test.Typed
+    if impl(ghc >= 8.0.2)
+        other-modules:  Algebra.Graph.Test.GraphRules
     build-depends:      algebraic-graphs,
                         array        >= 0.4     && < 0.6,
                         base         >= 4.7     && < 5,
@@ -141,6 +143,9 @@ test-suite test-alga
                         QuickCheck   >= 2.9     && < 2.12
     if !impl(ghc >= 8.0)
         build-depends:  semigroups   >= 0.18.3  && < 0.18.4
+    if impl(ghc >= 8.0.2)
+        build-depends:  inspection-testing >= 0.4 && < 0.5
+
     default-language:   Haskell2010
     GHC-options:        -Wall
                         -fno-warn-name-shadowing

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -295,7 +295,7 @@ connect = Connect
 -- @
 vertices :: [a] -> Graph a
 vertices = overlays . map vertex
-{-# INLINE [1] vertices #-}
+{-# NOINLINE [1] vertices #-}
 
 -- | Construct the graph from a list of edges.
 -- Complexity: /O(L)/ time, memory and size, where /L/ is the length of the

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -295,7 +295,7 @@ connect = Connect
 -- @
 vertices :: [a] -> Graph a
 vertices = overlays . map vertex
-{-# NOINLINE [1] vertices #-}
+{-# INLINE [1] vertices #-}
 
 -- | Construct the graph from a list of edges.
 -- Complexity: /O(L)/ time, memory and size, where /L/ is the length of the

--- a/src/Algebra/Graph/Internal.hs
+++ b/src/Algebra/Graph/Internal.hs
@@ -21,7 +21,7 @@ module Algebra.Graph.Internal (
 
     -- * Graph traversal
     Focus (..), emptyFocus, vertexFocus, overlayFoci, connectFoci, Hit (..),
-    foldr1Safe,
+    foldr1Safe, mf,
 
     -- * Utilities
     setProduct, setProductWith
@@ -116,11 +116,12 @@ data Hit = Miss | Tail | Edge deriving (Eq, Ord)
 
 -- | A safe version of 'foldr1'.
 foldr1Safe :: (a -> a -> a) -> [a] -> Maybe a
-foldr1Safe f = foldr mf Nothing
-  where
-    mf x m = Just (case m of
-                        Nothing -> x
-                        Just y  -> f x y)
+foldr1Safe f = foldr (mf f) Nothing
+
+mf :: (a -> a -> a) ->  a -> Maybe a -> Maybe a
+mf f x m = Just (case m of
+                  Nothing -> x
+                  Just y  -> f x y)
 {-# INLINE foldr1Safe #-}
 
 -- | Compute the Cartesian product of two sets.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,7 @@
+resolver: lts-12.11
+
 packages:
 - '.'
-resolver: lts-12.11
+
+extra-deps:
+- inspection-testing-0.4

--- a/test/Algebra/Graph/Test/GraphRules.hs
+++ b/test/Algebra/Graph/Test/GraphRules.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module     : Algebra.Graph.Test.Graph
+-- Copyright  : (c) Andrey Mokhov 2016-2018
+-- License    : MIT (see the file LICENSE)
+-- Maintainer : andrey.mokhov@gmail.com
+-- Stability  : experimental
+--
+-- Testsuite for "Algebra.Graph" rewrite-rules
+-----------------------------------------------------------------------------
+module Algebra.Graph.Test.GraphRules where
+
+import Algebra.Graph
+
+import qualified Test.Inspection as I
+
+-- transpose tests
+--- transpose . star
+starTranspose, transposeDotStar :: a -> [a] -> Graph a
+starTranspose a [] = vertex a
+starTranspose a xs = connect (vertices xs) (vertex a)
+
+transposeDotStar x = transpose . star x
+
+I.inspect $ 'starTranspose I.=== 'transposeDotStar
+
+--- transpose . overlays
+overlays', transposeDotOverlays :: [Graph a] -> Graph a
+overlays'            = overlays . map transpose
+
+transposeDotOverlays = transpose . overlays
+
+I.inspect $ 'overlays' I.=== 'transposeDotOverlays
+
+{-
+--- transpose . vertices
+vertices', transposeDotVertices :: [a] -> Graph a
+vertices'            = overlays . map vertex
+
+transposeDotVertices = transpose . vertices
+
+I.inspect $ 'vertices' I.=== 'transposeDotVertices
+-}

--- a/test/Algebra/Graph/Test/GraphRules.hs
+++ b/test/Algebra/Graph/Test/GraphRules.hs
@@ -11,9 +11,19 @@
 -----------------------------------------------------------------------------
 module Algebra.Graph.Test.GraphRules where
 
+import Data.Maybe (fromMaybe)
+
 import Algebra.Graph
+import Algebra.Graph.Internal
 
 import qualified Test.Inspection as I
+
+-- overlays tests
+vertices', overlaysDotMapVertex :: [a] -> Graph a
+vertices'            = fromMaybe Empty . foldr (mf Overlay . Vertex) Nothing
+overlaysDotMapVertex = overlays . map vertex
+
+I.inspect $ 'vertices' I.=== 'overlaysDotMapVertex
 
 -- transpose tests
 --- transpose . star
@@ -33,12 +43,10 @@ transposeDotOverlays = transpose . overlays
 
 I.inspect $ 'overlays' I.=== 'transposeDotOverlays
 
-{-
 --- transpose . vertices
-vertices', transposeDotVertices :: [a] -> Graph a
-vertices'            = overlays . map vertex
+verticesTransposed, transposeDotVertices :: [a] -> Graph a
+verticesTransposed   = overlays . map vertex
 
-transposeDotVertices = transpose . vertices
+transposeDotVertices = transpose . overlays . map vertex
 
-I.inspect $ 'vertices' I.=== 'transposeDotVertices
--}
+I.inspect $ 'verticesTransposed I.=== 'transposeDotVertices

--- a/test/Algebra/Graph/Test/GraphRules.hs
+++ b/test/Algebra/Graph/Test/GraphRules.hs
@@ -26,7 +26,7 @@ overlaysDotMapVertex = overlays . map vertex
 
 I.inspect $ 'vertices' I.=== 'overlaysDotMapVertex
 
---- overlays . map vertex
+--- connects . map vertex
 clique', connectsDotMapVertex :: [a] -> Graph a
 clique'              = fromMaybe Empty . foldr (mf Connect . Vertex) Nothing
 connectsDotMapVertex = connects . map vertex

--- a/test/Algebra/Graph/Test/GraphRules.hs
+++ b/test/Algebra/Graph/Test/GraphRules.hs
@@ -18,35 +18,82 @@ import Algebra.Graph.Internal
 
 import qualified Test.Inspection as I
 
--- overlays tests
+-- overlays/connects tests
+--- overlays . map vertex
 vertices', overlaysDotMapVertex :: [a] -> Graph a
 vertices'            = fromMaybe Empty . foldr (mf Overlay . Vertex) Nothing
 overlaysDotMapVertex = overlays . map vertex
 
 I.inspect $ 'vertices' I.=== 'overlaysDotMapVertex
 
+--- overlays . map vertex
+clique', connectsDotMapVertex :: [a] -> Graph a
+clique'              = fromMaybe Empty . foldr (mf Connect . Vertex) Nothing
+connectsDotMapVertex = connects . map vertex
+
+I.inspect $ 'clique' I.=== 'connectsDotMapVertex
+
 -- transpose tests
---- transpose . star
-starTranspose, transposeDotStar :: a -> [a] -> Graph a
-starTranspose a [] = vertex a
-starTranspose a xs = connect (vertices xs) (vertex a)
+--- transpose empty
+empty', transposeEmpty :: Graph a
+empty'         = Empty
+transposeEmpty = transpose Empty
 
-transposeDotStar x = transpose . star x
+I.inspect $ 'empty' I.=== 'transposeEmpty
 
-I.inspect $ 'starTranspose I.=== 'transposeDotStar
+--- transpose . vertex
+vertex', transposeDotVertex :: a -> Graph a
+vertex'            = Vertex
+transposeDotVertex = transpose . vertex
+
+I.inspect $ 'vertex' I.=== 'transposeDotVertex
+
+--- transpose . overlay
+overlayTransposed, transposeDotOverlay :: Graph a -> Graph a -> Graph a
+overlayTransposed   g1 g2 = Overlay (transpose g1) (transpose g2)
+transposeDotOverlay g1 g2 = transpose $ Overlay g1 g2
+
+I.inspect $ 'overlayTransposed I.=== 'transposeDotOverlay
+
+--- transpose . connect
+connectTransposed, transposeDotConnect :: Graph a -> Graph a -> Graph a
+connectTransposed   g1 g2 = Connect (transpose g2) (transpose g1)
+transposeDotConnect g1 g2 = transpose $ Connect g1 g2
+
+I.inspect $ 'connectTransposed I.=== 'transposeDotConnect
 
 --- transpose . overlays
-overlays', transposeDotOverlays :: [Graph a] -> Graph a
-overlays'            = overlays . map transpose
-
+overlaysTransposed, transposeDotOverlays :: [Graph a] -> Graph a
+overlaysTransposed   = overlays . map transpose
 transposeDotOverlays = transpose . overlays
 
-I.inspect $ 'overlays' I.=== 'transposeDotOverlays
+I.inspect $ 'overlaysTransposed I.=== 'transposeDotOverlays
+
+--- transpose . connects
+connectsTransposed, transposeDotConnects :: [Graph a] -> Graph a
+connectsTransposed   = connects . reverse . map transpose
+transposeDotConnects = transpose . connects
+
+I.inspect $ 'connectsTransposed I.=== 'transposeDotConnects
 
 --- transpose . vertices
 verticesTransposed, transposeDotVertices :: [a] -> Graph a
 verticesTransposed   = overlays . map vertex
-
 transposeDotVertices = transpose . overlays . map vertex
 
 I.inspect $ 'verticesTransposed I.=== 'transposeDotVertices
+
+--- transpose . clique
+cliqueTransposed, transposeDotClique :: [a] -> Graph a
+cliqueTransposed   = connects . reverse . map vertex
+transposeDotClique = transpose . connects . map vertex
+
+I.inspect $ 'cliqueTransposed I.=== 'transposeDotClique
+
+--- transpose . star
+starTranspose, transposeDotStar :: a -> [a] -> Graph a
+starTranspose a [] = vertex a
+starTranspose a xs = connect (vertices xs) (vertex a)
+transposeDotStar x = transpose . star x
+
+I.inspect $ 'starTranspose I.=== 'transposeDotStar


### PR DESCRIPTION
This is related to #129 and #123 

It implements tests of rewrite rules of `Algebra.Graph` using the (fantastic) `inspection-testing`.

* The correct `foldr/map` merge of `overlays . map vertex`
* The transpose rules
* Plus the nontrivial two combined: the rewriting of `transpose . star`

I don't really know if want to have such tests for other modules, they can obviously be added :)