### PR TITLE
Cabal flag for inspection testing

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -56,7 +56,7 @@ source-repository head
     type:     git
     location: https://github.com/snowleopard/alga.git
 
-Flag inspection-testing
+flag inspection-testing
     Description: Enable test of rewrite rules with inspection-testing
 
 library

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -56,6 +56,9 @@ source-repository head
     type:     git
     location: https://github.com/snowleopard/alga.git
 
+Flag inspection-testing
+    Description: Enable test of rewrite rules with inspection-testing
+
 library
     hs-source-dirs:     src
     exposed-modules:    Algebra.Graph,
@@ -132,7 +135,7 @@ test-suite test-alga
                         Algebra.Graph.Test.Labelled.AdjacencyMap,
                         Algebra.Graph.Test.Relation,
                         Data.Graph.Test.Typed
-    if impl(ghc >= 8.0.2)
+    if (impl(ghc >= 8.0.2) && flag(inspection-testing))
         other-modules:  Algebra.Graph.Test.RewriteRules
     build-depends:      algebraic-graphs,
                         array        >= 0.4     && < 0.6,
@@ -144,7 +147,7 @@ test-suite test-alga
                         QuickCheck   >= 2.9     && < 2.12
     if !impl(ghc >= 8.0)
         build-depends:  semigroups   >= 0.18.3  && < 0.18.4
-    if impl(ghc >= 8.0.2)
+    if (impl(ghc >= 8.0.2) && flag(inspection-testing))
         build-depends:  inspection-testing >= 0.4 && < 0.5
 
     default-language:   Haskell2010


### PR DESCRIPTION
Hi,

This is related to #129 

It adds a flag to disable test of rewrite rules, namely `inspection-testing`. Disabling it also remove the dependence on the `inspection-testing` package.

The flag is on by default.