### PR TITLE
Allow project to be developed using Nix

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -1,5 +1,5 @@
 name:          algebraic-graphs
-version:       0.3
+version:       0.4
 synopsis:      A library for algebraic graph construction and transformation
 license:       MIT
 license-file:  LICENSE

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+(import <nixpkgs> { }).haskellPackages.developPackage { root = ./.; }


### PR DESCRIPTION
Some Haskell developers like myself use **Nix** to manage their environment. This change makes it easier to use Nix to get the project up and running. The `nix-shell --run ghcid` command for example will pull the dependencies (including ghc itself!), and launch `ghcid` which is extremely handy for iterative compilation feedback from edits.

I have also increased the version (referring to a yet to be published version) in default.nix so that nix does not accidentally pick the published version from hackage.

Ref:
* https://nixos.org/nixpkgs/manual/#how-to-create-a-development-environment
* https://twitter.com/puffnfresh/status/990154797494943744?lang=en