### PR TITLE
Basic Acyclic AdjacencyIntMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ cabal.sandbox.config
 cabal.project.local
 ghcid.txt
 .vscode/
+*.swp
+*.swo

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -68,6 +68,7 @@ source-repository head
 library
     hs-source-dirs:     src
     exposed-modules:    Algebra.Graph,
+                        Algebra.Graph.Acyclic.AdjacencyIntMap,
                         Algebra.Graph.AdjacencyIntMap,
                         Algebra.Graph.AdjacencyIntMap.Algorithm,
                         Algebra.Graph.AdjacencyIntMap.Internal,

--- a/src/Algebra/Graph/Acyclic/AdjacencyIntMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyIntMap.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Algebra.Graph.Acyclic.AdjacencyIntMap where
+
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
+import Data.Proxy (Proxy(..))
+import GHC.TypeLits
+
+data Edge (f :: Nat) (t :: Nat) =
+  Edge
+
+newtype AdjacencyIntMap (edgesFollowRule :: Bool) =
+  AM (IntMap IntSet)
+  deriving (Show)
+
+empty :: AdjacencyIntMap 'True
+empty = AM IntMap.empty
+
+singleton :: Int -> AdjacencyIntMap 'True
+singleton x = AM $ IntMap.singleton x IntSet.empty
+
+addEdge ::
+     forall f t. (KnownNat f, KnownNat t)
+  => Edge f t
+  -> AdjacencyIntMap 'True
+  -> AdjacencyIntMap (f <=? t)
+addEdge _ (AM m) =
+  AM $ IntMap.insertWith IntSet.union fI (IntSet.singleton tI) m
+  where
+    fI = fromIntegral . natVal $ (Proxy :: Proxy f)
+    tI = fromIntegral . natVal $ (Proxy :: Proxy t)
+
+-- REPL testing
+graph :: AdjacencyIntMap 'True
+graph =
+  addEdge (Edge :: Edge 5 7) .
+  addEdge (Edge :: Edge 4 5) . addEdge (Edge :: Edge 3 4) $
+  empty

--- a/src/Algebra/Graph/Acyclic/AdjacencyIntMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyIntMap.hs
@@ -7,7 +7,7 @@
 
 module Algebra.Graph.Acyclic.AdjacencyIntMap where
 
-import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NAM
+import qualified Algebra.Graph.AdjacencyIntMap as AIM
 import Data.Proxy (Proxy(..))
 import GHC.TypeLits
 
@@ -15,23 +15,41 @@ data Edge (f :: Nat) (t :: Nat) =
   Edge
 
 newtype AdjacencyIntMap =
-  AM (NAM.AdjacencyMap Int)
+  AM AIM.AdjacencyIntMap
   deriving (Show)
 
+empty :: AdjacencyIntMap
+empty = AM AIM.empty
+
 singleton :: Int -> AdjacencyIntMap
-singleton x = AM $ NAM.vertex x
+singleton x = AM $ AIM.vertex x
 
 edge ::
      forall f t. (KnownNat f, KnownNat t, (f <=? t) ~ 'True)
   => Edge f t
   -> AdjacencyIntMap
-edge _ = AM $ NAM.edge fI tI
+edge _ = AM $ AIM.edge fI tI
   where
     fI = fromIntegral . natVal $ (Proxy :: Proxy f)
     tI = fromIntegral . natVal $ (Proxy :: Proxy t)
 
 overlay :: AdjacencyIntMap -> AdjacencyIntMap -> AdjacencyIntMap
-overlay (AM m1) (AM m2) = AM $ NAM.overlay m1 m2
+overlay (AM m1) (AM m2) = AM $ AIM.overlay m1 m2
+
+edges ::
+     forall f t. (KnownNat f, KnownNat t, (f <=? t) ~ 'True)
+  => [Edge f t]
+  -> AdjacencyIntMap
+edges es = AM . AIM.edges $ map edgeTuple es
+
+edgeTuple ::
+     forall f t. (KnownNat f, KnownNat t, (f <=? t) ~ 'True)
+  => Edge f t
+  -> (Int, Int)
+edgeTuple _ = (fI, tI)
+  where
+    fI = fromIntegral . natVal $ (Proxy :: Proxy f)
+    tI = fromIntegral . natVal $ (Proxy :: Proxy t)
 
 -- REPL testing
 graph :: AdjacencyIntMap


### PR DESCRIPTION
The idea is that there should be no edge from a higher valued vertex to a lower valued vertex. This is the basic edge rule. If the rule breaks there will be a compilation error.
This is the most basic implementation and is open to constructive debate.