### PR TITLE
Replace .ghcid with .ghci

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -2,5 +2,6 @@
 
 :set -isrc
 :set -itest
+:set prompt "> "
 
-:load test/Main.hs
+:load Main Algebra.Graph.Labelled.Example.Automaton Algebra.Graph.Labelled.Example.Network

--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,6 @@
+:set -Wall -fno-warn-name-shadowing -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+
+:set -isrc
+:set -itest
+
+:load test/Main.hs

--- a/.ghcid
+++ b/.ghcid
@@ -1,1 +1,0 @@
---command="stack ghci --test --bench --ghci-options=\"-fno-code -fno-break-on-exception -fno-break-on-error -v1 -ferror-spans -j -fobject-code -O -fspec-constr\""

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
-.ghci
 ghcid.txt
 .vscode/


### PR DESCRIPTION
@nobrakal I propose to change our `ghcid` setup: instead of using the `.ghcid` file, we'll use `.ghci` instead. This seems to be faster in the sense that we don't need to compile with optimisation.

As a drawback, I think the rewrite rules are no longer tested automatically.