### PR TITLE
Rewrite Rules for bind

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -1147,7 +1147,7 @@ this line: http://hackage.haskell.org/package/base/docs/src/GHC.Base.html#mapFB.
   a "buildR/f" rule. These functions are higher-order functions and therefore
   benefit from inlining in the final phase.
 
-* The "fmapR/fmapR" rule optimises compositions of multiple fmapR's.
+* The "bindR/bindR" rule optimises compositions of multiple bindR's.
 -}
 
 type Foldg a = forall b. b -> (a -> b) -> (b -> b -> b) -> (b -> b -> b) -> b
@@ -1188,9 +1188,9 @@ matchR e v p = \x -> if p x then v x else e
 "foldg/buildR" forall e v o c (g :: Foldg a).
     foldg e v o c (buildR g) = g e v o c
 
--- Fuse composeR's. This occurs when two adjacent 'fmapR' were rewritted into
+-- Fuse composeR's. This occurs when two adjacent 'bindR' were rewritted into
 -- their buildR form.
-"fmapR/fmapR" forall c f g.
+"bindR/bindR" forall c f g.
     composeR (composeR c f) g = composeR c (f.g)
  #-}
 

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -213,7 +213,7 @@ instance Functor Graph where
     fmap = fmapR
 
 fmapR :: (a -> b) -> Graph a -> Graph b
-fmapR f g = g >>= (vertex . f)
+fmapR f g = bindR g (vertex . f)
 {-# INLINE fmapR #-}
 
 instance NFData a => NFData (Graph a) where

--- a/test/Algebra/Graph/Test/RewriteRules.hs
+++ b/test/Algebra/Graph/Test/RewriteRules.hs
@@ -96,3 +96,9 @@ starTR a [] = vertex a
 starTR a xs = connect (vertices xs) (vertex a)
 
 inspect $ 'starT1 === 'starTR
+
+fmapFmap1, fmapFmapR :: Graph a -> (a -> b) -> (b -> c) -> Graph c
+fmapFmap1 g f h = fmap h (fmap f g)
+fmapFmapR g f h = fmap (h . f) g
+
+inspect $ 'fmapFmap1 === 'fmapFmapR


### PR DESCRIPTION
Hi there,

I have:
* implemented the deforestation rules for `bind`
* rewritten `fmap` in term of `bind`
* added a test to verify that `fmap f . fmap g` was rewritten in `fmap (f.g)`

Happy Holidays :)