### PR TITLE
Made the new version of Dijkstra Algorithm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ cabal.sandbox.config
 cabal.project.local
 ghcid.txt
 .vscode/
+*.swp
+*.swo

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -85,6 +85,7 @@ library
                         Algebra.Graph.Labelled,
                         Algebra.Graph.Labelled.AdjacencyMap,
                         Algebra.Graph.Labelled.AdjacencyMap.Internal,
+                        Algebra.Graph.Labelled.AdjacencyMap.Algorithm.Dijkstra,
                         Algebra.Graph.Labelled.Example.Automaton,
                         Algebra.Graph.Labelled.Example.Network,
                         Algebra.Graph.NonEmpty,
@@ -105,7 +106,9 @@ library
                         base-compat >= 0.9.1   && < 0.11,
                         containers  >= 0.5.5.1 && < 0.8,
                         deepseq     >= 1.3.0.1 && < 1.5,
-                        mtl         >= 2.1     && < 2.3
+                        mtl         >= 2.1     && < 2.3,
+                        transformers,
+                        heap
     if !impl(ghc >= 8.0)
         build-depends:  semigroups  >= 0.18.3  && < 0.18.4
     if !impl(ghc >= 7.10)

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -107,8 +107,7 @@ library
                         containers  >= 0.5.5.1 && < 0.8,
                         deepseq     >= 1.3.0.1 && < 1.5,
                         mtl         >= 2.1     && < 2.3,
-                        transformers,
-                        heap
+                        transformers
     if !impl(ghc >= 8.0)
         build-depends:  semigroups  >= 0.18.3  && < 0.18.4
     if !impl(ghc >= 7.10)

