### PR TITLE
Disallow inspection-testing 0.4.2

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -147,7 +147,7 @@ test-suite test-alga
     if !impl(ghc >= 8.0)
         build-depends:  semigroups   >= 0.18.2  && < 0.18.4
     if impl(ghc >= 8.0.2)
-        build-depends:  inspection-testing >= 0.4 && < 0.5
+        build-depends:  inspection-testing >= 0.4 && < 0.4.2
 
     default-language:   Haskell2010
     GHC-options:        -Wall


### PR DESCRIPTION
Looks like `inspection-testing-0.4.2` breaks our tests for rewrite rules, so I will disallow it for now.