### PR TITLE
Switch to Applicative-based Cartesian graph product

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -51,7 +51,7 @@ module Algebra.Graph (
     ) where
 
 import Prelude ()
-import Prelude.Compat hiding ((<>))
+import Prelude.Compat
 
 import Control.Applicative (Alternative)
 import Control.DeepSeq (NFData (..))

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -59,7 +59,6 @@ import Control.Monad.Compat
 import Control.Monad.State (runState, get, put)
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
 import Data.Tree
 
 import Algebra.Graph.Internal
@@ -1092,12 +1091,10 @@ compose x y = overlays
 -- 'edgeCount'   (box x y) <= 'vertexCount' x * 'edgeCount' y + 'edgeCount' x * 'vertexCount' y
 -- @
 box :: Graph a -> Graph b -> Graph (a, b)
-box x y = overlays $ xs ++ ys
+box x y = overlay (fx <*> y) (fy <*> x)
   where
-    xs = map (\b -> fmap (,b) x) $ toList $ toListGr y
-    ys = map (\a -> fmap (a,) y) $ toList $ toListGr x
-    toListGr :: Graph a -> List a
-    toListGr = foldg mempty pure (<>) (<>)
+    fx = foldg empty (vertex .      (,)) overlay overlay x
+    fy = foldg empty (vertex . flip (,)) overlay overlay y
 
 -- | /Sparsify/ a graph by adding intermediate 'Left' @Int@ vertices between the
 -- original vertices (wrapping the latter in 'Right') such that the resulting

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -898,13 +898,10 @@ simple op x y
 -- 'edgeCount'   (box x y) <= 'vertexCount' x * 'edgeCount' y + 'edgeCount' x * 'vertexCount' y
 -- @
 box :: Graph a -> Graph b -> Graph (a, b)
-box x y = overlays1 xs `overlay` overlays1 ys
+box x y = overlay (fx <*> y) (fy <*> x)
   where
-    xs = fmap (\b -> fmap (,b) x) $ toNonEmptyList y
-    ys = fmap (\a -> fmap (a,) y) $ toNonEmptyList x
-
-toNonEmptyList :: Graph a -> NonEmpty a
-toNonEmptyList = foldg1 (:| []) (<>) (<>)
+    fx = foldg1 (vertex .      (,)) overlay overlay x
+    fy = foldg1 (vertex . flip (,)) overlay overlay y
 
 -- | /Sparsify/ a graph by adding intermediate 'Left' @Int@ vertices between the
 -- original vertices (wrapping the latter in 'Right') such that the resulting

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -56,10 +56,6 @@ module Algebra.Graph.NonEmpty (
 import Prelude ()
 import Prelude.Compat
 
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup
-#endif
-
 import Control.DeepSeq
 import Control.Monad.Compat
 import Control.Monad.State


### PR DESCRIPTION
Re-implement Cartesian graph product `box` using Applicative instance, which allows to preserve the shape of original expressions to some degree (instead of flattening expression trees using `overlays`).