### PR TITLE
Speedup for isSubgraphOf

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -473,17 +473,13 @@ foldg e v o c = go
 -- isSubgraphOf x y                         ==> x <= y
 -- @
 isSubgraphOf :: Ord a => Graph a -> Graph a -> Bool
-isSubgraphOf x y = AM.overlay (toAdjacencyMap x) yAM == yAM
-  where
-    yAM = toAdjacencyMap y
+isSubgraphOf x y = AM.isSubgraphOf (toAdjacencyMap x) (toAdjacencyMap y)
 {-# NOINLINE [1] isSubgraphOf #-}
 {-# RULES "isSubgraphOf/Int" isSubgraphOf = isSubgraphOfIntR #-}
 
 -- Like 'isSubgraphOf' but specialised for graphs with vertices of type 'Int'.
 isSubgraphOfIntR :: Graph Int -> Graph Int -> Bool
-isSubgraphOfIntR x y = AIM.overlay (toAdjacencyIntMap x) yAM == yAM
-  where
-    yAM = toAdjacencyIntMap y
+isSubgraphOfIntR x y = AIM.isSubgraphOf (toAdjacencyIntMap x) (toAdjacencyIntMap y)
 
 -- | Structural equality on graph expressions.
 -- Complexity: /O(s)/ time.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -476,7 +476,14 @@ isSubgraphOf :: Ord a => Graph a -> Graph a -> Bool
 isSubgraphOf x y = AM.overlay (toAdjacencyMap x) yAM == yAM
   where
     yAM = toAdjacencyMap y
-{-# SPECIALISE isSubgraphOf :: Graph Int -> Graph Int -> Bool #-}
+{-# NOINLINE [1] isSubgraphOf #-}
+{-# RULES "isSubgraphOf/Int" isSubgraphOf = isSubgraphOfIntR #-}
+
+-- Like 'isSubgraphOf' but specialised for graphs with vertices of type 'Int'.
+isSubgraphOfIntR :: Graph Int -> Graph Int -> Bool
+isSubgraphOfIntR x y = AIM.overlay (toAdjacencyIntMap x) yAM == yAM
+  where
+    yAM = toAdjacencyIntMap y
 
 -- | Structural equality on graph expressions.
 -- Complexity: /O(s)/ time.

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -473,7 +473,9 @@ foldg e v o c = go
 -- isSubgraphOf x y                         ==> x <= y
 -- @
 isSubgraphOf :: Ord a => Graph a -> Graph a -> Bool
-isSubgraphOf x y = overlay x y == y
+isSubgraphOf x y = AM.overlay (toAdjacencyMap x) yAM == yAM
+  where
+    yAM = toAdjacencyMap y
 {-# SPECIALISE isSubgraphOf :: Graph Int -> Graph Int -> Bool #-}
 
 -- | Structural equality on graph expressions.

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -63,12 +63,14 @@ import Data.List.NonEmpty (NonEmpty (..))
 
 import Algebra.Graph.Internal
 
-import qualified Algebra.Graph         as G
-import qualified Algebra.Graph.ToGraph as T
-import qualified Data.IntSet           as IntSet
-import qualified Data.List.NonEmpty    as NonEmpty
-import qualified Data.Set              as Set
-import qualified Data.Tree             as Tree
+import qualified Algebra.Graph                 as G
+import qualified Algebra.Graph.ToGraph         as T
+import qualified Algebra.Graph.AdjacencyMap    as AM
+import qualified Algebra.Graph.AdjacencyIntMap as AIM
+import qualified Data.IntSet                   as IntSet
+import qualified Data.List.NonEmpty            as NonEmpty
+import qualified Data.Set                      as Set
+import qualified Data.Tree                     as Tree
 
 {-| Non-empty algebraic graphs, which are constructed using three primitives:
 'vertex', 'overlay' and 'connect'. See module "Algebra.Graph" for algebraic
@@ -398,8 +400,17 @@ foldg1 v o c = go
 -- isSubgraphOf x y                         ==> x <= y
 -- @
 isSubgraphOf :: Ord a => Graph a -> Graph a -> Bool
-isSubgraphOf x y = overlay x y == y
-{-# SPECIALISE isSubgraphOf :: Graph Int -> Graph Int -> Bool #-}
+isSubgraphOf x y = AM.overlay (T.toAdjacencyMap x) yAM == yAM
+  where
+    yAM = T.toAdjacencyMap y
+{-# NOINLINE [1] isSubgraphOf #-}
+{-# RULES "isSubgraphOf/Int" isSubgraphOf = isSubgraphOfIntR #-}
+
+-- Like 'isSubgraphOf' but specialised for graphs with vertices of type 'Int'.
+isSubgraphOfIntR :: Graph Int -> Graph Int -> Bool
+isSubgraphOfIntR x y = AIM.overlay (T.toAdjacencyIntMap x) yAM == yAM
+  where
+    yAM = T.toAdjacencyIntMap y
 
 -- | Structural equality on graph expressions.
 -- Complexity: /O(s)/ time.

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -400,17 +400,13 @@ foldg1 v o c = go
 -- isSubgraphOf x y                         ==> x <= y
 -- @
 isSubgraphOf :: Ord a => Graph a -> Graph a -> Bool
-isSubgraphOf x y = AM.overlay (T.toAdjacencyMap x) yAM == yAM
-  where
-    yAM = T.toAdjacencyMap y
+isSubgraphOf x y = AM.isSubgraphOf (T.toAdjacencyMap x) (T.toAdjacencyMap y)
 {-# NOINLINE [1] isSubgraphOf #-}
 {-# RULES "isSubgraphOf/Int" isSubgraphOf = isSubgraphOfIntR #-}
 
 -- Like 'isSubgraphOf' but specialised for graphs with vertices of type 'Int'.
 isSubgraphOfIntR :: Graph Int -> Graph Int -> Bool
-isSubgraphOfIntR x y = AIM.overlay (T.toAdjacencyIntMap x) yAM == yAM
-  where
-    yAM = T.toAdjacencyIntMap y
+isSubgraphOfIntR x y = AIM.isSubgraphOf (T.toAdjacencyIntMap x) (T.toAdjacencyIntMap y)
 
 -- | Structural equality on graph expressions.
 -- Complexity: /O(s)/ time.


### PR DESCRIPTION
Hi,

I just saw that in the actual `isSubGraphOf`, the second argument was converted two times in the same adjacency map in `Algebra.Graph{,.NonEmpty}`.
This PR solves this by introducing a variable. Note that the code is a bit less clear and I had to add specialized functions by hand (since I use directly `overlay` from `AdjacencyMap` or `AdjacencyIntMap` ).