### PR TITLE
Make (<*>) subject to fusion

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -1165,14 +1165,10 @@ matchR :: b -> (a -> b) -> (a -> Bool) -> a -> b
 matchR e v p = \x -> if p x then v x else e
 {-# INLINE [0] matchR #-}
 
-toR :: b -> (a -> b) -> (b -> b -> b) -> (b -> b -> b) -> Graph a -> b
-toR e v o c g = foldg e v o c g
-{-# INLINE [0] toR #-}
-
 -- These rules transform functions into their buildR equivalents.
 {-# RULES
 "buildR/bindR" forall f g.
-    bindR g f = buildR (\e v o c -> foldg e (composeR (toR e v o c) f) o c g)
+    bindR g f = buildR (\e v o c -> foldg e (composeR (foldg e v o c) f) o c g)
 
 "buildR/induce" [~1] forall p g.
     induce p g = buildR (\e v o c -> foldg e (matchR e v p) o c g)
@@ -1198,8 +1194,9 @@ toR e v o c g = foldg e v o c g
 "bindR/bindR" forall c f g.
     composeR (composeR c f) g = composeR c (f.g)
 
-"toR/final" forall f.
-    composeR (toR Empty Vertex Overlay Connect) f = f
+-- Remove identity (which can appear in the rewriting of bindR)
+"foldg/id"
+    foldg Empty Vertex Overlay Connect = id
  #-}
 
 -- Eliminate remaining rewrite-only functions.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -261,11 +261,11 @@ ordIntR x y = compare (toAdjacencyIntMap x) (toAdjacencyIntMap y)
 
 instance Applicative Graph where
     pure  = Vertex
-    (<*>) = seqApR
+    (<*>) = apR
 
-seqApR :: Graph (a -> b) -> Graph a -> Graph b
-seqApR f x = bindR f (<$> x)
-{-# INLINE seqApR #-}
+apR :: Graph (a -> b) -> Graph a -> Graph b
+apR f x = bindR f (<$> x)
+{-# INLINE apR #-}
 
 instance Monad Graph where
     return = pure
@@ -1194,7 +1194,7 @@ matchR e v p = \x -> if p x then v x else e
 "bindR/bindR" forall c f g.
     composeR (composeR c f) g = composeR c (f.g)
 
--- Remove identity (which can appear in the rewriting of bindR)
+-- Rewrite identity (which can appear in the rewriting of bindR) to a much efficient one
 "foldg/id"
     foldg Empty Vertex Overlay Connect = id
  #-}

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -260,8 +260,8 @@ ordIntR :: Graph Int -> Graph Int -> Ordering
 ordIntR x y = compare (toAdjacencyIntMap x) (toAdjacencyIntMap y)
 
 instance Applicative Graph where
-    pure  = Vertex
-    (<*>) = ap
+    pure    = Vertex
+    f <*> x = bindR f (<$> x)
 
 instance Monad Graph where
     return = pure

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -212,8 +212,8 @@ ordInt :: Graph Int -> Graph Int -> Ordering
 ordInt x y = compare (T.toAdjacencyIntMap x) (T.toAdjacencyIntMap y)
 
 instance Applicative Graph where
-    pure  = Vertex
-    (<*>) = ap
+    pure    = Vertex
+    f <*> x = f >>= (<$> x)
 
 instance Monad Graph where
     return  = pure

--- a/test/Algebra/Graph/Test/RewriteRules.hs
+++ b/test/Algebra/Graph/Test/RewriteRules.hs
@@ -102,3 +102,17 @@ fmapFmap1 g f h = fmap h (fmap f g)
 fmapFmapR g f h = fmap (h . f) g
 
 inspect $ 'fmapFmap1 === 'fmapFmapR
+
+bind2, bind2R :: (a -> Graph b) -> (b -> Graph c) -> Graph a -> Graph c
+bind2 f g x = x >>= f >>= g
+bind2R f g x = x >>= (\x -> f x >>= g)
+
+inspect $ 'bind2 === 'bind2R
+
+{-
+ovSeqAp, seqApOv :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
+ovSeqAp x y z = (overlay x y) <*> z
+seqApOv x y z = overlay (x <*> z) (y <*> z)
+
+inspect $ 'ovSeqAp === 'seqApOv
+-}

--- a/test/Algebra/Graph/Test/RewriteRules.hs
+++ b/test/Algebra/Graph/Test/RewriteRules.hs
@@ -113,14 +113,14 @@ inspect $ 'bind2 === 'bind2R
 -- Strangely, '<*>' in 'ovSeqApR' does not inline and makes the test fail.
 --
 -- This is corrected below, where '<*>' was inlined "by hand"
-ovSeqAp, ovSeqApR :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
-ovSeqAp  x y z = (overlay x y) <*> z
-ovSeqApR x y z = overlay (x <*> z) (y <*> z)
+ovAp, ovApR :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
+ovAp  x y z = overlay x y <*> z
+ovApR x y z = overlay (x <*> z) (y <*> z)
 
-inspect $ 'ovSeqAp =/= 'ovSeqApR
+inspect $ 'ovAp =/= 'ovApR
 
-ovSeqAp', ovSeqApR' :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
-ovSeqAp'  x y z = (overlay x y) <*> z
-ovSeqApR' x y z = overlay (x >>= (<$> z)) (y >>= (<$> z))
+ovAp', ovApR' :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
+ovAp'  x y z = overlay x y <*> z
+ovApR' x y z = overlay (x >>= (<$> z)) (y >>= (<$> z))
 
-inspect $ 'ovSeqAp' === 'ovSeqApR'
+inspect $ 'ovAp' === 'ovApR'

--- a/test/Algebra/Graph/Test/RewriteRules.hs
+++ b/test/Algebra/Graph/Test/RewriteRules.hs
@@ -109,8 +109,18 @@ bind2R f g x = x >>= (\x -> f x >>= g)
 
 inspect $ 'bind2 === 'bind2R
 
-ovSeqAp, seqApOv :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
-ovSeqAp x y z = (overlay x y) <*> z
-seqApOv x y z = overlay (x >>= (<$> z)) (y >>= (<$> z))
+-- Ideally, we want this test to pass.
+-- Strangely, '<*>' in 'ovSeqApR' does not inline and makes the test fail.
+--
+-- This is corrected below, where '<*>' was inlined "by hand"
+ovSeqAp, ovSeqApR :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
+ovSeqAp  x y z = (overlay x y) <*> z
+ovSeqApR x y z = overlay (x <*> z) (y <*> z)
 
-inspect $ 'ovSeqAp === 'seqApOv
+inspect $ 'ovSeqAp =/= 'ovSeqApR
+
+ovSeqAp', ovSeqApR' :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
+ovSeqAp'  x y z = (overlay x y) <*> z
+ovSeqApR' x y z = overlay (x >>= (<$> z)) (y >>= (<$> z))
+
+inspect $ 'ovSeqAp' === 'ovSeqApR'

--- a/test/Algebra/Graph/Test/RewriteRules.hs
+++ b/test/Algebra/Graph/Test/RewriteRules.hs
@@ -110,7 +110,7 @@ bind2R f g x = x >>= (\x -> f x >>= g)
 inspect $ 'bind2 === 'bind2R
 
 -- Ideally, we want this test to pass.
--- Strangely, '<*>' in 'ovSeqApR' does not inline and makes the test fail.
+-- Strangely, '<*>' in 'ovApR' does not inline and makes the test fail.
 --
 -- This is corrected below, where '<*>' was inlined "by hand"
 ovAp, ovApR :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b

--- a/test/Algebra/Graph/Test/RewriteRules.hs
+++ b/test/Algebra/Graph/Test/RewriteRules.hs
@@ -109,10 +109,8 @@ bind2R f g x = x >>= (\x -> f x >>= g)
 
 inspect $ 'bind2 === 'bind2R
 
-{-
 ovSeqAp, seqApOv :: Graph (a -> b) -> Graph (a -> b) -> Graph a -> Graph b
 ovSeqAp x y z = (overlay x y) <*> z
-seqApOv x y z = overlay (x <*> z) (y <*> z)
+seqApOv x y z = overlay (x >>= (<$> z)) (y >>= (<$> z))
 
 inspect $ 'ovSeqAp === 'seqApOv
--}


### PR DESCRIPTION
Hi there,

This only change the definition of `(<*>)` in `Algebra.Graph` to an equivalent made with `bindR` (suggested by @snowleopard  ), which allow fusion with compatible functions.