--- a/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
@@ -1,0 +1,100 @@
+module Algebra.Graph.Labelled.AdjacencyMap.Algorithm.Dijkstra where
+
+import Algebra.Graph.Label (Capacity, Distance, Semiring(..), (<+>), zero)
+import Algebra.Graph.Labelled.AdjacencyMap.Internal (AdjacencyMap(..))
+import Control.Monad (sequence_, when)
+import Control.Monad.Trans.State.Strict (State, execState, get, gets, put)
+import Data.Heap (FstMaxPolicy, FstMinPolicy, Heap, HeapItem(..))
+import qualified Data.Heap as Heap
+import Data.Map (Map, (!))
+import qualified Data.Map.Strict as Map
+
+type DijkstraForDistance a b = DijkstraState FstMinPolicy a (Distance b)
+
+type DijkstraForCapacity a b = DijkstraState FstMaxPolicy a (Capacity b)
+
+dijkstra ::
+     (Eq e, Ord a, HeapItem p (e, a), Semiring e)
+  => a
+  -> AdjacencyMap e a
+  -> DijkstraState p a e
+dijkstra a am =
+  flip execState (DijkstraState Heap.empty Map.empty Map.empty) $ do
+    initialize a am
+    exploreVertices am
+
+data DijkstraState p a e = DijkstraState
+  { heap :: Heap p (e, a)
+  , distance :: Map a e
+  , path :: Map a (Maybe a)
+  }
+
+instance (Show e, Show a) => Show (DijkstraState p a e) where
+  show (DijkstraState heap' distance' path') =
+    "distance: " ++ show distance' ++ "\n" ++ "path: " ++ show path'
+
+putHeap :: Heap p (e, a) -> State (DijkstraState p a e) ()
+putHeap h = do
+  (DijkstraState _ distance' path') <- get
+  put $ DijkstraState h distance' path'
+
+initialize ::
+     (Ord a, HeapItem p (e, a), Semiring e)
+  => a
+  -> AdjacencyMap e a
+  -> State (DijkstraState p a e) ()
+initialize a am =
+  put $
+  DijkstraState
+    (Heap.singleton (one, a))
+    (Map.insert a one . Map.map (const zero) $ adjacencyMap am)
+    (Map.map (const Nothing) $ adjacencyMap am)
+
+exploreVertices ::
+     (Ord a, Eq e, HeapItem p (e, a), Semiring e)
+  => AdjacencyMap e a
+  -> State (DijkstraState p a e) ()
+exploreVertices am = do
+  curHeap <- gets heap
+  case Heap.view curHeap of
+    Nothing -> return ()
+    (Just ((_, v), t)) -> do
+      putHeap t
+      exploreVertex v am
+      exploreVertices am
+
+exploreVertex ::
+     (Ord a, Semiring e, Eq e, HeapItem p (e, a))
+  => a
+  -> AdjacencyMap e a
+  -> State (DijkstraState p a e) ()
+exploreVertex v1 am =
+  sequence_ $
+  Map.mapWithKey (\v2 e -> exploreEdge e v1 v2) (adjacencyMap am ! v1)
+
+modifyHeapItemPrio ::
+     (HeapItem p (e, a), Eq a) => a -> e -> Heap p (e, a) -> Heap p (e, a)
+modifyHeapItemPrio vertex prio curHeap =
+  Heap.insert (prio, vertex) $ Heap.filter (isNot vertex) curHeap
+  where
+    isNot v (_, i) = v /= i
+
+exploreEdge ::
+     (HeapItem p (e, a), Ord a, Semiring e, Eq e)
+  => e
+  -> a
+  -> a
+  -> State (DijkstraState p a e) ()
+exploreEdge e v1 v2 = do
+  curHeap <- gets heap
+  curDistance <- gets distance
+  curPath <- gets path
+  let curDV1 = curDistance ! v1
+  let curDV2 = curDistance ! v2
+  let newDV2 = curDV2 <+> (curDV1 <.> e)
+  when (newDV2 /= curDV2) $
+    put $
+    DijkstraState
+      (modifyHeapItemPrio v2 newDV2 curHeap)
+      (Map.insert v2 newDV2 curDistance)
+      (Map.insert v2 (Just v1) curPath)

--- a/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
@@ -2,7 +2,7 @@ module Algebra.Graph.Labelled.AdjacencyMap.Algorithm.Dijkstra where
 
 import Algebra.Graph.Label (Capacity, Distance, Semiring(..), (<+>), zero)
 import Algebra.Graph.Labelled.AdjacencyMap.Internal (AdjacencyMap(..))
-import Control.Monad (sequence_, when)
+import Control.Monad (sequence_, unless, when)
 import Control.Monad.Trans.State.Strict (State, execState, get, gets, put)
 import Data.Heap (FstMaxPolicy, FstMinPolicy, Heap, HeapItem(..))
 import qualified Data.Heap as Heap
@@ -13,36 +13,33 @@ type DijkstraForDistance a b = DijkstraState FstMinPolicy a (Distance b)
 
 type DijkstraForCapacity a b = DijkstraState FstMaxPolicy a (Capacity b)
 
--- | `dijkstra` is the main function using bothe `initialize` and `exploreVertices`.
--- The time complexity of `dijkstra` is O(|V| + |V| * |E|) = O(|V| * |E|)
+-- | /O(|V| + |E| * log|V|) `dijkstra` is the main function using
+-- both `initialize` and `exploreVertices`.
 dijkstra ::
      (Eq e, Ord a, HeapItem p (e, a), Semiring e)
   => a
   -> AdjacencyMap e a
   -> DijkstraState p a e
 dijkstra a am =
-  flip execState (DijkstraState Heap.empty Map.empty Map.empty) $ do
+  flip execState (DijkstraState Heap.empty Map.empty Map.empty Map.empty) $ do
     initialize a am
     exploreVertices am
 
 data DijkstraState p a e = DijkstraState
   { heap :: Heap p (e, a)
+  , explored :: Map a Bool
   , distance :: Map a e
   , path :: Map a (Maybe a)
   }
 
 instance (Show e, Show a) => Show (DijkstraState p a e) where
-  show (DijkstraState heap' distance' path') =
-    "distance: " ++ show distance' ++ "\n" ++ "path: " ++ show path'
+  show (DijkstraState _ explored' distance' path') =
+    "explored :" ++
+    show explored' ++
+    "\n" ++ "distance: " ++ show distance' ++ "\n" ++ "path: " ++ show path'
 
--- | This is a helper function to work with the heap in DijkstraState
-putHeap :: Heap p (e, a) -> State (DijkstraState p a e) ()
-putHeap h = do
-  (DijkstraState _ distance' path') <- get
-  put $ DijkstraState h distance' path'
-
--- | `initializes` gives the initial state for the State computation.
--- The time complexity is O(|V|)
+-- | /O(|V|)/ `initialize` gives the initial state for the
+-- State computation.
 initialize ::
      (Ord a, HeapItem p (e, a), Semiring e)
   => a
@@ -52,27 +49,27 @@ initialize a am =
   put $
   DijkstraState
     (Heap.singleton (one, a))
+    (Map.insert a True . Map.map (const False) $ adjacencyMap am)
     (Map.insert a one . Map.map (const zero) $ adjacencyMap am)
     (Map.map (const Nothing) $ adjacencyMap am)
 
--- | `exploreVertices` is an iterative function which explores all the vertices.
--- The time complexity is O(|V| * |E|).
--- O(|E|) is due to the usage of `exploreVertex`.
+-- | /O(|E| * log|V|)/ `exploreVertices` is an iterative function which explores all the vertices.
 exploreVertices ::
      (Ord a, Eq e, HeapItem p (e, a), Semiring e)
   => AdjacencyMap e a
   -> State (DijkstraState p a e) ()
 exploreVertices am = do
   curHeap <- gets heap
+  curExplored <- gets explored
+  curS <- get
   case Heap.view curHeap of
     Nothing -> return ()
     (Just ((_, v), t)) -> do
-      putHeap t
+      put $ curS {heap = t, explored = Map.insert v True curExplored}
       exploreVertex v am
       exploreVertices am
 
--- | `exploreVertex` explores the edges of a single vertex.
--- The time complexity is hence O(|E|).
+-- | /O(log|V|)/ `exploreVertex` explores the edges of a single vertex.
 exploreVertex ::
      (Ord a, Semiring e, Eq e, HeapItem p (e, a))
   => a
@@ -82,22 +79,9 @@ exploreVertex v1 am =
   sequence_ $
   Map.mapWithKey (\v2 e -> exploreEdge e v1 v2) (adjacencyMap am ! v1)
 
--- | This is a helper function for modifying the weight of an element in the heap.
--- The current heap library does not provide a way to modify or delete any value.
--- Hence we first delete the value using the filter function and then we insert the value.
--- The time complexity of `Heap.filter` if O(|V|).
--- The time complexity of `Heap.insert` is O(log|V|).
--- The time complexity of `modifyHeapItemPrio` is O(|V|).
-modifyHeapItemPrio ::
-     (HeapItem p (e, a), Eq a) => a -> e -> Heap p (e, a) -> Heap p (e, a)
-modifyHeapItemPrio vertex prio curHeap =
-  Heap.insert (prio, vertex) $ Heap.filter (isNot vertex) curHeap
-  where
-    isNot v (_, i) = v /= i
-
--- | `exploreEdge` takes an edge (v1 -> v2) with weight e.
--- It computes a new distance value for v2 and changes it in the heap.
--- The time complexity for this function is O(|V|), this is directly dependent on `modifyHeapItemPrio`.
+-- | /O(log|V|)/ `exploreEdge` takes an edge (v1 -> v2) with weight e.
+-- It computes a new distance value for v2 and inserts it in the heap
+-- if not explored.
 exploreEdge ::
      (HeapItem p (e, a), Ord a, Semiring e, Eq e)
   => e
@@ -108,12 +92,15 @@ exploreEdge e v1 v2 = do
   curHeap <- gets heap
   curDistance <- gets distance
   curPath <- gets path
-  let curDV1 = curDistance ! v1
-  let curDV2 = curDistance ! v2
-  let newDV2 = curDV2 <+> (curDV1 <.> e)
-  when (newDV2 /= curDV2) $
-    put $
-    DijkstraState
-      (modifyHeapItemPrio v2 newDV2 curHeap)
-      (Map.insert v2 newDV2 curDistance)
-      (Map.insert v2 (Just v1) curPath)
+  curExplored <- gets explored
+  unless (curExplored ! v2) $ do
+    let curDV1 = curDistance ! v1
+    let curDV2 = curDistance ! v2
+    let newDV2 = curDV2 <+> (curDV1 <.> e)
+    when (newDV2 /= curDV2) $
+      put $
+      DijkstraState
+        (Heap.insert (newDV2, v2) curHeap)
+        curExplored
+        (Map.insert v2 newDV2 curDistance)
+        (Map.insert v2 (Just v1) curPath)

--- a/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
@@ -2,16 +2,12 @@ module Algebra.Graph.Labelled.AdjacencyMap.Algorithm.Dijkstra where
 
 import Algebra.Graph.Label (Distance, Semiring(..), (<+>), zero)
 import Algebra.Graph.Labelled.AdjacencyMap.Internal (AdjacencyMap(..))
-import Control.Monad (sequence_, when)
+import Control.Monad (when)
 import Control.Monad.Trans.State.Strict (State, execState, get, gets, put)
 import Data.Map (Map, (!))
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-
--- Note:
--- new |> indicates the new state after the operation above.
--- old |> indicates the old state before the opration below.
 
 -- | A state that the Dijkstra algorithm defined will work on.
 data DijkstraState a e = DijkstraState
@@ -25,8 +21,7 @@ data DijkstraState a e = DijkstraState
 -- @
 -- dijkstra 'x' (fromList []) = Error as 'x' does not exist in the adjacency map
 --
--- dijkstra 'a' (fromList [(2, 'b', 'c'), (1, 'a', 'b'), (3, 'a', 'c')])
--- new |> ([], {'a': 0, 'b': 1, 'c': 3}, {'a': Nothing, 'b': Just 'a', 'c': Just 'b'}
+-- dijkstra 'a' (fromList [(2, 'b', 'c'), (1, 'a', 'b'), (3, 'a', 'c')]) = ([], {'a': 0, 'b': 1, 'c': 3}, {'a': Nothing, 'b': Just 'a', 'c': Just 'b'})
 -- @
 dijkstra ::
      (Ord a, Num e, Ord e)
@@ -38,16 +33,7 @@ dijkstra a am =
     initialize a am
     exploreVertices am
 
-
 -- | /O(|V|)/ `initialize` gives the initial state for the State computation.
---
--- @
--- initialize 'x' (fromList [])
--- new |> ([(0, 'x')], {}, {})
---
--- initialize 'x' (fromList [(4, 'a', 'b'), (5, 'c', 'd')])
--- new |> ([(0, 'x')], {'a': 0, 'b': inf, 'c': inf, 'd': inf}, {'a': Nothing, 'b': Nothing, 'c': Nothing, 'd': Nothing})
--- @
 initialize ::
      (Ord a, Num e, Ord e)
   => a
@@ -61,12 +47,6 @@ initialize a am =
     (Map.map (const Nothing) $ adjacencyMap am)
 
 -- | /O(|E| * log|V|)/ `exploreVertices` is an iterative function which explores all the vertices.
---
--- @
--- exploreVertices 
---    | heap != empty == extractMin >> \minElem -> exploreVertex minElem >> exploreVertices
---    | heap == empty == return ()
--- @
 exploreVertices ::
      (Ord a, Ord e, Num e)
   => AdjacencyMap (Distance e) a
@@ -81,38 +61,19 @@ exploreVertices am = do
       exploreVertex v am
       exploreVertices am
 
--- | /O(log|V|)/ `exploreVertex` explores the edges of a single vertex.
--- 
--- @
--- exploreVertex 'a' (fromList []) == Error as 'a' does not exist in the adjacency map
--- exploreVertex 'a' (fromList [(2, 'b', 'c'), (4, 'b', 'a')]) = return ()
--- exploreVertex 'a' (fromList [(2, 'b', 'c'), (1, 'a', 'b'), (3, 'a', 'c')]) == exploreEdge 1 'a' 'b' >> exploreEdge 3 'a' 'c'
--- @
+-- | `exploreVertex` explores the edges of a single vertex.
+-- Atmost, `exploreVertex` is called |V| times.
 exploreVertex ::
      (Ord a, Ord e, Num e)
   => a
   -> AdjacencyMap (Distance e) a
   -> State (DijkstraState a (Distance e)) ()
 exploreVertex v1 am =
-  sequence_ $
-  Map.mapWithKey (\v2 e -> exploreEdge e v1 v2) (adjacencyMap am ! v1)
+  Map.foldrWithKey
+    (\v2 e s -> s >> exploreEdge e v1 v2) (return ()) (adjacencyMap am ! v1)
 
 -- | /O(log|V|)/ `exploreEdge` takes an edge (v1 -> v2) with weight e.
 -- It computes a new distance value for v2 and inserts it in the heap if not explored.
---
--- @
--- old |> ([], {}, {})
--- exploreEdge 5 'a' 'b'
--- Error because of (!). 'a' and 'b' don't exist in the distance Map.
--- 
--- old |> ([], {'a': 0, 'b': inf}, {'a': Nothing, 'b': Nothing})
--- exploreEdge 5 'a' 'b'
--- new |> ([(5, 'b')], {'a': 0, 'b': 5}, {'a': Nothing, 'b': Just 'a'})
---
--- old |> ([], {'a': 0, 'b': 4, 'c': 1}, {'a': Nothing, 'b': Just 'c', 'c': Just 'a'})
--- exploreEdge 5 'a' 'b'
--- new |> ([], {'a': 0, 'b': 4, 'c': 1}, {'a': Nothing, 'b': Just 'c', 'c': Just 'a'})
--- @
 exploreEdge ::
      (Ord a, Ord e, Num e)
   => Distance e

--- a/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
@@ -13,6 +13,8 @@ type DijkstraForDistance a b = DijkstraState FstMinPolicy a (Distance b)
 
 type DijkstraForCapacity a b = DijkstraState FstMaxPolicy a (Capacity b)
 
+-- | `dijkstra` is the main function using bothe `initialize` and `exploreVertices`.
+-- The time complexity of `dijkstra` is O(|V| + |V| * |E|) = O(|V| * |E|)
 dijkstra ::
      (Eq e, Ord a, HeapItem p (e, a), Semiring e)
   => a
@@ -33,11 +35,14 @@ instance (Show e, Show a) => Show (DijkstraState p a e) where
   show (DijkstraState heap' distance' path') =
     "distance: " ++ show distance' ++ "\n" ++ "path: " ++ show path'
 
+-- | This is a helper function to work with the heap in DijkstraState
 putHeap :: Heap p (e, a) -> State (DijkstraState p a e) ()
 putHeap h = do
   (DijkstraState _ distance' path') <- get
   put $ DijkstraState h distance' path'
 
+-- | `initializes` gives the initial state for the State computation.
+-- The time complexity is O(|V|)
 initialize ::
      (Ord a, HeapItem p (e, a), Semiring e)
   => a
@@ -50,6 +55,9 @@ initialize a am =
     (Map.insert a one . Map.map (const zero) $ adjacencyMap am)
     (Map.map (const Nothing) $ adjacencyMap am)
 
+-- | `exploreVertices` is an iterative function which explores all the vertices.
+-- The time complexity is O(|V| * |E|).
+-- O(|E|) is due to the usage of `exploreVertex`.
 exploreVertices ::
      (Ord a, Eq e, HeapItem p (e, a), Semiring e)
   => AdjacencyMap e a
@@ -63,6 +71,8 @@ exploreVertices am = do
       exploreVertex v am
       exploreVertices am
 
+-- | `exploreVertex` explores the edges of a single vertex.
+-- The time complexity is hence O(|E|).
 exploreVertex ::
      (Ord a, Semiring e, Eq e, HeapItem p (e, a))
   => a
@@ -72,6 +82,12 @@ exploreVertex v1 am =
   sequence_ $
   Map.mapWithKey (\v2 e -> exploreEdge e v1 v2) (adjacencyMap am ! v1)
 
+-- | This is a helper function for modifying the weight of an element in the heap.
+-- The current heap library does not provide a way to modify or delete any value.
+-- Hence we first delete the value using the filter function and then we insert the value.
+-- The time complexity of `Heap.filter` if O(|V|).
+-- The time complexity of `Heap.insert` is O(log|V|).
+-- The time complexity of `modifyHeapItemPrio` is O(|V|).
 modifyHeapItemPrio ::
      (HeapItem p (e, a), Eq a) => a -> e -> Heap p (e, a) -> Heap p (e, a)
 modifyHeapItemPrio vertex prio curHeap =
@@ -79,6 +95,9 @@ modifyHeapItemPrio vertex prio curHeap =
   where
     isNot v (_, i) = v /= i
 
+-- | `exploreEdge` takes an edge (v1 -> v2) with weight e.
+-- It computes a new distance value for v2 and changes it in the heap.
+-- The time complexity for this function is O(|V|), this is directly dependent on `modifyHeapItemPrio`.
 exploreEdge ::
      (HeapItem p (e, a), Ord a, Semiring e, Eq e)
   => e

--- a/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
@@ -9,8 +9,25 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 
--- | /O(|V| + |E| * log|V|)/ `dijkstra` is the main function using
--- both `initialize` and `exploreVertices`.
+-- Note:
+-- new |> indicates the new state after the operation above.
+-- old |> indicates the old state before the opration below.
+
+-- | A state that the Dijkstra algorithm defined will work on.
+data DijkstraState a e = DijkstraState
+  { heap :: Set (e, a)
+  , distance :: Map a e
+  , path :: Map a (Maybe a)
+  } deriving (Show)
+
+-- | /O(|V| + |E| * log|V|)/ `dijkstra` is the main function using both `initialize` and `exploreVertices`.
+--
+-- @
+-- dijkstra 'x' (fromList []) = Error as 'x' does not exist in the adjacency map
+--
+-- dijkstra 'a' (fromList [(2, 'b', 'c'), (1, 'a', 'b'), (3, 'a', 'c')])
+-- new |> ([], {'a': 0, 'b': 1, 'c': 3}, {'a': Nothing, 'b': Just 'a', 'c': Just 'b'}
+-- @
 dijkstra ::
      (Ord a, Num e, Ord e)
   => a
@@ -21,14 +38,16 @@ dijkstra a am =
     initialize a am
     exploreVertices am
 
-data DijkstraState a e = DijkstraState
-  { heap :: Set (e, a)
-  , distance :: Map a e
-  , path :: Map a (Maybe a)
-  } deriving (Show)
 
--- | /O(|V|)/ `initialize` gives the initial state for the
--- State computation.
+-- | /O(|V|)/ `initialize` gives the initial state for the State computation.
+--
+-- @
+-- initialize 'x' (fromList [])
+-- new |> ([(0, 'x')], {}, {})
+--
+-- initialize 'x' (fromList [(4, 'a', 'b'), (5, 'c', 'd')])
+-- new |> ([(0, 'x')], {'a': 0, 'b': inf, 'c': inf, 'd': inf}, {'a': Nothing, 'b': Nothing, 'c': Nothing, 'd': Nothing})
+-- @
 initialize ::
      (Ord a, Num e, Ord e)
   => a
@@ -42,6 +61,12 @@ initialize a am =
     (Map.map (const Nothing) $ adjacencyMap am)
 
 -- | /O(|E| * log|V|)/ `exploreVertices` is an iterative function which explores all the vertices.
+--
+-- @
+-- exploreVertices 
+--    | heap != empty == extractMin >> \minElem -> exploreVertex minElem >> exploreVertices
+--    | heap == empty == return ()
+-- @
 exploreVertices ::
      (Ord a, Ord e, Num e)
   => AdjacencyMap (Distance e) a
@@ -57,6 +82,12 @@ exploreVertices am = do
       exploreVertices am
 
 -- | /O(log|V|)/ `exploreVertex` explores the edges of a single vertex.
+-- 
+-- @
+-- exploreVertex 'a' (fromList []) == Error as 'a' does not exist in the adjacency map
+-- exploreVertex 'a' (fromList [(2, 'b', 'c'), (4, 'b', 'a')]) = return ()
+-- exploreVertex 'a' (fromList [(2, 'b', 'c'), (1, 'a', 'b'), (3, 'a', 'c')]) == exploreEdge 1 'a' 'b' >> exploreEdge 3 'a' 'c'
+-- @
 exploreVertex ::
      (Ord a, Ord e, Num e)
   => a
@@ -67,8 +98,21 @@ exploreVertex v1 am =
   Map.mapWithKey (\v2 e -> exploreEdge e v1 v2) (adjacencyMap am ! v1)
 
 -- | /O(log|V|)/ `exploreEdge` takes an edge (v1 -> v2) with weight e.
--- It computes a new distance value for v2 and inserts it in the heap
--- if not explored.
+-- It computes a new distance value for v2 and inserts it in the heap if not explored.
+--
+-- @
+-- old |> ([], {}, {})
+-- exploreEdge 5 'a' 'b'
+-- Error because of (!). 'a' and 'b' don't exist in the distance Map.
+-- 
+-- old |> ([], {'a': 0, 'b': inf}, {'a': Nothing, 'b': Nothing})
+-- exploreEdge 5 'a' 'b'
+-- new |> ([(5, 'b')], {'a': 0, 'b': 5}, {'a': Nothing, 'b': Just 'a'})
+--
+-- old |> ([], {'a': 0, 'b': 4, 'c': 1}, {'a': Nothing, 'b': Just 'c', 'c': Just 'a'})
+-- exploreEdge 5 'a' 'b'
+-- new |> ([], {'a': 0, 'b': 4, 'c': 1}, {'a': Nothing, 'b': Just 'c', 'c': Just 'a'})
+-- @
 exploreEdge ::
      (Ord a, Ord e, Num e)
   => Distance e

--- a/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap/Algorithm/Dijkstra.hs
@@ -1,63 +1,55 @@
 module Algebra.Graph.Labelled.AdjacencyMap.Algorithm.Dijkstra where
 
-import Algebra.Graph.Label (Capacity, Distance, Semiring(..), (<+>), zero)
+import Algebra.Graph.Label (Distance, Semiring(..), (<+>), zero)
 import Algebra.Graph.Labelled.AdjacencyMap.Internal (AdjacencyMap(..))
 import Control.Monad (sequence_, when)
 import Control.Monad.Trans.State.Strict (State, execState, get, gets, put)
-import Data.Heap (FstMaxPolicy, FstMinPolicy, Heap, HeapItem(..))
-import qualified Data.Heap as Heap
 import Data.Map (Map, (!))
 import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
-type DijkstraForDistance a b = DijkstraState FstMinPolicy a (Distance b)
-
-type DijkstraForCapacity a b = DijkstraState FstMaxPolicy a (Capacity b)
-
--- | /O(|V| + |E| * log|V|) `dijkstra` is the main function using
+-- | /O(|V| + |E| * log|V|)/ `dijkstra` is the main function using
 -- both `initialize` and `exploreVertices`.
 dijkstra ::
-     (Eq e, Ord a, HeapItem p (e, a), Semiring e)
+     (Ord a, Num e, Ord e)
   => a
-  -> AdjacencyMap e a
-  -> DijkstraState p a e
+  -> AdjacencyMap (Distance e) a
+  -> DijkstraState a (Distance e)
 dijkstra a am =
-  flip execState (DijkstraState Heap.empty Map.empty Map.empty) $ do
+  flip execState (DijkstraState Set.empty Map.empty Map.empty) $ do
     initialize a am
     exploreVertices am
 
-data DijkstraState p a e = DijkstraState
-  { heap :: Heap p (e, a)
+data DijkstraState a e = DijkstraState
+  { heap :: Set (e, a)
   , distance :: Map a e
   , path :: Map a (Maybe a)
-  }
-
-instance (Show e, Show a) => Show (DijkstraState p a e) where
-  show (DijkstraState _ distance' path') =
-    "distance: " ++ show distance' ++ "\n" ++ "path: " ++ show path'
+  } deriving (Show)
 
 -- | /O(|V|)/ `initialize` gives the initial state for the
 -- State computation.
 initialize ::
-     (Ord a, HeapItem p (e, a), Semiring e)
+     (Ord a, Num e, Ord e)
   => a
-  -> AdjacencyMap e a
-  -> State (DijkstraState p a e) ()
+  -> AdjacencyMap (Distance e) a
+  -> State (DijkstraState a (Distance e)) ()
 initialize a am =
   put $
   DijkstraState
-    (Heap.singleton (one, a))
+    (Set.singleton (one, a))
     (Map.insert a one . Map.map (const zero) $ adjacencyMap am)
     (Map.map (const Nothing) $ adjacencyMap am)
 
 -- | /O(|E| * log|V|)/ `exploreVertices` is an iterative function which explores all the vertices.
 exploreVertices ::
-     (Ord a, Eq e, HeapItem p (e, a), Semiring e)
-  => AdjacencyMap e a
-  -> State (DijkstraState p a e) ()
+     (Ord a, Ord e, Num e)
+  => AdjacencyMap (Distance e) a
+  -> State (DijkstraState a (Distance e)) ()
 exploreVertices am = do
   curHeap <- gets heap
   curS <- get
-  case Heap.view curHeap of
+  case Set.minView curHeap of
     Nothing -> return ()
     (Just ((_, v), t)) -> do
       put $ curS {heap = t}
@@ -66,10 +58,10 @@ exploreVertices am = do
 
 -- | /O(log|V|)/ `exploreVertex` explores the edges of a single vertex.
 exploreVertex ::
-     (Ord a, Semiring e, Eq e, HeapItem p (e, a))
+     (Ord a, Ord e, Num e)
   => a
-  -> AdjacencyMap e a
-  -> State (DijkstraState p a e) ()
+  -> AdjacencyMap (Distance e) a
+  -> State (DijkstraState a (Distance e)) ()
 exploreVertex v1 am =
   sequence_ $
   Map.mapWithKey (\v2 e -> exploreEdge e v1 v2) (adjacencyMap am ! v1)
@@ -78,11 +70,11 @@ exploreVertex v1 am =
 -- It computes a new distance value for v2 and inserts it in the heap
 -- if not explored.
 exploreEdge ::
-     (HeapItem p (e, a), Ord a, Semiring e, Eq e)
-  => e
+     (Ord a, Ord e, Num e)
+  => Distance e
   -> a
   -> a
-  -> State (DijkstraState p a e) ()
+  -> State (DijkstraState a (Distance e)) ()
 exploreEdge e v1 v2 = do
   curHeap <- gets heap
   curDistance <- gets distance
@@ -93,8 +85,6 @@ exploreEdge e v1 v2 = do
   when (newDV2 /= curDV2) $
     put $
     DijkstraState
-      (Heap.insert (newDV2, v2) curHeap)
+      (Set.insert (newDV2, v2) curHeap)
       (Map.insert v2 newDV2 curDistance)
       (Map.insert v2 (Just v1) curPath)
-
-


### PR DESCRIPTION
This is a response to the feedback given to the PR for Generic single source shortest distance. This version is Dijkstra and the running time is similar to that of Dijkstra (O(V + E * log (V)) as we used a priority Heap.

The usage should be like follows:
`dijkstra a am :: DijkstraForDistance Int Int`

There are 2 types alias' defined, DijkstraForDistance and DijkstraForCapacity. One should use these types to get the algorithm working as we used a heap.

I am unable to deduce the heap policy from the semiring. Hence, for any semiring `X` that dijkstra should work on, there needs to be a new type alias `DijkstraForX`.
Maybe I can deduce the heap policy from the semiring using DataKinds or reworking the heap but that seems like overkill.

Please let me know if this kind of usage seems fine. I'll comment and write up the documentation as soon as possible.