### PR TITLE
Bump LTS and allow newer QuickCheck

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## 0.4
 
+* #143: Allow newer QuickCheck.
 * #171: Implement sparsification for King-Launchbury graph representation.
-* #178: Derive `Generic` for adjacency maps. 
+* #178: Derive `Generic` for adjacency maps.
 
 ## 0.3
 

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -160,7 +160,7 @@ test-suite test-alga
                         base-orphans >= 0.5.4   && < 0.9,
                         containers   >= 0.5.5.1 && < 0.8,
                         extra        >= 1.5     && < 2,
-                        QuickCheck   >= 2.9     && < 2.13
+                        QuickCheck   >= 2.9     && < 2.14
     if !impl(ghc >= 8.0)
         build-depends:  semigroups   >= 0.18.3  && < 0.18.4
     if impl(ghc >= 8.0.2)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.19
+resolver: lts-13.17
 
 packages:
 - '.'


### PR DESCRIPTION
See https://github.com/commercialhaskell/stackage/issues/4444