### PR TITLE
Adding BFS support to AdjacencyMaps.

### DIFF
--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------
 module Algebra.Graph.AdjacencyMap.Algorithm (
     -- * Algorithms
-    dfsForest, dfsForestFrom, dfs, reachable, topSort, isAcyclic, scc,
+    dfsForest, dfsForestFrom, dfs, bfsForest, reachable, topSort, isAcyclic, scc,
 
     -- * Correctness properties
     isDfsForestOf, isTopSortOf
@@ -233,3 +233,66 @@ isTopSortOf xs m = go Set.empty xs
                   && go newSeen vs
       where
         newSeen = Set.insert v seen
+
+-- | Compute the /breadth-first search/ forest of a graph that corresponds to
+-- searching from each of the graph vertices in the 'Ord' @a@ order.
+--
+-- @
+-- bfsForest 'empty'                       == []
+-- 'forest' (bfsForest $ 'edge' 1 1)         == 'vertex' 1
+-- 'forest' (bfsForest $ 'edge' 1 2)         == 'edge' 1 2
+-- 'forest' (bfsForest $ 'edge' 2 1)         == 'vertices' [1,2]
+-- 'isSubgraphOf' ('forest' $ bfsForest x) x == True
+-- 'isbfsForestOf' (bfsForest x) x         == True
+-- bfsForest . 'forest' . bfsForest        == bfsForest
+-- bfsForest ('vertices' vs)               == 'map' (\\v -> Node v []) ('Data.List.nub' $ 'Data.List.sort' vs)
+-- bfsForest $ 1 * (3+5+7) + 3 * (5+4) + (4+3+5+7) * 6 ==  [Node {rootLabel = 1
+--                                                               , subForest = [Node {rootLabel = 3
+--                                                                                   , subForest = [ Node {rootLabel = 4
+--                                                                                                        , subForest = [] }
+--                                                                                                 , Node {rootLabel = 6
+--                                                                                                        , subForest = [] }]}
+--                                                                             , Node {rootLabel = 5
+--                                                                                    , subForest = [] }
+--                                                                             , Node {rootLabel = 7
+--                                                                                    , subForest = [] }]}]
+-- @
+bfsForest :: Ord a => AdjacencyMap a -> [Tree a]
+bfsForest g
+    | isEmpty g = []
+    | otherwise = headTree : (bfsForest . induce remove) g
+        where headTree = bfsTree ((head . vertexList) g) g
+              remove x = not $ elem x $ flatten headTree
+
+
+-- | Compute the /breadth-first search/ AdjacencyMap of a graph that corresponds to
+-- searching from a single vertex of the graph. 
+-- This is just for internal use. Might move it to `*.Internal` then?
+--
+bfsTreeAdjacencyMap :: Ord a => a -> AdjacencyMap a -> AdjacencyMap a
+bfsTreeAdjacencyMap s g = if (hasVertex s g) 
+                          then bfsTreeAdjacencyMapUtil [s] (Set.singleton s) g 
+                          else empty
+
+-- | Compute the /breadth-first search/ AdjacencyMap of a graph that corresponds to
+-- searching from the head of a queue (followed by other vertices to search from), 
+-- given a Set of seen vertices (vertices that shouldn't be visited).
+-- This is just for internal use. Might move it to `*.Internal` then?
+--
+bfsTreeAdjacencyMapUtil :: Ord a => [a] -> Set.Set a -> AdjacencyMap a -> AdjacencyMap a
+bfsTreeAdjacencyMapUtil [] _ _ = empty
+bfsTreeAdjacencyMapUtil queue@(v:qv) seen g = overlay (AM.AM $ Map.singleton v vSet) (bfsTreeAdjacencyMapUtil newQueue newSeen g)
+    where
+        neighbors = postSet v g
+        vSet = Set.difference neighbors seen
+        newSeen = Set.union seen neighbors
+        newQueue = qv ++ (Set.toAscList vSet)
+
+-- | Compute the /breadth-first search/ Tree of a graph that corresponds to
+-- searching from a single vertex of the graph. This is just for internal use. 
+-- Might move it to `*.Internal` then?
+--
+bfsTree :: Ord a => a -> AdjacencyMap a -> Tree a
+bfsTree s g = unfoldTree neighbors s
+    where neighbors b = (b, Set.toAscList . postSet b $ bfs)
+          bfs = bfsTreeAdjacencyMap s g


### PR DESCRIPTION
I've added a bfsForest algorithm that makes use of "helper" functions for a total of 4 new functions. These are located in AdjacencyMap/Algorithm.hs, however, I believe that the 3 helped functions might be rellocated to keep Algorithm.hs clean.

Complexity analysis is still missing. 

Also,  the next functions need to be implemented.

```Haskell
-- Run BFS from the list of initial vertices, returning the resulting BFS forest.
bfsForestFrom :: Ord a => [a] -> AdjacencyMap a -> Forest a

-- Run BFS from the list of initial vertices (roots), returning the resulting list of 
-- levels, i.e. vertices that are at the same distance from the roots.
bfs :: Ord a => [a] -> AdjacencyMap a -> [[a]]
```

