### PR TITLE
Revise Acyclic.AdjacencyMap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.5
 
+* #203, #215, #223: Add `Acyclic.AdjacencyMap`.
 * #202, #209, #211: Add `induceJust` and `induceJust1`.
 * #208: Add `fromNonEmpty` to `NonEmpty.AdjacencyMap`.
 * #208: Add `fromAdjacencyMap` to `AdjacencyIntMap`.

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -67,7 +67,7 @@ library
     hs-source-dirs:     src
     exposed-modules:    Algebra.Graph,
                         Algebra.Graph.Acyclic.AdjacencyMap,
-                        Algebra.Graph.Acyclic.Ord,
+                        Algebra.Graph.Acyclic.AdjacencyMap.Ord,
                         Algebra.Graph.AdjacencyIntMap,
                         Algebra.Graph.AdjacencyIntMap.Algorithm,
                         Algebra.Graph.AdjacencyMap,

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -31,22 +31,22 @@ module Algebra.Graph.Acyclic.AdjacencyMap (
 
     -- * Graph properties
     isEmpty, hasVertex, hasEdge, vertexCount, edgeCount, vertexList, edgeList,
-    adjacencyList, vertexSet, edgeSet,
+    adjacencyList, vertexSet, edgeSet, preSet, postSet,
 
     -- * Graph transformation
-    removeVertex, removeEdge, transpose, induce,
+    removeVertex, removeEdge, transpose, induce, induceJust,
 
     -- * Graph composition
     box,
 
-    -- * Functions on acyclic graphs
-    topSort,
-
-    -- * Acyclic graph construction methods
-    scc, fromGraph, PartialOrder, toAcyclic, toAcyclicOrd,
-
     -- * Relational operations
     transitiveClosure,
+
+    -- * Algorithms
+    topSort, scc,
+
+    -- * Conversion to acyclic graphs
+    fromGraph, PartialOrder, toAcyclic, toAcyclicOrd,
 
     -- * Miscellaneous
     consistent
@@ -119,9 +119,9 @@ newtype AdjacencyMap a = AAM {
     -- Complexity: /O(1)/ time and memory.
     --
     -- @
-    -- fromAcyclic 'empty'         == AdjacencyMap.'AM.empty'
-    -- fromAcyclic 'vertex'        == AdjacencyMap.'AM.vertex'
-    -- fromAcyclic (1 * 3 * 2)   == AdjacencyMap.'AM.star' 1 [2,3]
+    -- fromAcyclic 'empty'         == 'AM.empty'
+    -- fromAcyclic . 'vertex'      == 'AM.vertex'
+    -- fromAcyclic (1 * 3 * 2)   == 'AM.star' 1 [2,3]
     -- 'AM.vertexCount' . fromAcyclic == 'vertexCount'
     -- 'AM.edgeCount'   . fromAcyclic == 'edgeCount'
     -- 'AM.isAcyclic'   . fromAcyclic == 'const' True
@@ -193,8 +193,11 @@ vertices = coerce AM.vertices
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
 --
 -- @
--- 'vertexSet' (union x y) == Set.'Set.union' (Set.'Set.map' 'Left'              ('vertexSet' x)) (Set.'Set.map' 'Right'               ('vertexSet' y))
--- 'edgeSet'   (union x y) == Set.'Set.union' (Set.'Set.map' ('Data.Bifunctor.bimap' 'Left' 'Left') ('edgeSet'   x)) (Set.'Set.map' ('Data.Bifunctor.bimap' 'Right' 'Right') ('edgeSet'   y))
+-- 'vertexSet' (union x y) == Set.'Set.unions' [ Set.'Set.map' 'Left'  ('vertexSet' x)
+--                                     , Set.'Set.map' 'Right' ('vertexSet' y) ]
+--
+-- 'edgeSet'   (union x y) == Set.'Set.unions' [ Set.'Set.map' ('Data.Bifunctor.bimap' 'Left'  'Left' ) ('edgeSet' x)
+--                                     , Set.'Set.map' ('Data.Bifunctor.bimap' 'Right' 'Right') ('edgeSet' y) ]
 -- @
 union :: (Ord a, Ord b) => AdjacencyMap a -> AdjacencyMap b -> AdjacencyMap (Either a b)
 union (AAM x) (AAM y) = AAM $ AM.overlay (AM.gmap Left x) (AM.gmap Right y)
@@ -203,7 +206,9 @@ union (AAM x) (AAM y) = AAM $ AM.overlay (AM.gmap Left x) (AM.gmap Right y)
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
 --
 -- @
--- 'vertexSet' (join x y) == Set.'Set.union' (Set.'Set.map' 'Left' ('vertexSet' x)) (Set.'Set.map' 'Right' ('vertexSet' y))
+-- 'vertexSet' (join x y) == Set.'Set.unions' [ Set.'Set.map' 'Left'  ('vertexSet' x)
+--                                    , Set.'Set.map' 'Right' ('vertexSet' y) ]
+--
 -- 'edgeSet'   (join x y) == Set.'Set.unions' [ Set.'Set.map' ('Data.Bifunctor.bimap' 'Left'  'Left' ) ('edgeSet' x)
 --                                    , Set.'Set.map' ('Data.Bifunctor.bimap' 'Right' 'Right') ('edgeSet' y)
 --                                    , Set.'Set.map' ('Data.Bifunctor.bimap' 'Left'  'Right') (Set.'Set.cartesianProduct' ('vertexSet' x) ('vertexSet' y)) ]
@@ -224,186 +229,6 @@ join (AAM a) (AAM b) = AAM $ AM.connect (AM.gmap Left a) (AM.gmap Right b)
 -- @
 isSubgraphOf :: Ord a => AdjacencyMap a -> AdjacencyMap a -> Bool
 isSubgraphOf = coerce AM.isSubgraphOf
-
--- | Compute the /condensation/ of a graph, where each vertex
--- corresponds to a /strongly-connected component/ of the original
--- graph. Note that component graphs are non-empty, and are therefore
--- of type "Algebra.Graph.NonEmpty.AdjacencyMap".
---
--- @
--- scc        AdjacencyMap.'AM.empty'            == 'empty'
--- scc        (AdjacencyMap.'AM.vertex' x)       == 'vertex' (NonEmpty.'NonEmpty.vertex' x)
--- scc        (AdjacencyMap.'AM.edge' 1 1)       == 'vertex' (NonEmpty.'NonEmpty.edge' 1 1)
--- 'vertexList' (scc (AdjacencyMap.'AM.edge' 1 2)) == [NonEmpty.'NonEmpty.vertex' 1,NonEmpty.'NonEmpty.vertex' 2]
--- 'edgeList'   (scc (AdjacencyMap.'AM.edge' 1 2)) == [(NonEmpty.'NonEmpty.vertex' 1,NonEmpty.'NonEmpty.vertex' 2)]
--- scc        (AdjacencyMap.'AM.circuit' (1:xs)) == vertex (NonEmpty.'NonEmpty.circuit1' (1 :| xs))
--- 'vertexList' (scc (3 * 1 * 4 * 1 * 5))     == [NonEmpty.'NonEmpty.vertex' 3,NonEmpty.'NonEmpty.vertex' 5,NonEmpty.'NonEmpty.clique1' [1,4,1]]
--- 'edgeList'   (scc (3 * 1 * 4 * 1 * 5))     == [ (NonEmpty.'NonEmpty.vertex' 3,NonEmpty.'NonEmpty.vertex' 5)
---                                             , (NonEmpty.'NonEmpty.vertex' 3,NonEmpty.'NonEmpty.clique1' [1,4,1])
---                                             , (NonEmpty.'NonEmpty.clique1' [1,4,1],NonEmpty.'NonEmpty.vertex' 5)]
--- @
-scc :: (Ord a) => AM.AdjacencyMap a -> AdjacencyMap (NAM.AdjacencyMap a)
-scc = coerce AM.scc
-
--- | Compute the /topological sort/ of a graph.
---
--- @
--- topSort (1)         == [1]
--- topSort (1 * 2 * 3) == [1,2,3]
--- @
-topSort :: (Ord a) => AdjacencyMap a -> [a]
-topSort (AAM am) = Typed.topSort (Typed.fromAdjacencyMap am)
-
--- | Compute the /Cartesian product/ of graphs.
--- Complexity: /O(s1 * s2)/ time, memory and size, where /s1/ and /s2/
--- are the sizes of the given graphs.
---
--- @
--- 'edgeList'   (box (1 * 2) (3 * 4)) == [ ((1,3),(1,4))
---                                     , ((1,3),(2,3))
---                                     , ((1,4),(2,4))
---                                     , ((2,3),(2,4))]
--- 'edgeList'   (box (1 + 2) (3 + 4)) == []
--- 'vertexList' (box (1 + 2) (3 + 4)) == [(1,3),(1,4),(2,3),(2,4)]
--- @
-box :: (Ord a, Ord b) => AdjacencyMap a -> AdjacencyMap b -> AdjacencyMap (a, b)
-box = coerce AM.box
-
--- | Remove a vertex from a given acyclic graph.
--- Complexity: /O(n*log(n))/ time.
---
--- @
--- removeVertex x ('vertex' x)       == 'empty'
--- removeVertex 1 ('vertex' 2)       == 'vertex' 2
--- removeVertex 1 (1 * 2)          == 'vertex' 2
--- removeVertex x . removeVertex x == removeVertex x
--- @
-removeVertex :: Ord a => a -> AdjacencyMap a -> AdjacencyMap a
-removeVertex = coerce AM.removeVertex
-
--- | Remove an edge from a given acyclic graph.
--- Complexity: /O(log(n))/ time.
---
--- @
--- removeEdge 1 2 (1 * 2)          == (1 + 2)
--- removeEdge x y . removeEdge x y == removeEdge x y
--- removeEdge x y . 'removeVertex' x == 'removeVertex' x
--- removeEdge 1 2 (1 * 2 + 3 * 4)  == 1 + 2 + 3 * 4
--- @
-removeEdge :: Ord a => a -> a -> AdjacencyMap a -> AdjacencyMap a
-removeEdge = coerce AM.removeEdge
-
--- | This is a signature for a __Strict Partial Order__.
--- A strict partial order is a binary relation __/R/__ that has three
--- axioms, namely, irreflexive, transitive and asymmetric.
---
---   > a 'R' a == False               (Irreflexive)
---   > a 'R' b and b 'R' c => a 'R' c (Transitive)
--- Some examples of a Strict Partial Order are
--- __\<__ and __\>__.
-type PartialOrder a = a -> a -> Bool
-
--- | Constructs an acyclic graph from any graph based on
--- a strict partial order to produce an acyclic graph.
--- The partial order defines the valid set of edges.
---
--- If the partial order is \< then for any two
--- vertices x and y (x \> y), the only possible edge is (y, x).
--- This will guarantee the production of an acyclic graph since
--- no back edges are possible.
---
--- For example,
--- /fromGraph (\<) (1 \* 2 + 2 \* 1) == 1 \* 2/ because
--- /1 \< 2 == True/ and hence the edge is allowed.
--- /2 \< 1 == False/ and hence the edge is filtered out.
---
--- @
--- fromGraph (<) (2 * 1)         == 1 + 2
--- fromGraph (<) (1 * 2)         == 1 * 2
--- fromGraph (<) (1 * 2 + 2 * 1) == 1 * 2
--- @
-fromGraph :: Ord a => PartialOrder a -> Graph a -> AdjacencyMap a
-fromGraph o = AAM . induceEAM o . foldg AM.empty AM.vertex AM.overlay AM.connect
-
--- | The sorted list of edges of a graph.
--- Complexity: /O(n + m)/ time and /O(m)/ memory.
---
--- @
--- edgeList 'empty'      == []
--- edgeList ('vertex' x) == []
--- edgeList (1 * 2)    == [(1,2)]
--- edgeList (2 * 1)    == []
--- @
-edgeList :: AdjacencyMap a -> [(a, a)]
-edgeList = coerce AM.edgeList
-
--- | The sorted list of vertices of a given graph.
--- Complexity: /O(n)/ time and memory.
---
--- @
--- vertexList 'empty'      == []
--- vertexList ('vertex' x) == [x]
--- vertexList . 'vertices' == 'Data.List.nub' . 'Data.List.sort'
--- @
-vertexList :: AdjacencyMap a -> [a]
-vertexList = coerce AM.vertexList
-
--- | The number of vertices in a graph.
--- Complexity: /O(1)/ time.
---
--- @
--- vertexCount 'empty'             ==  0
--- vertexCount ('vertex' x)        ==  1
--- vertexCount                   ==  'length' . 'vertexList'
--- vertexCount x \< vertexCount y ==> x \< y
--- @
-vertexCount :: AdjacencyMap a -> Int
-vertexCount = coerce AM.vertexCount
-
--- | The number of edges in a graph.
--- Complexity: /O(n)/ time.
---
--- @
--- edgeCount 'empty'      == 0
--- edgeCount ('vertex' x) == 0
--- edgeCount (1 * 2)    == 1
--- edgeCount            == 'length' . 'edgeList'
--- @
-edgeCount :: AdjacencyMap a -> Int
-edgeCount = coerce AM.edgeCount
-
--- | The set of vertices of a given graph.
--- Complexity: /O(n)/ time and memory.
---
--- @
--- vertexSet 'empty'      == Set.'Set.empty'
--- vertexSet . 'vertex'   == Set.'Set.singleton'
--- vertexSet . 'vertices' == Set.'Set.fromList'
--- @
-vertexSet :: AdjacencyMap a -> Set a
-vertexSet = coerce AM.vertexSet
-
--- | The set of edges of a given graph.
--- Complexity: /O((n + m) * log(m))/ time and /O(m)/ memory.
---
--- @
--- edgeSet 'empty'      == Set.'Set.empty'
--- edgeSet ('vertex' x) == Set.'Set.empty'
--- edgeSet (1 * 2)    == Set.'Set.singleton' (1,2)
--- @
-edgeSet :: Eq a => AdjacencyMap a -> Set (a, a)
-edgeSet = coerce AM.edgeSet
-
--- | The sorted /adjacency list/ of a graph.
--- Complexity: /O(n + m)/ time and /O(m)/ memory.
---
--- @
--- adjacencyList 'empty'      == []
--- adjacencyList ('vertex' x) == [(x, [])]
--- adjacencyList (1 * 2)    == [(1, [2]), (2, [])]
--- @
-adjacencyList :: AdjacencyMap a -> [(a, [a])]
-adjacencyList = coerce AM.adjacencyList
 
 -- | Check if a graph is empty.
 -- Complexity: /O(1)/ time.
@@ -442,6 +267,137 @@ hasVertex = coerce AM.hasVertex
 hasEdge :: Ord a => a -> a -> AdjacencyMap a -> Bool
 hasEdge = coerce AM.hasEdge
 
+-- | The number of vertices in a graph.
+-- Complexity: /O(1)/ time.
+--
+-- @
+-- vertexCount 'empty'             ==  0
+-- vertexCount ('vertex' x)        ==  1
+-- vertexCount                   ==  'length' . 'vertexList'
+-- vertexCount x \< vertexCount y ==> x \< y
+-- @
+vertexCount :: AdjacencyMap a -> Int
+vertexCount = coerce AM.vertexCount
+
+-- | The number of edges in a graph.
+-- Complexity: /O(n)/ time.
+--
+-- @
+-- edgeCount 'empty'      == 0
+-- edgeCount ('vertex' x) == 0
+-- edgeCount (1 * 2)    == 1
+-- edgeCount            == 'length' . 'edgeList'
+-- @
+edgeCount :: AdjacencyMap a -> Int
+edgeCount = coerce AM.edgeCount
+
+-- | The sorted list of vertices of a given graph.
+-- Complexity: /O(n)/ time and memory.
+--
+-- @
+-- vertexList 'empty'      == []
+-- vertexList ('vertex' x) == [x]
+-- vertexList . 'vertices' == 'Data.List.nub' . 'Data.List.sort'
+-- @
+vertexList :: AdjacencyMap a -> [a]
+vertexList = coerce AM.vertexList
+
+-- | The sorted list of edges of a graph.
+-- Complexity: /O(n + m)/ time and /O(m)/ memory.
+--
+-- @
+-- edgeList 'empty'       == []
+-- edgeList ('vertex' x)  == []
+-- edgeList (1 * 2)     == [(1,2)]
+-- edgeList (2 * 1)     == []
+-- edgeList . 'transpose' == 'Data.List.sort' . 'map' 'Data.Tuple.swap' . edgeList
+-- @
+edgeList :: AdjacencyMap a -> [(a, a)]
+edgeList = coerce AM.edgeList
+
+-- | The sorted /adjacency list/ of a graph.
+-- Complexity: /O(n + m)/ time and /O(m)/ memory.
+--
+-- @
+-- adjacencyList 'empty'      == []
+-- adjacencyList ('vertex' x) == [(x, [])]
+-- adjacencyList (1 * 2)    == [(1, [2]), (2, [])]
+-- @
+adjacencyList :: AdjacencyMap a -> [(a, [a])]
+adjacencyList = coerce AM.adjacencyList
+
+-- | The set of vertices of a given graph.
+-- Complexity: /O(n)/ time and memory.
+--
+-- @
+-- vertexSet 'empty'      == Set.'Set.empty'
+-- vertexSet . 'vertex'   == Set.'Set.singleton'
+-- vertexSet . 'vertices' == Set.'Set.fromList'
+-- @
+vertexSet :: AdjacencyMap a -> Set a
+vertexSet = coerce AM.vertexSet
+
+-- | The set of edges of a given graph.
+-- Complexity: /O((n + m) * log(m))/ time and /O(m)/ memory.
+--
+-- @
+-- edgeSet 'empty'      == Set.'Set.empty'
+-- edgeSet ('vertex' x) == Set.'Set.empty'
+-- edgeSet (1 * 2)    == Set.'Set.singleton' (1,2)
+-- @
+edgeSet :: Eq a => AdjacencyMap a -> Set (a, a)
+edgeSet = coerce AM.edgeSet
+
+-- | The /preset/ of an element @x@ is the set of its /direct predecessors/.
+-- Complexity: /O(n * log(n))/ time and /O(n)/ memory.
+--
+-- @
+-- preSet x 'empty'          == Set.'Set.empty'
+-- preSet x ('vertex' x)     == Set.'Set.empty'
+-- preSet 1 (1 * 2)        == Set.'Set.empty'
+-- preSet 2 (1 * 2)        == Set.'Set.fromList' [1]
+-- Set.'Set.member' x . preSet x == 'const' False
+-- @
+preSet :: Ord a => a -> AdjacencyMap a -> Set a
+preSet = coerce AM.preSet
+
+-- | The /postset/ of a vertex is the set of its /direct successors/.
+-- Complexity: /O(log(n))/ time and /O(1)/ memory.
+--
+-- @
+-- postSet x 'empty'          == Set.'Set.empty'
+-- postSet x ('vertex' x)     == Set.'Set.empty'
+-- postSet 1 (1 * 2)        == Set.'Set.fromList' [2]
+-- postSet 2 (1 * 2)        == Set.'Set.empty'
+-- Set.'Set.member' x . postSet x == 'const' False
+-- @
+postSet :: Ord a => a -> AdjacencyMap a -> Set a
+postSet = coerce AM.postSet
+
+-- | Remove a vertex from a given acyclic graph.
+-- Complexity: /O(n*log(n))/ time.
+--
+-- @
+-- removeVertex x ('vertex' x)       == 'empty'
+-- removeVertex 1 ('vertex' 2)       == 'vertex' 2
+-- removeVertex 1 (1 * 2)          == 'vertex' 2
+-- removeVertex x . removeVertex x == removeVertex x
+-- @
+removeVertex :: Ord a => a -> AdjacencyMap a -> AdjacencyMap a
+removeVertex = coerce AM.removeVertex
+
+-- | Remove an edge from a given acyclic graph.
+-- Complexity: /O(log(n))/ time.
+--
+-- @
+-- removeEdge 1 2 (1 * 2)          == 'vertices' [1,2]
+-- removeEdge x y . removeEdge x y == removeEdge x y
+-- removeEdge x y . 'removeVertex' x == 'removeVertex' x
+-- removeEdge 1 2 (1 * 2 * 3)      == (1 + 2) * 3
+-- @
+removeEdge :: Ord a => a -> a -> AdjacencyMap a -> AdjacencyMap a
+removeEdge = coerce AM.removeEdge
+
 -- | Transpose a given acyclic graph.
 -- Complexity: /O(m * log(n))/ time, /O(n + m)/ memory.
 --
@@ -460,13 +416,126 @@ transpose = coerce AM.transpose
 -- be evaluated.
 --
 -- @
--- induce ('const' True ) x == x
--- induce ('const' False) x == 'empty'
--- induce (/= x)          == 'removeVertex' x
--- induce p . induce q    == induce (\x -> p x && q x)
+-- induce ('const' True ) x      == x
+-- induce ('const' False) x      == 'empty'
+-- induce (/= x)               == 'removeVertex' x
+-- induce p . induce q         == induce (\x -> p x && q x)
+-- 'isSubgraphOf' (induce p x) x == True
 -- @
 induce :: (a -> Bool) -> AdjacencyMap a -> AdjacencyMap a
 induce = coerce AM.induce
+
+-- | Construct the /induced subgraph/ of a given graph by removing the vertices
+-- that are 'Nothing'.
+-- Complexity: /O(n + m)/ time.
+--
+-- @
+-- induceJust ('vertex' 'Nothing')   == 'empty'
+-- induceJust . 'vertex' . 'Just'    == 'vertex'
+-- 'isSubgraphOf' (induceJust x) x == True
+-- @
+induceJust :: Ord a => AdjacencyMap (Maybe a) -> AdjacencyMap a
+induceJust = coerce AM.induceJust
+
+-- | Compute the /Cartesian product/ of graphs.
+-- Complexity: /O(n * m * log(n)^2)/ time.
+--
+-- @
+-- 'edgeList' (box (1 * 2) (10 * 20)) == [ ((1,10), (1,20))
+--                                     , ((1,10), (2,10))
+--                                     , ((1,20), (2,20))
+--                                     , ((2,10), (2,20)) ]
+-- @
+--
+-- Up to an isomorphism between the resulting vertex types, this operation
+-- is /commutative/ and /associative/, has singleton graphs as /identities/ and
+-- 'empty' as the /annihilating zero/. Below @~~@ stands for the equality up to
+-- an isomorphism, e.g. @(x, ()) ~~ x@.
+--
+-- @
+-- box x y               ~~ box y x
+-- box x (box y z)       ~~ box (box x y) z
+-- box x ('vertex' ())     ~~ x
+-- box x 'empty'           ~~ 'empty'
+-- 'transpose'   (box x y) == box ('transpose' x) ('transpose' y)
+-- 'vertexCount' (box x y) == 'vertexCount' x * 'vertexCount' y
+-- 'edgeCount'   (box x y) <= 'vertexCount' x * 'edgeCount' y + 'edgeCount' x * 'vertexCount' y
+-- @
+box :: (Ord a, Ord b) => AdjacencyMap a -> AdjacencyMap b -> AdjacencyMap (a, b)
+box = coerce AM.box
+
+-- | Compute the /transitive closure/ of a graph.
+-- Complexity: /O(n * m * log(n)^2)/ time.
+--
+-- @
+-- transitiveClosure 'empty'               == 'empty'
+-- transitiveClosure ('vertex' x)          == 'vertex' x
+-- transitiveClosure (1 * 2 + 2 * 3)     == 1 * 2 + 2 * 3 + 1 * 3
+-- transitiveClosure . transitiveClosure == transitiveClosure
+-- @
+transitiveClosure :: Ord a => AdjacencyMap a -> AdjacencyMap a
+transitiveClosure = coerce AM.transitiveClosure
+
+-- | Compute the /topological sort/ of a graph.
+--
+-- @
+-- topSort (1)         == [1]
+-- topSort (1 * 2 * 3) == [1,2,3]
+-- @
+topSort :: (Ord a) => AdjacencyMap a -> [a]
+topSort (AAM am) = Typed.topSort (Typed.fromAdjacencyMap am)
+
+-- | Compute the /condensation/ of a graph, where each vertex
+-- corresponds to a /strongly-connected component/ of the original
+-- graph. Note that component graphs are non-empty, and are therefore
+-- of type "Algebra.Graph.NonEmpty.AdjacencyMap".
+--
+-- @
+-- scc        AdjacencyMap.'AM.empty'            == 'empty'
+-- scc        (AdjacencyMap.'AM.vertex' x)       == 'vertex' (NonEmpty.'NonEmpty.vertex' x)
+-- scc        (AdjacencyMap.'AM.edge' 1 1)       == 'vertex' (NonEmpty.'NonEmpty.edge' 1 1)
+-- 'vertexList' (scc (AdjacencyMap.'AM.edge' 1 2)) == [NonEmpty.'NonEmpty.vertex' 1,NonEmpty.'NonEmpty.vertex' 2]
+-- 'edgeList'   (scc (AdjacencyMap.'AM.edge' 1 2)) == [(NonEmpty.'NonEmpty.vertex' 1,NonEmpty.'NonEmpty.vertex' 2)]
+-- scc        (AdjacencyMap.'AM.circuit' (1:xs)) == vertex (NonEmpty.'NonEmpty.circuit1' (1 :| xs))
+-- 'vertexList' (scc (3 * 1 * 4 * 1 * 5))     == [NonEmpty.'NonEmpty.vertex' 3,NonEmpty.'NonEmpty.vertex' 5,NonEmpty.'NonEmpty.clique1' [1,4,1]]
+-- 'edgeList'   (scc (3 * 1 * 4 * 1 * 5))     == [ (NonEmpty.'NonEmpty.vertex' 3,NonEmpty.'NonEmpty.vertex' 5)
+--                                             , (NonEmpty.'NonEmpty.vertex' 3,NonEmpty.'NonEmpty.clique1' [1,4,1])
+--                                             , (NonEmpty.'NonEmpty.clique1' [1,4,1],NonEmpty.'NonEmpty.vertex' 5)]
+-- @
+scc :: (Ord a) => AM.AdjacencyMap a -> AdjacencyMap (NAM.AdjacencyMap a)
+scc = coerce AM.scc
+
+-- | This is a signature for a __Strict Partial Order__.
+-- A strict partial order is a binary relation __/R/__ that has three
+-- axioms, namely, irreflexive, transitive and asymmetric.
+--
+--   > a 'R' a == False               (Irreflexive)
+--   > a 'R' b and b 'R' c => a 'R' c (Transitive)
+-- Some examples of a Strict Partial Order are
+-- __\<__ and __\>__.
+type PartialOrder a = a -> a -> Bool
+
+-- | Constructs an acyclic graph from any graph based on
+-- a strict partial order to produce an acyclic graph.
+-- The partial order defines the valid set of edges.
+--
+-- If the partial order is \< then for any two
+-- vertices x and y (x \> y), the only possible edge is (y, x).
+-- This will guarantee the production of an acyclic graph since
+-- no back edges are possible.
+--
+-- For example,
+-- /fromGraph (\<) (1 \* 2 + 2 \* 1) == 1 \* 2/ because
+-- /1 \< 2 == True/ and hence the edge is allowed.
+-- /2 \< 1 == False/ and hence the edge is filtered out.
+--
+-- @
+-- fromGraph (<) (2 * 1)         == 1 + 2
+-- fromGraph (<) (1 * 2)         == 1 * 2
+-- fromGraph (<) (1 * 2 + 2 * 1) == 1 * 2
+-- @
+fromGraph :: Ord a => PartialOrder a -> Graph a -> AdjacencyMap a
+fromGraph o = AAM . induceEAM o . foldg AM.empty AM.vertex AM.overlay AM.connect
 
 -- | If possible, construct a graph of type Acyclic.AdjacencyMap
 -- from a graph of type AdjacencyMap. If the input graph is contains
@@ -515,18 +584,6 @@ induceEAM p m = AM.fromAdjacencySets
 -- @
 toAcyclicOrd :: Ord a => AM.AdjacencyMap a -> AdjacencyMap a
 toAcyclicOrd = AAM . induceEAM (<)
-
--- | Compute the /transitive closure/ of a graph.
--- Complexity: /O(n * m * log(n)^2)/ time.
---
--- @
--- transitiveClosure 'empty'               == 'empty'
--- transitiveClosure ('vertex' x)          == 'vertex' x
--- transitiveClosure (1 * 2 + 2 * 3)     == 1 * 2 + 2 * 3 + 1 * 3
--- transitiveClosure . transitiveClosure == transitiveClosure
--- @
-transitiveClosure :: Ord a => AdjacencyMap a -> AdjacencyMap a
-transitiveClosure = coerce AM.transitiveClosure
 
 -- | Check if the internal graph representation is consistent,
 -- i.e. that all edges refer to existing vertices and the graph

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap/Ord.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap/Ord.hs
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------
 -- |
--- Module     : Algebra.Graph.Acyclic.Ord
+-- Module     : Algebra.Graph.Acyclic.AdjacencyMap.Ord
 -- License    : MIT (see the file LICENSE)
 -- Stability  : experimental
 --
@@ -8,35 +8,32 @@
 -- in Haskell. See <https://github.com/snowleopard/alga-paper this paper> for the
 -- motivation behind the library, the underlying theory, and implementation details.
 --
--- This module defines functions which guarantee Acyclic graph by
--- establishing an invariant on the edges.
--- An edge (x, y) exists if and only if x < y. This way no back
--- edges are formed and hence making a cyclic graph is impossible.
+-- This module provides convenient functions for constructing acyclic graphs by
+-- keeping only edges @(x,y)@ where @x < y@ according to the supplied 'Ord' @a@
+-- instance. This module can be imported qualified to avoid confusion with the
+-- modules "Algebra.Graph.AdjacencyMap" and "Algebra.Graph.Acyclic.AdjacencyMap":
+--
+-- @
+-- import qualified Algebra.Graph.Acyclic.AdjacencyMap.Ord as Acyclic.Ord
+-- @
 ----------------------------------------------------------------
-module Algebra.Graph.Acyclic.Ord (
-    -- * Graph construction primitives
-    edge, overlay, connect, edges, overlays, connects,
-
-    -- * Graph transformation
-    replaceVertex, mergeVertices, gmap,
+module Algebra.Graph.Acyclic.AdjacencyMap.Ord (
+    -- * Basic graph construction primitives
+    edge, overlay, connect, edges, overlays, connects
     ) where
 
 import Algebra.Graph.Acyclic.AdjacencyMap
+
 import qualified Algebra.Graph.AdjacencyMap as AM
-import Data.Function (on)
 
 -- | Construct the graph comprising /a single edge/.
 -- Complexity: /O(1)/ time, memory.
 --
 -- @
 -- edge x y               == 'connect' ('vertex' x) ('vertex' y)
+-- 'hasEdge' 1 1 (edge 1 1) == False
 -- 'hasEdge' 1 2 (edge 1 2) == True
 -- 'hasEdge' 2 1 (edge 2 1) == False
--- 'edgeCount'   (edge 1 2) == 1
--- 'edgeCount'   (edge 2 1) == 0
--- 'vertexCount' (edge 1 1) == 1
--- 'vertexCount' (edge 1 2) == 2
--- 'vertexCount' (edge 2 1) == 2
 -- @
 edge :: Ord a => a -> a -> AdjacencyMap a
 edge x y = toAcyclicOrd (AM.edge x y)
@@ -56,7 +53,7 @@ edge x y = toAcyclicOrd (AM.edge x y)
 -- 'edgeCount'   (overlay 1 2) == 0
 -- @
 overlay :: Ord a => AdjacencyMap a -> AdjacencyMap a -> AdjacencyMap a
-overlay x y = toAcyclicOrd $ (AM.overlay `on` fromAcyclic) x y
+overlay x y = toAcyclicOrd $ AM.overlay (fromAcyclic x) (fromAcyclic y)
 
 -- | /Connect/ two graphs. This is an associative operation with the identity
 -- 'empty', which distributes over 'overlay' and obeys the decomposition axiom.
@@ -77,7 +74,7 @@ overlay x y = toAcyclicOrd $ (AM.overlay `on` fromAcyclic) x y
 -- 'edgeCount'   (connect 2 1) == 0
 -- @
 connect :: Ord a => AdjacencyMap a -> AdjacencyMap a -> AdjacencyMap a
-connect x y = toAcyclicOrd $ (AM.connect `on` fromAcyclic) x y
+connect x y = toAcyclicOrd $ AM.connect (fromAcyclic x) (fromAcyclic y)
 
 -- | Construct the graph from a list of edges.
 -- Complexity: /O((n + m) * log(n))/ time and /O(n + m)/ memory.
@@ -116,50 +113,3 @@ overlays = toAcyclicOrd . AM.overlays . map fromAcyclic
 -- @
 connects :: Ord a => [AdjacencyMap a] -> AdjacencyMap a
 connects = toAcyclicOrd . AM.connects . map fromAcyclic
-
--- | The function @'replaceVertex' x y@ replaces vertex @x@ with 
--- vertex @y@ in a given 'AdjacencyMap'. All the edges are filtered
--- for the invariant to hold true.
--- If @y@ already exists, @x@ and @y@ will be merged.
--- Complexity: /O((n + m) * log(n))/ time.
---
--- @
--- replaceVertex x x            == id
--- replaceVertex x y ('vertex' x) == 'vertex' y
--- replaceVertex x y            == 'mergeVertices' (== x) y
--- replaceVertex 1 2 (1 * 3)    == 2 * 3
--- replaceVertex 1 4 (1 * 3)    == 4 + 3
--- @
-replaceVertex :: Ord a => a -> a -> AdjacencyMap a -> AdjacencyMap a
-replaceVertex u v = gmap $ \w -> if w == u then v else w
-
--- | Merge vertices satisfying a given predicate into a given vertex
--- keeping the invariant true.
--- Complexity: /O((n + m) * log(n))/ time, assuming that the predicate takes
--- /O(1)/ to be evaluated.
---
--- @
--- mergeVertices ('const' False) x        == id
--- mergeVertices (== x) y               == 'replaceVertex' x y
--- mergeVertices 'even' 1 (0 * 2)         == 1
--- mergeVertices 'odd'  1 (3 + 4 * 5)     == 4 + 1
--- mergeVertices 'even' 1 (2 * 3 + 4 * 5) == 1 * 3 + 1 * 5
--- @
-mergeVertices :: Ord a => (a -> Bool) -> a -> AdjacencyMap a -> AdjacencyMap a
-mergeVertices p v = gmap $ \u -> if p u then v else u
-
--- | Transform a graph by applying a function to each of its
--- vertices without breaking the edge invariant.
--- Complexity: /O((n + m) * log(n))/ time.
---
--- @
--- gmap f 'empty'                   == 'empty'
--- gmap f ('vertex' x)              == 'vertex' (f x)
--- 'vertexList' (gmap f ('edge' x y)) == 'vertexList' ('edge' (f x) (f y))
--- 'edgeCount'  (gmap f ('edge' x y)) <= 'edgeCount' ('edge' (f x) (f y))
--- gmap 'id'                        == 'id'
--- 'vertexList' . gmap f . gmap g   == 'vertexList' . gmap (f . g)
--- 'edgeCount' (gmap f (gmap g x))  <= 'edgeCount' (gmap (f . g) x)
--- @
-gmap :: (Ord a, Ord b) => (a -> b) -> AdjacencyMap a -> AdjacencyMap b
-gmap f = toAcyclicOrd . AM.gmap f . fromAcyclic

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap/Ord.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap/Ord.hs
@@ -1,8 +1,11 @@
------------------------------------------------------------------
+-----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Acyclic.AdjacencyMap.Ord
+-- Copyright  : (c) Andrey Mokhov 2016-2019
 -- License    : MIT (see the file LICENSE)
+-- Maintainer : andrey.mokhov@gmail.com
 -- Stability  : experimental
+--
 --
 -- __Alga__ is a library for algebraic construction and manipulation of graphs
 -- in Haskell. See <https://github.com/snowleopard/alga-paper this paper> for the
@@ -16,7 +19,7 @@
 -- @
 -- import qualified Algebra.Graph.Acyclic.AdjacencyMap.Ord as Acyclic.Ord
 -- @
-----------------------------------------------------------------
+-----------------------------------------------------------------------------
 module Algebra.Graph.Acyclic.AdjacencyMap.Ord (
     -- * Basic graph construction primitives
     edge, overlay, connect, edges, overlays, connects

--- a/src/Algebra/Graph/AdjacencyIntMap.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap.hs
@@ -754,7 +754,7 @@ gmap f = AM . IntMap.map (IntSet.map f) . IntMap.mapKeysWith IntSet.union f . ad
 
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
--- Complexity: /O(m)/ time, assuming that the predicate takes /O(1)/ to
+-- Complexity: /O(n + m)/ time, assuming that the predicate takes /O(1)/ to
 -- be evaluated.
 --
 -- @

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -487,7 +487,7 @@ adjacencyList = map (fmap Set.toAscList) . Map.toAscList . adjacencyMap
 -- preSet 1 ('edge' 1 2) == Set.'Set.empty'
 -- preSet y ('edge' x y) == Set.'Set.fromList' [x]
 -- @
-preSet :: Ord a => a -> AdjacencyMap a -> Set.Set a
+preSet :: Ord a => a -> AdjacencyMap a -> Set a
 preSet x = Set.fromAscList . map fst . filter p  . Map.toAscList . adjacencyMap
   where
     p (_, set) = x `Set.member` set
@@ -804,6 +804,7 @@ compose x y = fromAdjacencySets
 --                                       , ((0,\'b\'), (1,\'b\'))
 --                                       , ((1,\'a\'), (1,\'b\')) ]
 -- @
+--
 -- Up to an isomorphism between the resulting vertex types, this operation
 -- is /commutative/, /associative/, /distributes/ over 'overlay', has singleton
 -- graphs as /identities/ and 'empty' as the /annihilating zero/. Below @~~@

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -96,15 +96,13 @@ The 'Eq' instance satisfies all axioms of algebraic graphs:
         >       x + y == y + x
         > x + (y + z) == (x + y) + z
 
-    * 'connect' is associative and has
-    'empty' as the identity:
+    * 'connect' is associative and has 'empty' as the identity:
 
         >   x * empty == x
         >   empty * x == x
         > x * (y * z) == (x * y) * z
 
-    * 'connect' distributes over
-    'overlay':
+    * 'connect' distributes over 'overlay':
 
         > x * (y + z) == x * y + x * z
         > (x + y) * z == x * z + y * z
@@ -115,8 +113,7 @@ The 'Eq' instance satisfies all axioms of algebraic graphs:
 
 The following useful theorems can be proved from the above set of axioms.
 
-    * 'overlay' has 'empty'
-    as the identity and is idempotent:
+    * 'overlay' has 'empty' as the identity and is idempotent:
 
         >   x + empty == x
         >   empty + x == x
@@ -146,9 +143,8 @@ Here are a few examples:
 'edge' 1 2 < 'edge' 1 1 + 'edge' 2 2
 'edge' 1 2 < 'edge' 1 3@
 
-Note that the resulting order refines the 'isSubgraphOf'
-relation and is compatible with 'overlay' and
-'connect' operations:
+Note that the resulting order refines the 'isSubgraphOf' relation and is
+compatible with 'overlay' and 'connect' operations:
 
 @'isSubgraphOf' x y ==> x <= y@
 
@@ -180,9 +176,9 @@ instance (Ord a, Show a) => Show (AdjacencyMap a) where
         | null vs    = showString "empty"
         | null es    = showParen (p > 10) $ vshow vs
         | vs == used = showParen (p > 10) $ eshow es
-        | otherwise  = showParen (p > 10) $
-                           showString "overlay (" . vshow (vs \\ used) .
-                           showString ") (" . eshow es . showString ")"
+        | otherwise  = showParen (p > 10) $ showString "overlay ("
+                     . vshow (vs \\ used) . showString ") ("
+                     . eshow es . showString ")"
       where
         vs             = vertexList am
         es             = edgeList am

--- a/src/Algebra/Graph/AdjacencyMap.hs
+++ b/src/Algebra/Graph/AdjacencyMap.hs
@@ -738,7 +738,7 @@ gmap f = AM . Map.map (Set.map f) . Map.mapKeysWith Set.union f . adjacencyMap
 
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
--- Complexity: /O(m)/ time, assuming that the predicate takes /O(1)/ to
+-- Complexity: /O(n + m)/ time, assuming that the predicate takes /O(1)/ to
 -- be evaluated.
 --
 -- @

--- a/src/Algebra/Graph/Label.hs
+++ b/src/Algebra/Graph/Label.hs
@@ -471,8 +471,8 @@ instance (Eq o, Dioid a, Dioid o) => Dioid (Optimum o a) where
 -- | A /path/ is a list of edges.
 type Path a = [(a, a)]
 
--- | The 'Optimum' semiring specialised to /finding the lexicographically
--- smallest shortest path/.
+-- | The 'Optimum' semiring specialised to
+-- /finding the lexicographically smallest shortest path/.
 type ShortestPath e a = Optimum (Distance e) (Minimum (Path a))
 
 -- | The 'Optimum' semiring specialised to /finding all shortest paths/.
@@ -481,6 +481,6 @@ type AllShortestPaths e a = Optimum (Distance e) (PowerSet (Path a))
 -- | The 'Optimum' semiring specialised to /counting all shortest paths/.
 type CountShortestPaths e a = Optimum (Distance e) (Count Integer)
 
--- | The 'Optimum' semiring specialised to /finding the lexicographically
--- smallest widest path/.
+-- | The 'Optimum' semiring specialised to
+-- /finding the lexicographically smallest widest path/.
 type WidestPath e a = Optimum (Capacity e) (Minimum (Path a))

--- a/src/Algebra/Graph/Labelled/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap.hs
@@ -585,7 +585,7 @@ emap h = AM . trimZeroes . Map.map (Map.map h) . adjacencyMap
 
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
--- Complexity: /O(m)/ time, assuming that the predicate takes /O(1)/ to
+-- Complexity: /O(n + m)/ time, assuming that the predicate takes /O(1)/ to
 -- be evaluated.
 --
 -- @

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE ViewPatterns #-}
--------------------------------------------------------------
+-----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Test.Acyclic.AdjacencyMap
+-- Copyright  : (c) Andrey Mokhov 2016-2019
+-- License    : MIT (see the file LICENSE)
+-- Maintainer : andrey.mokhov@gmail.com
 -- Stability  : experimental
 --
 -- Testsuite for "Algebra.Graph.Acyclic.AdjacencyMap".
--------------------------------------------------------------
-
-module Algebra.Graph.Test.Acyclic.AdjacencyMap (
-  testAcyclicAdjacencyMap 
-  ) where
+-----------------------------------------------------------------------------
+module Algebra.Graph.Test.Acyclic.AdjacencyMap (testAcyclicAdjacencyMap) where
 
 import Algebra.Graph.Acyclic.AdjacencyMap
 import Algebra.Graph.Acyclic.Ord
@@ -65,7 +65,7 @@ testAcyclicAdjacencyMap = do
         toAcyclicOrd (1 * 2 + 2 * 1 :: AI) == 1 * 2
   test "toAcyclicOrd                       == fromGraph (<) . toGraph" $ \x ->
         toAcyclicOrd (x :: AI)             == (fromGraph (<) . toGraph $ x)
-  
+
   putStrLn "\n=====AcyclicAdjacencyMap fromAcyclic====="
 
   test "fromAcyclic (1 * 2 + 3 * 4)                 == AM.edges [(1,2), (3,4)]" $
@@ -96,10 +96,10 @@ testAcyclicAdjacencyMap = do
         consistent (1 * 2 + 2 * 3 :: AAI) == True
 
   putStrLn "\n=====AcyclicAdjacencyMap Num instance====="
-  test "edgeList    0                 == []" $
-        edgeList   (0 :: AAI)         == []
-  test "vertexList  0                 == [0]" $
-        vertexList (0 :: AAI)         == [0]
+  test "vertexList  1                 == [1]" $
+        vertexList (1 :: AAI)         == [1]
+  test "edgeList    1                 == []" $
+        edgeList   (1 :: AAI)         == []
   test "edgeList   (1 + 2)            == []" $
         edgeList   (1 + 2 :: AAI)     == []
   test "vertexList (1 + 2)            == [1,2]" $
@@ -121,10 +121,10 @@ testAcyclicAdjacencyMap = do
 
   test "isEmpty 'empty'                                  == True" $
         isEmpty (empty :: AAI)                           == True
-  test "isEmpty ('disjointOverlay' 'empty' 'empty')             == True" $
-        isEmpty (disjointOverlay (empty :: AAI) (empty :: AAI)) == True
   test "isEmpty ('vertex' x)                             == False" $ \x ->
         isEmpty (vertex x :: AAI)                        == False
+  test "isEmpty ('disjointOverlay' 'empty' 'empty')             == True" $
+        isEmpty (disjointOverlay (empty :: AAI) (empty :: AAI)) == True
   test "isEmpty ('removeVertex' x $ 'vertex' x)          == True" $ \x ->
         isEmpty (removeVertex x $ vertex x :: AAI)       == True
   test "isEmpty ('removeEdge' 1 2 $ 1 * 2)               == False" $
@@ -390,8 +390,8 @@ testAcyclicOrd = do
   test "overlays" $ \x                     -> consistent (overlays x :: AAI)
   test "connects" $ \x                     -> consistent (connects x :: AAI)
   test "replaceVertex" $ \x y z            -> consistent (replaceVertex x y z :: AAI)
-  test "mergeVertices" $ \(apply -> p) v x -> consistent (mergeVertices p v x :: AAI) 
-  test "gmap" $ \(apply -> f) x            -> consistent (gmap f (x :: AAI) :: AAI) 
+  test "mergeVertices" $ \(apply -> p) v x -> consistent (mergeVertices p v x :: AAI)
+  test "gmap" $ \(apply -> f) x            -> consistent (gmap f (x :: AAI) :: AAI)
 
   putStrLn "\n=====AcyclicOrd edge====="
 

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -524,26 +524,14 @@ testAcyclicAdjacencyMap = do
     test "edge x y               == connect (vertex x) (vertex y)" $ \x y ->
           (edge x y :: AAI)      == connect (vertex x) (vertex y)
 
+    test "hasEdge 1 1 (edge 1 1) == False" $
+          hasEdge 1 1 (edge 1 1 :: AAI) == False
+
     test "hasEdge 1 2 (edge 1 2) == True" $
           hasEdge 1 2 (edge 1 2 :: AAI) == True
 
     test "hasEdge 2 1 (edge 2 1) == False" $
           hasEdge 2 1 (edge 2 1 :: AAI) == False
-
-    test "edgeCount   (edge 1 2) == 1" $
-          edgeCount   (edge 1 2 :: AAI) == 1
-
-    test "edgeCount   (edge 2 1) == 0" $
-          edgeCount   (edge 2 1 :: AAI) == 0
-
-    test "vertexCount (edge 1 1) == 1" $
-          vertexCount (edge 1 1 :: AAI) == 1
-
-    test "vertexCount (edge 1 2) == 2" $
-          vertexCount (edge 1 2 :: AAI) == 2
-
-    test "vertexCount (edge 2 1) == 2" $
-          vertexCount (edge 2 1 :: AAI) == 2
 
     putStrLn "\n============ Acyclic.AdjacencyMap.Ord.overlay ============"
     test "isEmpty     (overlay x y) == isEmpty x && isEmpty y" $ \x y ->

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedLists, ViewPatterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Test.Acyclic.AdjacencyMap
@@ -13,523 +13,661 @@ module Algebra.Graph.Test.Acyclic.AdjacencyMap (testAcyclicAdjacencyMap) where
 
 import Algebra.Graph.Acyclic.AdjacencyMap
 import Algebra.Graph.Acyclic.Ord
+import Algebra.Graph.Internal
 import Algebra.Graph.Test
-import Algebra.Graph.ToGraph (ToGraph (toGraph))
-import Data.List.NonEmpty hiding (transpose, filter, length)
+import Algebra.Graph.Test.Generic
 
-import qualified Algebra.Graph.AdjacencyMap as AM
-import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NonEmpty
-import qualified Data.List as List
-import qualified Data.Set as Set
-import qualified Data.Tuple as Tuple
+import Data.Bifunctor
+import Data.Maybe
+import Data.Tuple
+
+import qualified Algebra.Graph.AdjacencyMap           as AM
+import qualified Algebra.Graph.AdjacencyMap.Algorithm as AM
+import qualified Algebra.Graph.NonEmpty.AdjacencyMap  as NonEmpty
+import qualified Data.List                            as List
+import qualified Data.Set                             as Set
 
 type AAI = AdjacencyMap Int
-type AAE = AdjacencyMap (Either Int Int)
-type AAT = AdjacencyMap (Int, Int)
-type AI = AM.AdjacencyMap Int
+type AI  = AM.AdjacencyMap Int
 
 -- TODO: Switch to using generic tests.
 testAcyclicAdjacencyMap :: IO ()
 testAcyclicAdjacencyMap = do
-  testAcyclicOrd
-
-  putStrLn "\n=====AcyclicAdjacencyMap Show====="
-
-  test "show empty              == \"fromMaybe empty . toAcyclic $ empty\"" $
-        show (empty :: AAI)     == "fromMaybe empty . toAcyclic $ empty"
-  test "show 1                  == \"fromMaybe empty . toAcyclic $ vertex 1\"" $
-        show (1 :: AAI)         == "fromMaybe empty . toAcyclic $ vertex 1"
-  test "show (1 + 2)            == \"fromMaybe empty . toAcyclic $ vertices [1,2]\"" $
-        show (1 + 2 :: AAI)     == "fromMaybe empty . toAcyclic $ vertices [1,2]"
-  test "show (1 * 2)            == \"fromMaybe empty . toAcyclic $ edge 1 2\"" $
-        show (1 * 2 :: AAI)     == "fromMaybe empty . toAcyclic $ edge 1 2"
-  test "show (1 * 2 * 3)        == \"fromMaybe empty . toAcyclic $ edges [(1,2),(1,3),(2,3)]\"" $
-        show (1 * 2 * 3 :: AAI) == "fromMaybe empty . toAcyclic $ edges [(1,2),(1,3),(2,3)]"
-  test "show (1 * 2 + 3)        == \"fromMaybe empty . toAcyclic $ overlay (vertex 3) (edge 1 2)\"" $
-        show (1 * 2 + 3 :: AAI) == "fromMaybe empty . toAcyclic $ overlay (vertex 3) (edge 1 2)"
-
-  putStrLn "\n=====AcyclicAdjacencyMap toAcyclic====="
-
-  test "toAcyclic (AdjacencyMap.'AM.path' [1, 2, 1]) == Nothing" $
-        toAcyclic (AM.path [1, 2, 1] :: AI)          == Nothing
-  test "toAcyclic (AdjacencyMap.'AM.path' [1, 2, 3]) == Just (1 * 2 + 2 * 3)" $
-        toAcyclic (AM.path [1, 2, 3] :: AI)          == Just (1 * 2 + 2 * 3)
-
-  putStrLn "\n=====AcyclicAdjacencyMap toAcyclicOrd====="
-
-  test "toAcyclicOrd (2 * 1)               == 1 + 2" $
-        toAcyclicOrd (2 * 1 :: AI)         == 1 + 2
-  test "toAcyclicOrd (1 * 2)               == 1 * 2" $
-        toAcyclicOrd (1 * 2 :: AI)         == 1 * 2
-  test "toAcyclicOrd (1 * 2 + 2 * 1)       == 1 * 2" $
-        toAcyclicOrd (1 * 2 + 2 * 1 :: AI) == 1 * 2
-  test "toAcyclicOrd                       == fromGraph (<) . toGraph" $ \x ->
-        toAcyclicOrd (x :: AI)             == (fromGraph (<) . toGraph $ x)
-
-  putStrLn "\n=====AcyclicAdjacencyMap fromAcyclic====="
-
-  test "fromAcyclic (1 * 2 + 3 * 4)                 == AM.edges [(1,2), (3,4)]" $
-        fromAcyclic (1 * 2 + 3 * 4 :: AAI)          == AM.edges [(1,2), (3,4)]
-  test "AM.vertexCount  . fromAcyclic               == vertexCount" $ \x ->
-        (AM.vertexCount . fromAcyclic $ (x :: AAI)) == vertexCount x
-  test "AM.edgeCount    . fromAcyclic               == edgeCount" $ \x ->
-        (AM.edgeCount   . fromAcyclic $ (x :: AAI)) == edgeCount x
-
-  putStrLn "\n=====AcyclicAdjacencyMap consistency====="
-
-  test "arbitraryAcyclicAdjacencyMap" $ \x -> consistent (x :: AAI)
-  test "empty" $                              consistent (empty :: AAI)
-  test "vertex" $ \x                       -> consistent (vertex x :: AAI)
-  test "union" $ \x y                      -> consistent (union x y :: AAE)
-  test "join" $ \x y                       -> consistent (join x y :: AAE)
-  test "vertices" $ \x                     -> consistent (vertices x :: AAI)
-  test "box" $ \x y                        -> consistent (box x y :: AAT)
-  test "transitiveClosure" $ \x            -> consistent (transitiveClosure x :: AAI)
-  test "transpose" $ \x                    -> consistent (transpose x :: AAI)
-  test "fromGraph (<)" $ \x                -> consistent (fromGraph (<) x :: AAI)
-  test "fromGraph (>)" $ \x                -> consistent (fromGraph (>) x :: AAI)
-  test "toAcyclicOrd" $ \x                 -> consistent (toAcyclicOrd x :: AAI)
-
-  test "consistent (1 + 2)                == True" $
-        consistent (1 + 2 :: AAI)         == True
-  test "consistent (1 * 2 + 2 * 3)        == True" $
-        consistent (1 * 2 + 2 * 3 :: AAI) == True
-
-  putStrLn "\n=====AcyclicAdjacencyMap Num instance====="
-  test "vertexList  1                 == [1]" $
-        vertexList (1 :: AAI)         == [1]
-  test "edgeList    1                 == []" $
-        edgeList   (1 :: AAI)         == []
-  test "edgeList   (1 + 2)            == []" $
-        edgeList   (1 + 2 :: AAI)     == []
-  test "vertexList (1 + 2)            == [1,2]" $
-        vertexList (1 + 2 :: AAI)     == [1,2]
-  test "edgeList   (1 * 2)            == [(1,2)]" $
-        edgeList   (1 * 2 :: AAI)     == [(1,2)]
-  test "vertexList (1 * 2)            == [1,2]" $
-        vertexList (1 * 2 :: AAI)     == [1,2]
-  test "edgeList   (1 + 2 * 3)        == [(2,3)]" $
-        edgeList   (1 + 2 * 3 :: AAI) == [(2,3)]
-  test "vertexList (1 + 2 * 3)        == [1,2,3]" $
-        vertexList (1 + 2 * 3 :: AAI) == [1,2,3]
-  test "edgeList   (1 * 2 + 3)        == [(1,2)]" $
-        edgeList   (1 * 2 + 3 :: AAI) == [(1,2)]
-  test "vertexList (1 * 2 + 3)        == [1,2,3]" $
-        vertexList (1 * 2 + 3 :: AAI) == [1,2,3]
-
-  putStrLn "\n=====AcyclicAdjacencyMap construction primitives====="
-
-  test "isEmpty 'empty'                                  == True" $
-        isEmpty (empty :: AAI)                           == True
-  test "isEmpty ('vertex' x)                             == False" $ \x ->
-        isEmpty (vertex x :: AAI)                        == False
-  test "isEmpty ('union' 'empty' 'empty')                == True" $
-        isEmpty (union (empty :: AAI) (empty :: AAI))    == True
-  test "isEmpty ('removeVertex' x $ 'vertex' x)          == True" $ \x ->
-        isEmpty (removeVertex x $ vertex x :: AAI)       == True
-  test "isEmpty ('removeEdge' 1 2 $ 1 * 2)               == False" $
-        isEmpty (removeEdge 1 2 $ 1 * 2 :: AAI)          == False
-
-  test "'isEmpty'     (vertex x)        == False" $ \x ->
-         isEmpty      (vertex x :: AAI) == False
-  test "'hasVertex' x (vertex x)        == True" $ \x ->
-         hasVertex x  (vertex x :: AAI) == True
-  test "'vertexCount' (vertex x)        == 1" $ \x ->
-         vertexCount  (vertex x :: AAI) == 1
-  test "'edgeCount'   (vertex x)        == 0" $ \x ->
-         edgeCount    (vertex x :: AAI) == 0
-
-  test "vertices []                       == 'empty'" $
-        vertices []                       == (empty :: AAI)
-  test "vertices [x]                      == 'vertex' x" $ \x ->
-        vertices [x]                      == (vertex x :: AAI)
-  test "'hasVertex' x . vertices          == 'elem' x" $ \x y ->
-        (hasVertex x (vertices y :: AAI)) == elem x y
-  test "'vertexCount' . vertices          == 'length' . 'Data.List.nub'" $ \x ->
-        (vertexCount (vertices x :: AAI)) == (List.length . List.nub $ x)
-  test "'vertexSet'   . vertices          == Set.'Set.fromList'" $ \x ->
-        (vertexSet (vertices x :: AAI))   == Set.fromList x
-
-  test "'isEmpty' (union x y)                  == 'isEmpty' x && 'isEmpty' y" $ \x y ->
-        isEmpty (union x y :: AAE)             == (isEmpty x && isEmpty y)
-  test "'hasVertex' (Left z) (union x y)       == 'hasVertex' z x" $ \x y z ->
-        hasVertex (Left z) (union x y :: AAE)  == hasVertex z x
-  test "'hasVertex' (Right z) (union x y)      == 'hasVertex' z y" $ \x y z ->
-        hasVertex (Right z) (union x y :: AAE) == hasVertex z y
-  test "'vertexCount' (union x y)              >= 'vertexCount' x" $ \x y ->
-        vertexCount (union x y :: AAE)         >= vertexCount x
-  test "'vertexCount' (union x y)              == 'vertexCount' x + 'vertexCount' y" $ \x y ->
-        vertexCount (union x y :: AAE)         == vertexCount x + vertexCount y
-  test "'edgeCount' (union x y)                >= 'edgeCount' x" $ \x y ->
-        edgeCount (union x y :: AAE)           >= edgeCount x
-  test "'edgeCount' (union x y)                == 'edgeCount' x   + 'edgeCount' y" $ \x y ->
-        edgeCount (union x y :: AAE)           == edgeCount x   + edgeCount y
-  test "'vertexCount' (union 1 2)              == 2" $
-        vertexCount (union 1 2 :: AAE)         == 2
-  test "'edgeCount' (union 1 2)                == 0" $
-        edgeCount (union 1 2 :: AAE)           == 0
-
-  test "'isEmpty' (join x y)                  == 'isEmpty' x && 'isEmpty' y" $ \x y ->
-        isEmpty (join x y :: AAE)             == (isEmpty x && isEmpty y)
-  test "'hasVertex' (Left z) (join x y)       == 'hasVertex' z x" $ \x y z ->
-        hasVertex (Left z) (join x y :: AAE)  == hasVertex z x
-  test "'hasVertex' (Right z) (join x y)      == 'hasVertex' z y" $ \x y z ->
-        hasVertex (Right z) (join x y :: AAE) == hasVertex z y
-  test "'vertexCount' (join x y)              >= 'vertexCount' x" $ \x y ->
-        vertexCount (join x y :: AAE)         >= vertexCount x
-  test "'vertexCount' (join x y)              == 'vertexCount' x + 'vertexCount' y" $ \x y ->
-        vertexCount (join x y :: AAE)         == vertexCount x + vertexCount y
-  test "'edgeCount' (join x y)                >= 'edgeCount' x" $ \x y ->
-        edgeCount (join x y :: AAE)           >= edgeCount x
-  test "'edgeCount' (join x y)                >= 'edgeCount' y" $ \x y ->
-        edgeCount (join x y :: AAE)           >= edgeCount y
-  test "'edgeCount' (join x y)                >= 'vertexCount' x * 'vertexCount' y" $ \x y ->
-        edgeCount (join x y :: AAE)           >= vertexCount x * vertexCount y
-  test "'edgeCount' (join x y)                == 'vertexCount' x * 'vertexCount' y + 'edgeCount' x + 'edgeCount' y" $ \x y ->
-        edgeCount (join x y :: AAE)           == vertexCount x * vertexCount y + edgeCount x + edgeCount y
-  test "'vertexCount' (join 1 2)              == 2" $
-        vertexCount (join 1 2 :: AAE)         == 2
-  test "'edgeCount' (join 1 2)                == 1" $
-        edgeCount (join 1 2 :: AAE)           == 1
-
-  putStrLn "\n=====AcyclicAdjacencyMap transitiveClosure====="
-
-  test "transitiveClosure empty                           == empty" $
-        transitiveClosure (empty :: AAI)                  == empty
-  test "transitiveClosure (vertex x)                      == vertex x" $ \x ->
-        transitiveClosure (vertex x :: AAI)               == vertex x
-  test "transitiveClosure (1 * 2 + 2 * 3)                 == 1 * 2 + 2 * 3 + 1 * 3" $
-        transitiveClosure (1 * 2 + 2 * 3 :: AAI)          == 1 * 2 + 2 * 3 + 1 * 3
-  test "transitiveClosure . transitiveClosure             == transitiveClosure" $ \x ->
-       (transitiveClosure . transitiveClosure $ x :: AAI) == transitiveClosure x
-
-  putStrLn "\n=====AcyclicAdjacencyMap box====="
-
-  test "edgeList (box (1 * 2) (3 * 4))                 == [((1,3),(1,4)),((1,3),(2,3)),((1,4),(2,4)),((2,3),(2,4))]" $
-        edgeList (box (1 * 2 :: AAI) (3 * 4 :: AAI))   == [((1,3),(1,4)),((1,3),(2,3)),((1,4),(2,4)),((2,3),(2,4))]
-  test "edgeList (box (1 + 2) (3 + 4))                 == []" $
-        edgeList (box (1 + 2 :: AAI) (3 + 4 :: AAI))   == []
-  test "vertexList (box (1 + 2) (3 + 4))               == [(1,3),(1,4),(2,3),(2,4)]" $
-        vertexList (box (1 + 2 :: AAI) (3 + 4 :: AAI)) == [(1,3),(1,4),(2,3),(2,4)]
-
-  putStrLn "\n=====AcyclicAdjacencyMap topsort====="
-
-  test "topSort (1)                == [1]" $
-        topSort (1 :: AAI)         == [1]
-  test "topSort (1 * 2 * 3)        == [1,2,3]" $
-        topSort (1 * 2 * 3 :: AAI) == [1,2,3]
-
-  putStrLn "\n=====AcyclicAdjacencyMap fromGraph primitive====="
-
-  test "fromGraph (<) (2 * 1)         == 1 + 2" $
-        fromGraph (<) (2 * 1)         == (1 + 2 :: AAI)
-  test "fromGraph (<) (1 * 2)         == 1 * 2" $
-        fromGraph (<) (1 * 2)         == (1 * 2 :: AAI)
-  test "fromGraph (<) (1 * 2 + 2 * 1) == 1 * 2" $
-        fromGraph (<) (1 * 2 + 2 * 1) == (1 * 2 :: AAI)
-
-  putStrLn "\n=====AcyclicAdjacencyMap graph transformation====="
-
-  test "removeVertex x ('vertex' x)                  == 'empty'" $ \x ->
-        removeVertex x (vertex x :: AAI)             == empty
-  test "removeVertex 1 ('vertex' 2)                  == 'vertex' 2" $
-        removeVertex 1 (vertex 2 :: AAI)             == vertex 2
-  test "removeVertex 1 (1 * 2)                       == 'vertex' 2" $
-        removeVertex 1 (1 * 2 :: AAI)                == vertex 2
-  test "removeVertex x . removeVertex x              == removeVertex x" $ \x y ->
-        (removeVertex x . removeVertex x $ y :: AAI) == removeVertex x y
-
-  test "removeEdge 1 2 (1 * 2)                       == (1 + 2)" $
-        removeEdge 1 2 (1 * 2 :: AAI)                == (1 + 2)
-  test "removeEdge x y . removeEdge x y              == removeEdge x y" $ \x y z ->
-        (removeEdge x y . removeEdge x y $ z :: AAI) == removeEdge x y z
-  test "removeEdge x y . 'removeVertex' x            == 'removeVertex' x" $ \x y z ->
-        (removeEdge x y . removeVertex x $ z :: AAI) == removeVertex x z
-  test "removeEdge 1 2 (1 * 2 + 3 * 4)               == 1 + 2 + 3 * 4" $
-        removeEdge 1 2 (1 * 2 + 3 * 4 :: AAI)        == 1 + 2 + 3 * 4
-
-  test "induce ('const' True) x          == x" $ \x ->
-        induce (const True) (x :: AAI)   == x
-  test "induce ('const' False) x         == 'empty'" $ \x ->
-        induce (const False) (x :: AAI)  == empty
-  test "induce (/= x)                    == 'removeVertex' x" $ \x y ->
-        induce (/= x) y                  == (removeVertex x y :: AAI)
-  test "induce p . induce q              == induce (\\x -> p x && q x)" $ \(apply -> p) (apply -> q) y ->
-        (induce p . induce q $ y :: AAI) == induce (\x -> p x && q x) y
-
-  test "transpose 'empty'                   == 'empty'" $
-        transpose empty                     == (empty :: AAI)
-  test "transpose ('vertex' x)              == 'vertex' x" $ \x ->
-        transpose (vertex x :: AAI)         == vertex x
-  test "transpose . transpose               == id" $ \x ->
-        (transpose . transpose $ x :: AAI)  == id x
-  test "'edgeList' . transpose              == 'Data.List.sort' . 'map' 'Data.Tuple.swap' . 'edgeList'" $ \x ->
-        (edgeList . transpose $ (x :: AAI)) == (List.sort . List.map Tuple.swap . edgeList $ x)
-
-  putStrLn "\n=====AcyclicAdjacencyMap properties====="
-
-  test "isEmpty empty                              == True" $
-        isEmpty (empty :: AAI)                     == True
-  test "isEmpty (vertex x)                         == False" $ \x ->
-        isEmpty (vertex x :: AAI)                  == False
-  test "isEmpty (removeVertex x $ vertex x)        == True" $ \x ->
-        isEmpty (removeVertex x $ vertex x :: AAI) == True
-  test "isEmpty (removeEdge 1 2 $ 1 * 2)           == False" $
-        isEmpty (removeEdge 1 2 $ 1 * 2 :: AAI)    == False
-
-  test "edgeSet empty             == Set.empty" $
-        edgeSet (empty :: AAI)    == Set.empty
-  test "edgeSet (vertex x)        == Set.empty" $ \x ->
-        edgeSet (vertex x :: AAI) == Set.empty
-  test "edgeSet (1 * 2)           == Set.singleton (1,2)" $
-        edgeSet (1 * 2 :: AAI)    == Set.singleton (1,2)
-
-  test "vertexSet empty               == Set.empty" $
-        vertexSet (empty :: AAI)      == Set.empty
-  test "vertexSet . vertex            == Set.singleton" $ \x ->
-        vertexSet (vertex x :: AAI)   == Set.singleton x
-  test "vertexSet . vertices          == Set.fromList" $ \x ->
-        vertexSet (vertices x :: AAI) == Set.fromList x
-
-  test "vertexCount empty                                     == 0" $
-        vertexCount (empty :: AAI)                            == 0
-  test "vertexCount (vertex x)                                == 1" $ \x ->
-        vertexCount (vertex x :: AAI)                         == 1
-  test "vertexCount                                           == length . vertexList" $ \x ->
-        vertexCount (x :: AAI)                                == (List.length . vertexList $ x)
-  test "vertexCount x < vertexCount y                         == > x < y" $ \x y ->
-        not (vertexCount (x :: AAI) < vertexCount y) || x < y
-
-  test "edgeCount empty             == 0" $
-        edgeCount (empty :: AAI)    == 0
-  test "edgeCount (vertex x)        == 0" $ \x ->
-        edgeCount (vertex x :: AAI) == 0
-  test "edgeCount (1 * 2)           == 1" $
-        edgeCount (1 * 2 :: AAI)    == 1
-  test "edgeCount                   == length . edgeList" $ \x ->
-        edgeCount (x :: AAI)        == (List.length . edgeList $ x)
-
-  test "adjacencyList empty             == []" $
-        adjacencyList (empty :: AAI)    == []
-  test "adjacencyList (vertex x)        == [(x, [])]" $ \x ->
-        adjacencyList (vertex x :: AAI) == [(x, [])]
-  test "adjacencyList (1 * 2)           == [(1, [2]), (2, [])]" $
-        adjacencyList (1 * 2 :: AAI)    == [(1, [2]), (2, [])]
-
-  test "hasEdge x y empty                           == False" $ \x y ->
-        hasEdge x y (empty :: AAI)                  == False
-  test "hasEdge x y (vertex z)                      == False" $ \x y z ->
-        hasEdge x y (vertex z :: AAI)               == False
-  test "hasEdge 1 2 (1 * 2)                         == True" $
-        hasEdge 1 2 (1 * 2 :: AAI)                  == True
-  test "hasEdge x y . removeEdge x y                == const False" $ \x y z ->
-        (hasEdge x y . removeEdge x y $ (z :: AAI)) == const False z
-  test "hasEdge x y                                 == elem (x,y) . edgeList" $ \x y z ->
-        (hasEdge x y $ (z :: AAI))                  == (elem (x,y) . edgeList $ z)
-
-  test "hasVertex x empty                           == False" $ \x ->
-        hasVertex x (empty :: AAI)                  == False
-  test "hasVertex x (vertex x)                      == True" $ \x ->
-        hasVertex x (vertex x :: AAI)               == True
-  test "hasVertex 1 (vertex 2)                      == False" $
-        hasVertex 1 (vertex 2 :: AAI)               == False
-  test "hasVertex x . removeVertex x                == const False" $ \x z ->
-        (hasVertex x . removeVertex x $ (z :: AAI)) == const False z
-
-  test "edgeList empty             == []" $
-        edgeList (empty :: AAI)    == []
-  test "edgeList (vertex 5)        == []" $
-        edgeList (vertex 5 :: AAI) == []
-  test "edgeList (1 * 2)           == [(1,2)]" $
-        edgeList (1 * 2 :: AAI)    == [(1,2)]
-  test "edgeList (2 * 1)           == []" $
-        edgeList (2 * 1 :: AAI)    == []
-
-  test "vertexList empty                         == []" $
-        vertexList (empty :: AAI)                == []
-  test "vertexList (vertex 1)                    == [1]" $
-        vertexList (vertex 1 :: AAI)             == [1]
-  test "vertexList (vertices ([1, 3, 2]))        == List.sort [1, 3, 2] == [1,2,3]" $
-        vertexList (vertices ([1, 3, 2]) :: AAI) == List.sort [1, 3, 2]
-
-
-  putStrLn "\n============ AcyclicAdjacencyMap scc ============"
-
-  test "scc AM.empty         == empty" $
-        scc (AM.empty :: AI) == empty
-
-  test "scc (AM.vertex x) == vertex (NonEmpty.vertex x)" $ \(x :: Int) ->
-        scc (AM.vertex x) == vertex (NonEmpty.vertex x)
-
-  test "scc (edge 1 1)          == vertex (NonEmpty.edge 1 1)" $
-        scc (AM.edge 1 1 :: AI) == vertex (NonEmpty.edge 1 1)
-
-  test "vertexList (scc (edge 1 2))          == [NonEmpty.vertex 1,NonEmpty.vertex 2]" $
-        vertexList (scc (AM.edge 1 2 :: AI)) == [NonEmpty.vertex 1,NonEmpty.vertex 2]
-  test "edgeList (scc (edge 1 2))            == [(NonEmpty.vertex 1,NonEmpty.vertex 2)]" $
-        edgeList (scc (AM.edge 1 2 :: AI))   == [(NonEmpty.vertex 1,NonEmpty.vertex 2)]
-
-  test "scc (AM.circuit (1:xs)) == vertex (NonEmpty.circuit1 (1 :| xs))" $ \(xs :: [Int]) ->
-        scc (AM.circuit (1:xs)) == vertex (NonEmpty.circuit1 (1 :| xs))
-
-  test "vertexList (scc (3 * 1 * 4 * 1 * 5))       == <correct result>" $
-        vertexList (scc (3 * 1 * 4 * 1 * 5 :: AI)) == [NonEmpty.vertex 3,NonEmpty.vertex 5,NonEmpty.clique1 (1 :| [4,1])]
-  test "edgeList (scc (3 * 1 * 4 * 1 * 5))         == <correct result>" $
-        edgeList (scc (3 * 1 * 4 * 1 * 5 :: AI))   == [(NonEmpty.vertex 3,NonEmpty.vertex 5),(NonEmpty.vertex 3,NonEmpty.clique1 (1 :| [4,1])),(NonEmpty.clique1 (1 :| [4,1]),NonEmpty.vertex 5)]
-
--- TODO: Switch to using generic tests.
-testAcyclicOrd :: IO ()
-testAcyclicOrd = do
-
-  putStrLn "\n=====AcyclicOrd consistency====="
-
-  test "edge" $ \x y                       -> consistent (edge x y :: AAI)
-  test "overlay" $ \x y                    -> consistent (overlay x y :: AAI)
-  test "connect" $ \x y                    -> consistent (connect x y :: AAI)
-  test "edges" $ \x                        -> consistent (edges x :: AAI)
-  test "overlays" $ \x                     -> consistent (overlays x :: AAI)
-  test "connects" $ \x                     -> consistent (connects x :: AAI)
-  test "replaceVertex" $ \x y z            -> consistent (replaceVertex x y z :: AAI)
-  test "mergeVertices" $ \(apply -> p) v x -> consistent (mergeVertices p v x :: AAI)
-  test "gmap" $ \(apply -> f) x            -> consistent (gmap f (x :: AAI) :: AAI)
-
-  putStrLn "\n=====AcyclicOrd edge====="
-
-  test "edge x y                      == connect (vertex x) (vertex y)" $ \x y ->
-        (edge x y :: AAI)             == connect (vertex x) (vertex y)
-  test "hasEdge 1 2 (edge 1 2)        == True" $
-        hasEdge 1 2 (edge 1 2 :: AAI) == True
-  test "hasEdge 2 1 (edge 2 1)        == False" $
-        hasEdge 2 1 (edge 2 1 :: AAI) == False
-  test "edgeCount   (edge 1 2)        == 1" $
-        edgeCount   (edge 1 2 :: AAI) == 1
-  test "edgeCount   (edge 2 1)        == 0" $
-        edgeCount   (edge 2 1 :: AAI) == 0
-  test "vertexCount (edge 1 1)        == 1" $
-        vertexCount (edge 1 1 :: AAI) == 1
-  test "vertexCount (edge 1 2)        == 2" $
-        vertexCount (edge 1 2 :: AAI) == 2
-  test "vertexCount (edge 2 1)        == 2" $
-        vertexCount (edge 2 1 :: AAI) == 2
-
-  putStrLn "\n=====AcyclicOrd overlay====="
-
-  test "isEmpty     (overlay x y)        == isEmpty x && isEmpty y" $ \x y ->
-        isEmpty     (overlay x y :: AAI) == (isEmpty x && isEmpty y)
-  test "hasVertex z (overlay x y)        == hasVertex z x || hasVertex z y" $ \x y z ->
-        hasVertex z (overlay x y :: AAI) == (hasVertex z x || hasVertex z y)
-  test "vertexCount (overlay x y)        >= vertexCount x" $ \x y ->
-        vertexCount (overlay x y :: AAI) >= vertexCount x
-  test "vertexCount (overlay x y)        <= vertexCount x + vertexCount y" $ \x y ->
-        vertexCount (overlay x y :: AAI) <= vertexCount x + vertexCount y
-  test "edgeCount   (overlay x y)        >= edgeCount x" $ \x y ->
-        edgeCount   (overlay x y :: AAI) >= edgeCount x
-  test "edgeCount   (overlay x y)        <= edgeCount x + edgeCount y" $ \x y ->
-        edgeCount   (overlay x y :: AAI) <= edgeCount x + edgeCount y
-  test "vertexCount (overlay 1 2)        == 2" $
-        vertexCount (overlay 1 2 :: AAI) == 2
-  test "edgeCount   (overlay 1 2)        == 0" $
-        edgeCount   (overlay 1 2 :: AAI) == 0
-
-  putStrLn "\n=====AcyclicOrd connect====="
-
-  test "isEmpty     (connect x y)        == isEmpty x && isEmpty y" $ \x y ->
-        isEmpty     (connect x y :: AAI) == (isEmpty x && isEmpty y)
-  test "hasVertex z (connect x y)        == hasVertex z x || hasVertex z y" $ \x y z ->
-        hasVertex z (connect x y :: AAI) == (hasVertex z x || hasVertex z y)
-  test "vertexCount (connect x y)        >= vertexCount x" $ \x y ->
-        vertexCount (connect x y :: AAI) >= vertexCount x
-  test "vertexCount (connect x y)        <= vertexCount x + vertexCount y" $ \x y ->
-        vertexCount (connect x y :: AAI) <= vertexCount x + vertexCount y
-  test "edgeCount   (connect x y)        >= edgeCount x" $ \x y ->
-        edgeCount   (connect x y :: AAI) >= edgeCount x
-  test "edgeCount   (connect x y)        >= edgeCount y" $ \x y ->
-        edgeCount   (connect x y :: AAI) >= edgeCount y
-  test "edgeCount   (connect x y)        <= vertexCount x * vertexCount y + edgeCount x + edgeCount y" $ \x y ->
-        edgeCount   (connect x y :: AAI) <= vertexCount x * vertexCount y + edgeCount x + edgeCount y
-  test "vertexCount (connect 1 2)        == 2" $
-        vertexCount (connect 1 2 :: AAI) == 2
-  test "edgeCount   (connect 1 2)        == 1" $
-        edgeCount   (connect 1 2 :: AAI) == 1
-  test "edgeCount   (connect 2 1) == 0" $
-        edgeCount   (connect 2 1 :: AAI) == 0
-
-  putStrLn "\n=====AcyclicOrd edges====="
-
-  test "edges []                   == empty" $
-        (edges [] :: AAI)          == empty
-  test "edges [(x,y)]              == edge x y" $ \x y ->
-        (edges [(x,y)] :: AAI)     == edge x y
-  test "edgeCount . edges          == length . filter (uncurry (<)) . Data.List.nub" $ \x ->
-        edgeCount (edges x :: AAI) == (length . filter (uncurry (<)) . List.nub $ x)
-  test "edgeList . edges           == filter (uncurry (<)) . Data.List.nub . Data.List.sort" $ \x ->
-        edgeList (edges x :: AAI)  == (filter (uncurry (<)) . List.nub . List.sort $ x)
-
-  putStrLn "\n=====AcyclicOrd overlays====="
-
-  test "overlays []               == empty" $
-        (overlays [] :: AAI)      == empty
-  test "overlays [x]              == x" $ \x ->
-        (overlays [x] :: AAI)     == x
-  test "overlays [x,y]            == overlay x y" $ \x y ->
-        (overlays [x,y] :: AAI)   == overlay x y
-  test "overlays                  == foldr overlay empty" $ \x ->
-        (overlays x :: AAI)       == foldr overlay empty x
-  test "isEmpty . overlays        == all isEmpty" $ \x ->
-        isEmpty (overlays x :: AAI) == all isEmpty x
-
-  putStrLn "\n=====AcyclicAdjacencyMap Show====="
-
-  test "connects []                 == empty" $
-        (connects [] :: AAI)        == empty
-  test "connects [x]                == x" $ \x ->
-        (connects [x] :: AAI)       == x
-  test "connects [x,y]              == connect x y" $ \x y ->
-        (connects [x,y] :: AAI)     == connect x y
-  test "connects                    == foldr connect empty" $ \x ->
-        (connects x :: AAI)         == foldr connect empty x
-  test "isEmpty . connects          == all isEmpty" $ \x ->
-        isEmpty (connects x :: AAI) == all isEmpty x
-
-  putStrLn "\n=====AcyclicOrd replaceVertex====="
-
-  test "replaceVertex x x                   == id" $ \x y ->
-        (replaceVertex x x y :: AAI)        == id y
-  test "replaceVertex x y (vertex x)        == vertex y" $ \x y ->
-        replaceVertex x y (vertex x :: AAI) == vertex y
-  test "replaceVertex x y                   == mergeVertices ( == x) y" $ \x y z ->
-        (replaceVertex x y z :: AAI)        == mergeVertices ( == x) y z
-  test "replaceVertex 1 2 (1 * 3)           == 2 * 3" $
-        replaceVertex 1 2 (1 * 3 :: AAI)    == 2 * 3
-  test "replaceVertex 1 4 (1 * 3)           == 4 + 3" $
-        replaceVertex 1 4 (1 * 3 :: AAI)    == 4 + 3
-
-  putStrLn "\n=====AcyclicOrd mergeVertices====="
-
-  test "mergeVertices (const False) x               == id" $ \x y ->
-        mergeVertices (const False) x (y :: AAI)    == id y
-  test "mergeVertices (                             == x) y             == replaceVertex x y" $ \x y z ->
-        mergeVertices (                             == x) y (z :: AAI)  == replaceVertex x y z
-  test "mergeVertices even 1 (0 * 2)                == 1" $
-        mergeVertices even 1 (0 * 2 :: AAI)         == 1
-  test "mergeVertices odd  1 (3 + 4 * 5)            == 4 + 1" $
-        mergeVertices odd  1 (3 + 4 * 5 :: AAI)     == 4 + 1
-  test "mergeVertices even 1 (2 * 3 + 4 * 5)        == 1 * 3 + 1 * 5" $
-        mergeVertices even 1 (2 * 3 + 4 * 5 :: AAI) == 1 * 3 + 1 * 5
-
-  putStrLn "\n=====AcyclicOrd gmap====="
-
-  test "gmap f empty                                 == empty" $ \(apply -> f) ->
-        gmap f (empty :: AAI)                        == (empty :: AAI)
-  test "gmap f (vertex x)                            == vertex (f x)" $ \(apply -> f) x ->
-        gmap f (vertex x :: AAI)                     == (vertex (f x) :: AAI)
-  test "edgeCount (gmap f (edge x y))                <= edgeCount (edge (f x) (f y))" $ \(apply -> f) x y ->
-        edgeCount (gmap f (edge x y :: AAI))         <= edgeCount (edge (f x) (f y) :: AAI)
-  test "vertexList (gmap f (edge x y))               == vertexList (edge (f x) (f y))" $ \(apply -> f) x y ->
-        vertexList (gmap f (edge x y :: AAI))        == vertexList (edge (f x) (f y) :: AAI)
-  test "gmap id                                      == id" $ \x ->
-        gmap id (x :: AAI)                           == id x
-  test "vertexList . gmap f . gmap g                 == vertexList . gmap (f . g)" $ \(apply -> f) (apply -> g) x ->
-        vertexList (gmap f (gmap g x :: AAI) :: AAI) == vertexList (gmap (f . g) (x :: AAI))
-  test "edgeCount (gmap f (gmap g x))                <= edgeCount (gmap (f . g) x)" $ \(apply -> f) (apply -> g) x ->
-        edgeCount (gmap f (gmap g x :: AAI) :: AAI)  <= edgeCount (gmap (f . g) (x :: AAI))
+    putStrLn "\n============ Acyclic.AdjacencyMap.Num ============"
+    test "edgeList 1           == []" $
+          edgeList (1 :: AAI)  == []
+
+    test "edgeList (1 + 2)     == []" $
+          edgeList (1 + 2 :: AAI) == []
+
+    test "edgeList (1 * 2)     == [(1,2)]" $
+          edgeList (1 * 2 :: AAI) == [(1,2)]
+
+    test "edgeList (2 * 1)     == []" $
+          edgeList (2 * 1 :: AAI) == []
+
+    test "edgeList (1 * 2 * 1) == [(1,2)]" $
+          edgeList (1 * 2 * 1 :: AAI) == [(1,2)]
+
+    test "edgeList (1 * 2 * 3) == [(1,2), (1,3), (2,3)]" $
+          edgeList (1 * 2 * 3 :: AAI) == [(1,2), (1,3), (2,3)]
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.Show ============"
+    test "show empty       == \"empty\"" $
+          show (empty :: AAI) == "empty"
+
+    test "show 1           == \"vertex 1\"" $
+          show (1 :: AAI)  == "vertex 1"
+
+    test "show (1 + 2)     == \"vertices [1,2]\"" $
+          show (1 + 2 :: AAI) == "vertices [1,2]"
+
+    test "show (1 * 2)     == \"(fromJust . toAcyclic) (edge 1 2)\"" $
+          show (1 * 2 :: AAI) == "(fromJust . toAcyclic) (edge 1 2)"
+
+    test "show (1 * 2 * 3) == \"(fromJust . toAcyclic) (edges [(1,2),(1,3),(2,3)])\"" $
+          show (1 * 2 * 3 :: AAI) == "(fromJust . toAcyclic) (edges [(1,2),(1,3),(2,3)])"
+
+    test "show (1 * 2 + 3) == \"(fromJust . toAcyclic) (overlay (vertex 3) (edge 1 2))\"" $
+          show (1 * 2 + 3 :: AAI) == "(fromJust . toAcyclic) (overlay (vertex 3) (edge 1 2))"
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.fromAcyclic ============"
+    test "fromAcyclic empty         == empty" $
+          fromAcyclic (empty :: AAI) == AM.empty
+
+    test "fromAcyclic . vertex      == vertex" $ \(x :: Int) ->
+         (fromAcyclic . vertex) x   == AM.vertex x
+
+    test "fromAcyclic (1 * 3 * 2)   == star 1 [2,3]" $
+          fromAcyclic (1 * 3 * 2)   == AM.star 1 [2,3 :: Int]
+
+    test "vertexCount . fromAcyclic == vertexCount" $ \(x :: AAI) ->
+         (AM.vertexCount . fromAcyclic) x == vertexCount x
+
+    test "edgeCount   . fromAcyclic == edgeCount" $ \(x :: AAI) ->
+         (AM.edgeCount . fromAcyclic) x == edgeCount x
+
+    test "isAcyclic   . fromAcyclic == const True" $ \(x :: AAI) ->
+         (AM.isAcyclic . fromAcyclic) x == const True x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.empty ============"
+    test "isEmpty     empty == True" $
+          isEmpty     (empty :: AAI) == True
+
+    test "hasVertex x empty == False" $ \x ->
+          hasVertex x (empty :: AAI) == False
+
+    test "vertexCount empty == 0" $
+          vertexCount (empty :: AAI) == 0
+
+    test "edgeCount   empty == 0" $
+          edgeCount   (empty :: AAI) == 0
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.vertex ============"
+    test "isEmpty     (vertex x) == False" $ \(x :: Int) ->
+          isEmpty     (vertex x) == False
+
+    test "hasVertex x (vertex x) == True" $ \(x :: Int) ->
+          hasVertex x (vertex x) == True
+
+    test "vertexCount (vertex x) == 1" $ \(x :: Int) ->
+          vertexCount (vertex x) == 1
+
+    test "edgeCount   (vertex x) == 0" $ \(x :: Int) ->
+          edgeCount   (vertex x) == 0
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.vertices ============"
+    test "vertices []            == empty" $
+          vertices []            == (empty :: AAI)
+
+    test "vertices [x]           == vertex x" $ \(x :: Int) ->
+          vertices [x]           == vertex x
+
+    test "hasVertex x . vertices == elem x" $ \(x :: Int) xs ->
+         (hasVertex x . vertices) xs == elem x xs
+
+    test "vertexCount . vertices == length . nub" $ \(xs :: [Int]) ->
+         (vertexCount . vertices) xs == (length . nubOrd) xs
+
+    test "vertexSet   . vertices == Set.fromList" $ \(xs :: [Int]) ->
+         (vertexSet   . vertices) xs == Set.fromList xs
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.union ============"
+    test "vertexSet (union x y) == <correct result>" $ \(x :: AAI) (y :: AAI) ->
+          vertexSet (union x y) == Set.unions ([ Set.map Left  (vertexSet x)
+                                               , Set.map Right (vertexSet y) ] ++ [])
+
+    test "edgeSet   (union x y) == <correct result>" $ \(x :: AAI) (y :: AAI) ->
+          edgeSet   (union x y) == Set.unions ([ Set.map (bimap Left  Left ) (edgeSet x)
+                                               , Set.map (bimap Right Right) (edgeSet y) ] ++ [])
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.join ============"
+    test "vertexSet (join x y) == <correct result>" $ \(x :: AAI) (y :: AAI) ->
+          vertexSet (join x y) == Set.unions ([ Set.map Left  (vertexSet x)
+                                              , Set.map Right (vertexSet y) ] ++ [])
+
+    test "edgeSet   (join x y) == <correct result>" $ \(x :: AAI) (y :: AAI) ->
+          edgeSet   (join x y) == Set.unions ([ Set.map (bimap Left  Left ) (edgeSet x)
+                                              , Set.map (bimap Right Right) (edgeSet y)
+                                              , Set.map (bimap Left  Right) (setProduct (vertexSet x) (vertexSet y)) ] ++ [])
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.isSubgraphOf ============"
+    test "isSubgraphOf empty        x                     ==  True" $ \(x :: AAI) ->
+          isSubgraphOf empty        x                     ==  True
+
+    test "isSubgraphOf (vertex x)   empty                 ==  False" $ \(x :: Int) ->
+          isSubgraphOf (vertex x)   empty                 ==  False
+
+    test "isSubgraphOf (induce p x) x                     ==  True" $ \(x :: AAI) (apply -> p) ->
+          isSubgraphOf (induce p x) x                     ==  True
+
+    test "isSubgraphOf x            (transitiveClosure x) ==  True" $ \(x :: AAI) ->
+          isSubgraphOf x            (transitiveClosure x) ==  True
+
+    test "isSubgraphOf x y                                ==> x <= y" $ \(x :: AAI) z ->
+        let y = x + z -- Make sure we hit the precondition
+        in isSubgraphOf x y                               ==> x <= y
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.isEmpty ============"
+    test "isEmpty empty                       == True" $
+          isEmpty (empty :: AAI)              == True
+
+    test "isEmpty (vertex x)                  == False" $ \(x :: Int) ->
+          isEmpty (vertex x)                  == False
+
+    test "isEmpty (removeVertex x $ vertex x) == True" $ \(x :: Int) ->
+          isEmpty (removeVertex x $ vertex x) == True
+
+    test "isEmpty (removeEdge 1 2 $ 1 * 2)    == False" $
+          isEmpty (removeEdge 1 2 $ 1 * 2 :: AAI) == False
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.hasVertex ============"
+    test "hasVertex x empty            == False" $ \(x :: Int) ->
+          hasVertex x empty            == False
+
+    test "hasVertex x (vertex x)       == True" $ \(x :: Int) ->
+          hasVertex x (vertex x)       == True
+
+    test "hasVertex 1 (vertex 2)       == False" $
+          hasVertex 1 (vertex 2 :: AAI) == False
+
+    test "hasVertex x . removeVertex x == const False" $ \(x :: Int) y ->
+         (hasVertex x . removeVertex x) y == const False y
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.hasEdge ============"
+    test "hasEdge x y empty            == False" $ \(x :: Int) y ->
+          hasEdge x y empty            == False
+
+    test "hasEdge x y (vertex z)       == False" $ \(x :: Int) y z ->
+          hasEdge x y (vertex z)       == False
+
+    test "hasEdge 1 2 (1 * 2)          == True" $
+          hasEdge 1 2 (1 * 2 :: AAI)   == True
+
+    test "hasEdge x y . removeEdge x y == const False" $ \(x :: Int) y z ->
+         (hasEdge x y . removeEdge x y) z == const False z
+
+    test "hasEdge x y                  == elem (x,y) . edgeList" $ \(x :: Int) y z -> do
+        (u, v) <- elements ((x, y) : edgeList z)
+        return $ hasEdge u v z == elem (u, v) (edgeList z)
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.vertexCount ============"
+    test "vertexCount empty             ==  0" $
+          vertexCount (empty :: AAI)    ==  0
+
+    test "vertexCount (vertex x)        ==  1" $ \(x :: Int) ->
+          vertexCount (vertex x)        ==  1
+
+    test "vertexCount                   ==  length . vertexList" $ \(x :: AAI) ->
+          vertexCount x                 == (length . vertexList) x
+
+    test "vertexCount x < vertexCount y ==> x < y" $ \(x :: AAI) y ->
+        if vertexCount x < vertexCount y
+        then property (x < y)
+        else (vertexCount x > vertexCount y ==> x > y)
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.edgeCount ============"
+    test "edgeCount empty      == 0" $
+          edgeCount (empty :: AAI) == 0
+
+    test "edgeCount (vertex x) == 0" $ \(x :: Int) ->
+          edgeCount (vertex x) == 0
+
+    test "edgeCount (1 * 2)    == 1" $
+          edgeCount (1 * 2 :: AAI) == 1
+
+    test "edgeCount            == length . edgeList" $ \(x :: AAI) ->
+          edgeCount x          == (length . edgeList) x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.vertexList ============"
+    test "vertexList empty      == []" $
+          vertexList (empty :: AAI) == []
+
+    test "vertexList (vertex x) == [x]" $ \(x :: Int) ->
+          vertexList (vertex x) == [x]
+
+    test "vertexList . vertices == nub . sort" $ \(xs :: [Int]) ->
+         (vertexList . vertices) xs == (nubOrd . sort) xs
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.edgeList ============"
+    test "edgeList empty       == []" $
+          edgeList (empty :: AAI) == []
+
+    test "edgeList (vertex x)  == []" $ \(x :: Int) ->
+          edgeList (vertex x)  == []
+
+    test "edgeList (1 * 2)     == [(1,2)]" $
+          edgeList (1 * 2 :: AAI) == [(1,2)]
+
+    test "edgeList (2 * 1)     == []" $
+          edgeList (2 * 1 :: AAI) == []
+
+    test "edgeList . transpose == sort . map swap . edgeList" $ \(x :: AAI) ->
+         (edgeList . transpose) x == (sort . map swap . edgeList) x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.adjacencyList ============"
+    test "adjacencyList empty      == []" $
+          adjacencyList (empty :: AAI) == []
+
+    test "adjacencyList (vertex x) == [(x, [])]" $ \(x :: Int) ->
+          adjacencyList (vertex x) == [(x, [])]
+
+    test "adjacencyList (1 * 2)    == [(1, [2]), (2, [])]" $
+          adjacencyList (1 * 2 :: AAI) == [(1, [2]), (2, [])]
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.vertexSet ============"
+    test "vertexSet empty      == Set.empty" $
+          vertexSet (empty :: AAI) == Set.empty
+
+    test "vertexSet . vertex   == Set.singleton" $ \(x :: Int) ->
+         (vertexSet . vertex) x == Set.singleton x
+
+    test "vertexSet . vertices == Set.fromList" $ \(xs :: [Int]) ->
+         (vertexSet . vertices) xs == Set.fromList xs
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.edgeSet ============"
+    test "edgeSet empty      == Set.empty" $
+          edgeSet (empty :: AAI) == Set.empty
+
+    test "edgeSet (vertex x) == Set.empty" $ \(x :: Int) ->
+          edgeSet (vertex x) == Set.empty
+
+    test "edgeSet (1 * 2)    == Set.singleton (1,2)" $
+          edgeSet (1 * 2 :: AAI) == Set.singleton (1,2)
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.preSet ============"
+    test "preSet x empty          == Set.empty" $ \(x :: Int) ->
+          preSet x empty          == Set.empty
+
+    test "preSet x (vertex x)     == Set.empty" $ \(x :: Int) ->
+          preSet x (vertex x)     == Set.empty
+
+    test "preSet 1 (1 * 2)        == Set.empty" $
+          preSet 1 (1 * 2 :: AAI) == Set.empty
+
+    test "preSet 2 (1 * 2)        == Set.fromList [1]" $
+          preSet 2 (1 * 2 :: AAI) == Set.fromList [1]
+
+    test "Set.member x . preSet x == const False" $ \(x :: Int) y ->
+         (Set.member x . preSet x) y == const False y
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.postSet ============"
+    test "postSet x empty          == Set.empty" $ \(x :: Int) ->
+          postSet x empty          == Set.empty
+
+    test "postSet x (vertex x)     == Set.empty" $ \(x :: Int) ->
+          postSet x (vertex x)     == Set.empty
+
+    test "postSet 1 (1 * 2)        == Set.fromList [2]" $
+          postSet 1 (1 * 2 :: AAI) == Set.fromList [2]
+
+    test "postSet 2 (1 * 2)        == Set.empty" $
+          postSet 2 (1 * 2 :: AAI) == Set.empty
+
+    test "Set.member x . postSet x == const False" $ \(x :: Int) y ->
+         (Set.member x . postSet x) y == const False y
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.removeVertex ============"
+    test "removeVertex x (vertex x)       == empty" $ \(x :: Int) ->
+          removeVertex x (vertex x)       == empty
+
+    test "removeVertex 1 (vertex 2)       == vertex 2" $
+          removeVertex 1 (vertex 2 :: AAI) == vertex 2
+
+    test "removeVertex 1 (1 * 2)          == vertex 2" $
+          removeVertex 1 (1 * 2 :: AAI)   == vertex 2
+
+    test "removeVertex x . removeVertex x == removeVertex x" $ \(x :: Int) y ->
+         (removeVertex x . removeVertex x) y == removeVertex x y
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.removeEdge ============"
+    test "removeEdge 1 2 (1 * 2)          == vertices [1,2]" $
+          removeEdge 1 2 (1 * 2 :: AAI)   == vertices [1,2]
+
+    test "removeEdge x y . removeEdge x y == removeEdge x y" $ \(x :: Int) y z ->
+         (removeEdge x y . removeEdge x y) z == removeEdge x y z
+
+    test "removeEdge x y . removeVertex x == removeVertex x" $ \(x :: Int) y z ->
+         (removeEdge x y . removeVertex x) z == removeVertex x z
+
+    test "removeEdge 1 2 (1 * 2 * 3)      == (1 + 2) * 3" $
+          removeEdge 1 2 (1 * 2 * 3 :: AAI) == (1 + 2) * 3
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.transpose ============"
+    test "transpose empty       == empty" $
+          transpose (empty :: AAI) == empty
+
+    test "transpose (vertex x)  == vertex x" $ \(x :: Int) ->
+          transpose (vertex x)  == vertex x
+
+    test "transpose . transpose == id" $ size10 $ \(x :: AAI) ->
+         (transpose . transpose) x == id x
+
+    test "edgeList . transpose  == sort . map swap . edgeList" $ \(x :: AAI) ->
+         (edgeList . transpose) x == (sort . map swap . edgeList) x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.induce ============"
+    test "induce (const True ) x      == x" $ \(x :: AAI) ->
+          induce (const True ) x      == x
+
+    test "induce (const False) x      == empty" $ \(x :: AAI) ->
+          induce (const False) x      == empty
+
+    test "induce (/= x)               == removeVertex x" $ \x (y :: AAI) ->
+          induce (/= x) y             == removeVertex x y
+
+    test "induce p . induce q         == induce (\\x -> p x && q x)" $ \(apply -> p) (apply -> q) (y :: AAI) ->
+         (induce p . induce q) y      == induce (\x -> p x && q x) y
+
+    test "isSubgraphOf (induce p x) x == True" $ \(apply -> p) (x :: AAI) ->
+          isSubgraphOf (induce p x) x == True
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.induceJust ============"
+    test "induceJust (vertex Nothing) == empty" $
+          induceJust (vertex Nothing) == (empty :: AAI)
+
+    test "induceJust . vertex . Just  == vertex" $ \(x :: Int) ->
+         (induceJust . vertex . Just) x == vertex x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.box ============"
+    test "edgeList (box (1 * 2) (10 * 20)) == <correct result>\n" $
+          edgeList (box (1 * 2) (10 * 20)) == [ ((1,10), (1,20))
+                                              , ((1,10), (2,10))
+                                              , ((1,20), (2,20))
+                                              , ((2,10), (2 :: Int,20 :: Int)) ]
+
+    let unit = gmap $ \(a :: Int, ()      ) -> a
+        comm = gmap $ \(a :: Int, b :: Int) -> (b, a)
+    test "box x y               ~~ box y x" $ mapSize (min 10) $ \x y ->
+          comm (box x y)        == box y x
+
+    test "box x (vertex ())     ~~ x" $ mapSize (min 10) $ \x ->
+     unit(box x (vertex ()))    == (x `asTypeOf` empty)
+
+    test "box x empty           ~~ empty" $ mapSize (min 10) $ \x ->
+     unit(box x empty)          == empty
+
+    let assoc = gmap $ \(a :: Int, (b :: Int, c :: Int)) -> ((a, b), c)
+    test "box x (box y z)       ~~ box (box x y) z" $ mapSize (min 10) $ \x y z ->
+      assoc (box x (box y z))   == box (box x y) z
+
+    test "transpose   (box x y) == box (transpose x) (transpose y)" $ mapSize (min 10) $ \x y ->
+        let _ = x + y + vertex (0 :: Int) in
+          transpose   (box x y) == box (transpose x) (transpose y)
+
+    test "vertexCount (box x y) == vertexCount x * vertexCount y" $ mapSize (min 10) $ \x y ->
+        let _ = x + y + vertex (0 :: Int) in
+          vertexCount (box x y) == vertexCount x * vertexCount y
+
+    test "edgeCount   (box x y) <= vertexCount x * edgeCount y + edgeCount x * vertexCount y" $ mapSize (min 10) $ \x y ->
+        let _ = x + y + vertex (0 :: Int) in
+          edgeCount   (box x y) <= vertexCount x * edgeCount y + edgeCount x * vertexCount y
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.transitiveClosure ============"
+    test "transitiveClosure empty               == empty" $
+          transitiveClosure empty               == (empty :: AAI)
+
+    test "transitiveClosure (vertex x)          == vertex x" $ \(x :: Int) ->
+          transitiveClosure (vertex x)          == vertex x
+
+    test "transitiveClosure (1 * 2 + 2 * 3)     == 1 * 2 + 1 * 3 + 2 * 3" $
+          transitiveClosure (1 * 2 + 2 * 3  :: AAI) == 1 * 2 + 1 * 3 + 2 * 3
+
+    test "transitiveClosure . transitiveClosure == transitiveClosure" $ \(x :: AAI) ->
+         (transitiveClosure . transitiveClosure) x == transitiveClosure x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.topSort ============"
+    test "topSort empty                 == []" $
+          topSort (empty :: AAI)        == []
+
+    test "topSort (vertex x)            == [x]" $ \(x :: Int) ->
+          topSort (vertex x)            == [x]
+
+    test "topSort (1 * (2 + 4) + 3 * 4) == [3, 1, 4, 2]" $
+          topSort (1 * (2 + 4) + 3 * 4) == [3, 1, 4, 2 :: Int]
+
+    test "topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)" $ \(x :: AAI) (y :: AAI) ->
+          topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)
+
+    test "topSort                       == fromJust . topSort . fromAcyclic" $ \(x :: AAI) ->
+          topSort x                     == (fromJust . AM.topSort . fromAcyclic) x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.scc ============"
+    test "           scc empty               == empty" $
+                     scc (AM.empty :: AI)    == empty
+
+    test "           scc (vertex x)          == vertex (NonEmpty.vertex x)" $ \(x :: Int) ->
+                     scc (AM.vertex x)       == vertex (NonEmpty.vertex x)
+
+    test "           scc (edge 1 1)          == vertex (NonEmpty.edge 1 1)" $
+                     scc (AM.edge 1 1 :: AI) == vertex (NonEmpty.edge 1 1)
+
+    test "edgeList $ scc (edge 1 2)          == [ (NonEmpty.vertex 1       , NonEmpty.vertex 2       ) ]" $
+          edgeList (scc (AM.edge 1 2 :: AI)) == [ (NonEmpty.vertex 1       , NonEmpty.vertex 2       ) ]
+
+    test "edgeList $ scc (3 * 1 * 4 * 1 * 5) == <correct result>" $
+          edgeList (scc (3 * 1 * 4 * 1 * 5)) == [ (NonEmpty.vertex 3       , NonEmpty.vertex (5 :: Int))
+                                                , (NonEmpty.vertex 3       , NonEmpty.clique1 [1,4,1])
+                                                , (NonEmpty.clique1 [1,4,1], NonEmpty.vertex 5       ) ]
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.toAcyclic ============"
+    test "toAcyclic (path    [1,2,3]) == Just (1 * 2 + 2 * 3)" $
+          toAcyclic (AM.path [1,2,3]) == Just (1 * 2 + 2 * 3 :: AAI)
+
+    test "toAcyclic (clique  [3,2,1]) == Just (transpose (1 * 2 * 3))" $
+          toAcyclic (AM.clique [3,2,1]) == Just (transpose (1 * 2 * 3 :: AAI))
+
+    test "toAcyclic (circuit [1,2,3]) == Nothing" $
+          toAcyclic (AM.circuit [1,2,3 :: Int]) == Nothing
+
+    test "toAcyclic . fromAcyclic     == Just" $ \(x :: AAI) ->
+         (toAcyclic . fromAcyclic) x  == Just x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.toAcyclicOrd ============"
+    test "toAcyclicOrd empty       == empty" $
+          toAcyclicOrd AM.empty    == (empty :: AAI)
+
+    test "toAcyclicOrd . vertex    == vertex" $ \(x :: Int) ->
+         (toAcyclicOrd . AM.vertex) x == vertex x
+
+    test "toAcyclicOrd (1 + 2)     == 1 + 2" $
+          toAcyclicOrd (1 + 2)     == (1 + 2 :: AAI)
+
+    test "toAcyclicOrd (1 * 2)     == 1 * 2" $
+          toAcyclicOrd (1 * 2)     == (1 * 2 :: AAI)
+
+    test "toAcyclicOrd (2 * 1)     == 1 + 2" $
+          toAcyclicOrd (2 * 1)     == (1 + 2 :: AAI)
+
+    test "toAcyclicOrd (1 * 2 * 1) == 1 * 2" $
+          toAcyclicOrd (1 * 2 * 1) == (1 * 2 :: AAI)
+
+    test "toAcyclicOrd (1 * 2 * 3) == 1 * 2 * 3" $
+          toAcyclicOrd (1 * 2 * 3) == (1 * 2 * 3 :: AAI)
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.consistent ============"
+    test "Aribtrary"         $ \(x :: AAI) ->            consistent x
+    test "empty"             $                           consistent (empty :: AAI)
+    test "vertex"            $ \(x :: Int) ->            consistent (vertex x)
+    test "vertices"          $ \(xs :: [Int]) ->         consistent (vertices xs)
+    test "union"             $ \(x :: AAI) (y :: AAI) -> consistent (union x y)
+    test "join"              $ \(x :: AAI) (y :: AAI) -> consistent (join x y)
+    test "transpose"         $ \(x :: AAI) ->            consistent (transpose x)
+    test "box"               $ \(x :: AAI) (y :: AAI) -> consistent (box x y)
+    test "transitiveClosure" $ \(x :: AAI) ->            consistent (transitiveClosure x)
+    test "scc"               $ \(x :: AI)  ->            consistent (scc x)
+    test "toAcyclic"         $ \(x :: AI)  ->       fmap consistent (toAcyclic x) /= Just False
+    test "toAcyclicOrd"      $ \(x :: AI)  ->            consistent (toAcyclicOrd x)
+
+    putStrLn "\n============ AcyclicOrd consistent============"
+
+    test "edge" $ \x y                       -> consistent (edge x y :: AAI)
+    test "overlay" $ \x y                    -> consistent (overlay x y :: AAI)
+    test "connect" $ \x y                    -> consistent (connect x y :: AAI)
+    test "edges" $ \x                        -> consistent (edges x :: AAI)
+    test "overlays" $ \x                     -> consistent (overlays x :: AAI)
+    test "connects" $ \x                     -> consistent (connects x :: AAI)
+    test "replaceVertex" $ \x y z            -> consistent (replaceVertex x y z :: AAI)
+    test "mergeVertices" $ \(apply -> p) v x -> consistent (mergeVertices p v x :: AAI)
+    test "gmap" $ \(apply -> f) x            -> consistent (gmap f (x :: AAI) :: AAI)
+
+    putStrLn "\n============AcyclicOrd edge============"
+
+    test "edge x y                      == connect (vertex x) (vertex y)" $ \x y ->
+          (edge x y :: AAI)             == connect (vertex x) (vertex y)
+    test "hasEdge 1 2 (edge 1 2)        == True" $
+          hasEdge 1 2 (edge 1 2 :: AAI) == True
+    test "hasEdge 2 1 (edge 2 1)        == False" $
+          hasEdge 2 1 (edge 2 1 :: AAI) == False
+    test "edgeCount   (edge 1 2)        == 1" $
+          edgeCount   (edge 1 2 :: AAI) == 1
+    test "edgeCount   (edge 2 1)        == 0" $
+          edgeCount   (edge 2 1 :: AAI) == 0
+    test "vertexCount (edge 1 1)        == 1" $
+          vertexCount (edge 1 1 :: AAI) == 1
+    test "vertexCount (edge 1 2)        == 2" $
+          vertexCount (edge 1 2 :: AAI) == 2
+    test "vertexCount (edge 2 1)        == 2" $
+          vertexCount (edge 2 1 :: AAI) == 2
+
+    putStrLn "\n============AcyclicOrd overlay============"
+
+    test "isEmpty     (overlay x y)        == isEmpty x && isEmpty y" $ \x y ->
+          isEmpty     (overlay x y :: AAI) == (isEmpty x && isEmpty y)
+    test "hasVertex z (overlay x y)        == hasVertex z x || hasVertex z y" $ \x y z ->
+          hasVertex z (overlay x y :: AAI) == (hasVertex z x || hasVertex z y)
+    test "vertexCount (overlay x y)        >= vertexCount x" $ \x y ->
+          vertexCount (overlay x y :: AAI) >= vertexCount x
+    test "vertexCount (overlay x y)        <= vertexCount x + vertexCount y" $ \x y ->
+          vertexCount (overlay x y :: AAI) <= vertexCount x + vertexCount y
+    test "edgeCount   (overlay x y)        >= edgeCount x" $ \x y ->
+          edgeCount   (overlay x y :: AAI) >= edgeCount x
+    test "edgeCount   (overlay x y)        <= edgeCount x + edgeCount y" $ \x y ->
+          edgeCount   (overlay x y :: AAI) <= edgeCount x + edgeCount y
+    test "vertexCount (overlay 1 2)        == 2" $
+          vertexCount (overlay 1 2 :: AAI) == 2
+    test "edgeCount   (overlay 1 2)        == 0" $
+          edgeCount   (overlay 1 2 :: AAI) == 0
+
+    putStrLn "\n============AcyclicOrd connect============"
+
+    test "isEmpty     (connect x y)        == isEmpty x && isEmpty y" $ \x y ->
+          isEmpty     (connect x y :: AAI) == (isEmpty x && isEmpty y)
+    test "hasVertex z (connect x y)        == hasVertex z x || hasVertex z y" $ \x y z ->
+          hasVertex z (connect x y :: AAI) == (hasVertex z x || hasVertex z y)
+    test "vertexCount (connect x y)        >= vertexCount x" $ \x y ->
+          vertexCount (connect x y :: AAI) >= vertexCount x
+    test "vertexCount (connect x y)        <= vertexCount x + vertexCount y" $ \x y ->
+          vertexCount (connect x y :: AAI) <= vertexCount x + vertexCount y
+    test "edgeCount   (connect x y)        >= edgeCount x" $ \x y ->
+          edgeCount   (connect x y :: AAI) >= edgeCount x
+    test "edgeCount   (connect x y)        >= edgeCount y" $ \x y ->
+          edgeCount   (connect x y :: AAI) >= edgeCount y
+    test "edgeCount   (connect x y)        <= vertexCount x * vertexCount y + edgeCount x + edgeCount y" $ \x y ->
+          edgeCount   (connect x y :: AAI) <= vertexCount x * vertexCount y + edgeCount x + edgeCount y
+    test "vertexCount (connect 1 2)        == 2" $
+          vertexCount (connect 1 2 :: AAI) == 2
+    test "edgeCount   (connect 1 2)        == 1" $
+          edgeCount   (connect 1 2 :: AAI) == 1
+    test "edgeCount   (connect 2 1) == 0" $
+          edgeCount   (connect 2 1 :: AAI) == 0
+
+    putStrLn "\n============AcyclicOrd edges============"
+
+    test "edges []                   == empty" $
+          (edges [] :: AAI)          == empty
+    test "edges [(x,y)]              == edge x y" $ \x y ->
+          (edges [(x,y)] :: AAI)     == edge x y
+    test "edgeCount . edges          == length . filter (uncurry (<)) . Data.List.nub" $ \x ->
+          edgeCount (edges x :: AAI) == (length . filter (uncurry (<)) . List.nub $ x)
+    test "edgeList . edges           == filter (uncurry (<)) . Data.List.nub . Data.List.sort" $ \x ->
+          edgeList (edges x :: AAI)  == (filter (uncurry (<)) . List.nub . List.sort $ x)
+
+    putStrLn "\n============AcyclicOrd overlays============"
+
+    test "overlays []               == empty" $
+          (overlays [] :: AAI)      == empty
+    test "overlays [x]              == x" $ \x ->
+          (overlays [x] :: AAI)     == x
+    test "overlays [x,y]            == overlay x y" $ \x y ->
+          (overlays [x,y] :: AAI)   == overlay x y
+    test "overlays                  == foldr overlay empty" $ \x ->
+          (overlays x :: AAI)       == foldr overlay empty x
+    test "isEmpty . overlays        == all isEmpty" $ \x ->
+          isEmpty (overlays x :: AAI) == all isEmpty x
+
+    putStrLn "\n============ Acyclic.AdjacencyMap.Show ============"
+
+    test "connects []                 == empty" $
+          (connects [] :: AAI)        == empty
+    test "connects [x]                == x" $ \x ->
+          (connects [x] :: AAI)       == x
+    test "connects [x,y]              == connect x y" $ \x y ->
+          (connects [x,y] :: AAI)     == connect x y
+    test "connects                    == foldr connect empty" $ \x ->
+          (connects x :: AAI)         == foldr connect empty x
+    test "isEmpty . connects          == all isEmpty" $ \x ->
+          isEmpty (connects x :: AAI) == all isEmpty x
+
+    putStrLn "\n============AcyclicOrd replaceVertex============"
+
+    test "replaceVertex x x                   == id" $ \x y ->
+          (replaceVertex x x y :: AAI)        == id y
+    test "replaceVertex x y (vertex x)        == vertex y" $ \x y ->
+          replaceVertex x y (vertex x :: AAI) == vertex y
+    test "replaceVertex x y                   == mergeVertices ( == x) y" $ \x y z ->
+          (replaceVertex x y z :: AAI)        == mergeVertices ( == x) y z
+    test "replaceVertex 1 2 (1 * 3)           == 2 * 3" $
+          replaceVertex 1 2 (1 * 3 :: AAI)    == 2 * 3
+    test "replaceVertex 1 4 (1 * 3)           == 4 + 3" $
+          replaceVertex 1 4 (1 * 3 :: AAI)    == 4 + 3
+
+    putStrLn "\n============AcyclicOrd mergeVertices============"
+
+    test "mergeVertices (const False) x               == id" $ \x y ->
+          mergeVertices (const False) x (y :: AAI)    == id y
+    test "mergeVertices (                             == x) y             == replaceVertex x y" $ \x y z ->
+          mergeVertices (                             == x) y (z :: AAI)  == replaceVertex x y z
+    test "mergeVertices even 1 (0 * 2)                == 1" $
+          mergeVertices even 1 (0 * 2 :: AAI)         == 1
+    test "mergeVertices odd  1 (3 + 4 * 5)            == 4 + 1" $
+          mergeVertices odd  1 (3 + 4 * 5 :: AAI)     == 4 + 1
+    test "mergeVertices even 1 (2 * 3 + 4 * 5)        == 1 * 3 + 1 * 5" $
+          mergeVertices even 1 (2 * 3 + 4 * 5 :: AAI) == 1 * 3 + 1 * 5
+
+    putStrLn "\n============AcyclicOrd gmap============"
+
+    test "gmap f empty                                 == empty" $ \(apply -> f) ->
+          gmap f (empty :: AAI)                        == (empty :: AAI)
+    test "gmap f (vertex x)                            == vertex (f x)" $ \(apply -> f) x ->
+          gmap f (vertex x :: AAI)                     == (vertex (f x) :: AAI)
+    test "edgeCount (gmap f (edge x y))                <= edgeCount (edge (f x) (f y))" $ \(apply -> f) x y ->
+          edgeCount (gmap f (edge x y :: AAI))         <= edgeCount (edge (f x) (f y) :: AAI)
+    test "vertexList (gmap f (edge x y))               == vertexList (edge (f x) (f y))" $ \(apply -> f) x y ->
+          vertexList (gmap f (edge x y :: AAI))        == vertexList (edge (f x) (f y) :: AAI)
+    test "gmap id                                      == id" $ \x ->
+          gmap id (x :: AAI)                           == id x
+    test "vertexList . gmap f . gmap g                 == vertexList . gmap (f . g)" $ \(apply -> f) (apply -> g) x ->
+          vertexList (gmap f (gmap g x :: AAI) :: AAI) == vertexList (gmap (f . g) (x :: AAI))
+    test "edgeCount (gmap f (gmap g x))                <= edgeCount (gmap (f . g) x)" $ \(apply -> f) (apply -> g) x ->
+          edgeCount (gmap f (gmap g x :: AAI) :: AAI)  <= edgeCount (gmap (f . g) (x :: AAI))

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -80,8 +80,8 @@ testAcyclicAdjacencyMap = do
   test "arbitraryAcyclicAdjacencyMap" $ \x -> consistent (x :: AAI)
   test "empty" $                              consistent (empty :: AAI)
   test "vertex" $ \x                       -> consistent (vertex x :: AAI)
-  test "disjointOverlay" $ \x y            -> consistent (disjointOverlay x y :: AAE)
-  test "disjointConnect" $ \x y            -> consistent (disjointConnect x y :: AAE)
+  test "union" $ \x y                      -> consistent (union x y :: AAE)
+  test "join" $ \x y                       -> consistent (join x y :: AAE)
   test "vertices" $ \x                     -> consistent (vertices x :: AAI)
   test "box" $ \x y                        -> consistent (box x y :: AAT)
   test "transitiveClosure" $ \x            -> consistent (transitiveClosure x :: AAI)
@@ -123,8 +123,8 @@ testAcyclicAdjacencyMap = do
         isEmpty (empty :: AAI)                           == True
   test "isEmpty ('vertex' x)                             == False" $ \x ->
         isEmpty (vertex x :: AAI)                        == False
-  test "isEmpty ('disjointOverlay' 'empty' 'empty')             == True" $
-        isEmpty (disjointOverlay (empty :: AAI) (empty :: AAI)) == True
+  test "isEmpty ('union' 'empty' 'empty')                == True" $
+        isEmpty (union (empty :: AAI) (empty :: AAI))    == True
   test "isEmpty ('removeVertex' x $ 'vertex' x)          == True" $ \x ->
         isEmpty (removeVertex x $ vertex x :: AAI)       == True
   test "isEmpty ('removeEdge' 1 2 $ 1 * 2)               == False" $
@@ -150,47 +150,47 @@ testAcyclicAdjacencyMap = do
   test "'vertexSet'   . vertices          == Set.'Set.fromList'" $ \x ->
         (vertexSet (vertices x :: AAI))   == Set.fromList x
 
-  test "'isEmpty' (disjointOverlay x y)                  == 'isEmpty' x && 'isEmpty' y" $ \x y ->
-        isEmpty (disjointOverlay x y :: AAE)             == (isEmpty x && isEmpty y)
-  test "'hasVertex' (Left z) (disjointOverlay x y)       == 'hasVertex' z x" $ \x y z ->
-        hasVertex (Left z) (disjointOverlay x y :: AAE)  == hasVertex z x
-  test "'hasVertex' (Right z) (disjointOverlay x y)      == 'hasVertex' z y" $ \x y z ->
-        hasVertex (Right z) (disjointOverlay x y :: AAE) == hasVertex z y
-  test "'vertexCount' (disjointOverlay x y)              >= 'vertexCount' x" $ \x y ->
-        vertexCount (disjointOverlay x y :: AAE)         >= vertexCount x
-  test "'vertexCount' (disjointOverlay x y)              == 'vertexCount' x + 'vertexCount' y" $ \x y ->
-        vertexCount (disjointOverlay x y :: AAE)         == vertexCount x + vertexCount y
-  test "'edgeCount' (disjointOverlay x y)                >= 'edgeCount' x" $ \x y ->
-        edgeCount (disjointOverlay x y :: AAE)           >= edgeCount x
-  test "'edgeCount' (disjointOverlay x y)                == 'edgeCount' x   + 'edgeCount' y" $ \x y ->
-        edgeCount (disjointOverlay x y :: AAE)           == edgeCount x   + edgeCount y
-  test "'vertexCount' (disjointOverlay 1 2)              == 2" $
-        vertexCount (disjointOverlay 1 2 :: AAE)         == 2
-  test "'edgeCount' (disjointOverlay 1 2)                == 0" $
-        edgeCount (disjointOverlay 1 2 :: AAE)           == 0
+  test "'isEmpty' (union x y)                  == 'isEmpty' x && 'isEmpty' y" $ \x y ->
+        isEmpty (union x y :: AAE)             == (isEmpty x && isEmpty y)
+  test "'hasVertex' (Left z) (union x y)       == 'hasVertex' z x" $ \x y z ->
+        hasVertex (Left z) (union x y :: AAE)  == hasVertex z x
+  test "'hasVertex' (Right z) (union x y)      == 'hasVertex' z y" $ \x y z ->
+        hasVertex (Right z) (union x y :: AAE) == hasVertex z y
+  test "'vertexCount' (union x y)              >= 'vertexCount' x" $ \x y ->
+        vertexCount (union x y :: AAE)         >= vertexCount x
+  test "'vertexCount' (union x y)              == 'vertexCount' x + 'vertexCount' y" $ \x y ->
+        vertexCount (union x y :: AAE)         == vertexCount x + vertexCount y
+  test "'edgeCount' (union x y)                >= 'edgeCount' x" $ \x y ->
+        edgeCount (union x y :: AAE)           >= edgeCount x
+  test "'edgeCount' (union x y)                == 'edgeCount' x   + 'edgeCount' y" $ \x y ->
+        edgeCount (union x y :: AAE)           == edgeCount x   + edgeCount y
+  test "'vertexCount' (union 1 2)              == 2" $
+        vertexCount (union 1 2 :: AAE)         == 2
+  test "'edgeCount' (union 1 2)                == 0" $
+        edgeCount (union 1 2 :: AAE)           == 0
 
-  test "'isEmpty' (disjointConnect x y)                  == 'isEmpty' x && 'isEmpty' y" $ \x y ->
-        isEmpty (disjointConnect x y :: AAE)             == (isEmpty x && isEmpty y)
-  test "'hasVertex' (Left z) (disjointConnect x y)       == 'hasVertex' z x" $ \x y z ->
-        hasVertex (Left z) (disjointConnect x y :: AAE)  == hasVertex z x
-  test "'hasVertex' (Right z) (disjointConnect x y)      == 'hasVertex' z y" $ \x y z ->
-        hasVertex (Right z) (disjointConnect x y :: AAE) == hasVertex z y
-  test "'vertexCount' (disjointConnect x y)              >= 'vertexCount' x" $ \x y ->
-        vertexCount (disjointConnect x y :: AAE)         >= vertexCount x
-  test "'vertexCount' (disjointConnect x y)              == 'vertexCount' x + 'vertexCount' y" $ \x y ->
-        vertexCount (disjointConnect x y :: AAE)         == vertexCount x + vertexCount y
-  test "'edgeCount' (disjointConnect x y)                >= 'edgeCount' x" $ \x y ->
-        edgeCount (disjointConnect x y :: AAE)           >= edgeCount x
-  test "'edgeCount' (disjointConnect x y)                >= 'edgeCount' y" $ \x y ->
-        edgeCount (disjointConnect x y :: AAE)           >= edgeCount y
-  test "'edgeCount' (disjointConnect x y)                >= 'vertexCount' x * 'vertexCount' y" $ \x y ->
-        edgeCount (disjointConnect x y :: AAE)           >= vertexCount x * vertexCount y
-  test "'edgeCount' (disjointConnect x y)                == 'vertexCount' x * 'vertexCount' y + 'edgeCount' x + 'edgeCount' y" $ \x y ->
-        edgeCount (disjointConnect x y :: AAE)           == vertexCount x * vertexCount y + edgeCount x + edgeCount y
-  test "'vertexCount' (disjointConnect 1 2)              == 2" $
-        vertexCount (disjointConnect 1 2 :: AAE)         == 2
-  test "'edgeCount' (disjointConnect 1 2)                == 1" $
-        edgeCount (disjointConnect 1 2 :: AAE)           == 1
+  test "'isEmpty' (join x y)                  == 'isEmpty' x && 'isEmpty' y" $ \x y ->
+        isEmpty (join x y :: AAE)             == (isEmpty x && isEmpty y)
+  test "'hasVertex' (Left z) (join x y)       == 'hasVertex' z x" $ \x y z ->
+        hasVertex (Left z) (join x y :: AAE)  == hasVertex z x
+  test "'hasVertex' (Right z) (join x y)      == 'hasVertex' z y" $ \x y z ->
+        hasVertex (Right z) (join x y :: AAE) == hasVertex z y
+  test "'vertexCount' (join x y)              >= 'vertexCount' x" $ \x y ->
+        vertexCount (join x y :: AAE)         >= vertexCount x
+  test "'vertexCount' (join x y)              == 'vertexCount' x + 'vertexCount' y" $ \x y ->
+        vertexCount (join x y :: AAE)         == vertexCount x + vertexCount y
+  test "'edgeCount' (join x y)                >= 'edgeCount' x" $ \x y ->
+        edgeCount (join x y :: AAE)           >= edgeCount x
+  test "'edgeCount' (join x y)                >= 'edgeCount' y" $ \x y ->
+        edgeCount (join x y :: AAE)           >= edgeCount y
+  test "'edgeCount' (join x y)                >= 'vertexCount' x * 'vertexCount' y" $ \x y ->
+        edgeCount (join x y :: AAE)           >= vertexCount x * vertexCount y
+  test "'edgeCount' (join x y)                == 'vertexCount' x * 'vertexCount' y + 'edgeCount' x + 'edgeCount' y" $ \x y ->
+        edgeCount (join x y :: AAE)           == vertexCount x * vertexCount y + edgeCount x + edgeCount y
+  test "'vertexCount' (join 1 2)              == 2" $
+        vertexCount (join 1 2 :: AAE)         == 2
+  test "'edgeCount' (join 1 2)                == 1" $
+        edgeCount (join 1 2 :: AAE)           == 1
 
   putStrLn "\n=====AcyclicAdjacencyMap transitiveClosure====="
 

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -12,7 +12,7 @@
 module Algebra.Graph.Test.Acyclic.AdjacencyMap (testAcyclicAdjacencyMap) where
 
 import Algebra.Graph.Acyclic.AdjacencyMap
-import Algebra.Graph.Acyclic.Ord
+import Algebra.Graph.Acyclic.AdjacencyMap.Ord
 import Algebra.Graph.Internal
 import Algebra.Graph.Test
 import Algebra.Graph.Test.Generic
@@ -396,30 +396,31 @@ testAcyclicAdjacencyMap = do
                                               , ((1,20), (2,20))
                                               , ((2,10), (2 :: Int,20 :: Int)) ]
 
-    let unit = gmap $ \(a :: Int, ()      ) -> a
+    let gmap f = toAcyclicOrd . AM.gmap f . fromAcyclic
+        unit = gmap $ \(a :: Int, ()      ) -> a
         comm = gmap $ \(a :: Int, b :: Int) -> (b, a)
-    test "box x y               ~~ box y x" $ mapSize (min 10) $ \x y ->
+    test "box x y               ~~ box y x" $ size10 $ \x y ->
           comm (box x y)        == box y x
 
-    test "box x (vertex ())     ~~ x" $ mapSize (min 10) $ \x ->
+    test "box x (vertex ())     ~~ x" $ size10 $ \x ->
      unit(box x (vertex ()))    == (x `asTypeOf` empty)
 
-    test "box x empty           ~~ empty" $ mapSize (min 10) $ \x ->
+    test "box x empty           ~~ empty" $ size10 $ \x ->
      unit(box x empty)          == empty
 
     let assoc = gmap $ \(a :: Int, (b :: Int, c :: Int)) -> ((a, b), c)
-    test "box x (box y z)       ~~ box (box x y) z" $ mapSize (min 10) $ \x y z ->
+    test "box x (box y z)       ~~ box (box x y) z" $ size10 $ \x y z ->
       assoc (box x (box y z))   == box (box x y) z
 
-    test "transpose   (box x y) == box (transpose x) (transpose y)" $ mapSize (min 10) $ \x y ->
+    test "transpose   (box x y) == box (transpose x) (transpose y)" $ size10 $ \x y ->
         let _ = x + y + vertex (0 :: Int) in
           transpose   (box x y) == box (transpose x) (transpose y)
 
-    test "vertexCount (box x y) == vertexCount x * vertexCount y" $ mapSize (min 10) $ \x y ->
+    test "vertexCount (box x y) == vertexCount x * vertexCount y" $ size10 $ \x y ->
         let _ = x + y + vertex (0 :: Int) in
           vertexCount (box x y) == vertexCount x * vertexCount y
 
-    test "edgeCount   (box x y) <= vertexCount x * edgeCount y + edgeCount x * vertexCount y" $ mapSize (min 10) $ \x y ->
+    test "edgeCount   (box x y) <= vertexCount x * edgeCount y + edgeCount x * vertexCount y" $ size10 $ \x y ->
         let _ = x + y + vertex (0 :: Int) in
           edgeCount   (box x y) <= vertexCount x * edgeCount y + edgeCount x * vertexCount y
 
@@ -506,168 +507,149 @@ testAcyclicAdjacencyMap = do
           toAcyclicOrd (1 * 2 * 3) == (1 * 2 * 3 :: AAI)
 
     putStrLn "\n============ Acyclic.AdjacencyMap.consistent ============"
-    test "Aribtrary"         $ \(x :: AAI) ->            consistent x
+    test "Arbitrary"         $ \(x :: AAI)            -> consistent x
     test "empty"             $                           consistent (empty :: AAI)
-    test "vertex"            $ \(x :: Int) ->            consistent (vertex x)
-    test "vertices"          $ \(xs :: [Int]) ->         consistent (vertices xs)
+    test "vertex"            $ \(x :: Int)            -> consistent (vertex x)
+    test "vertices"          $ \(xs :: [Int])         -> consistent (vertices xs)
     test "union"             $ \(x :: AAI) (y :: AAI) -> consistent (union x y)
     test "join"              $ \(x :: AAI) (y :: AAI) -> consistent (join x y)
-    test "transpose"         $ \(x :: AAI) ->            consistent (transpose x)
-    test "box"               $ \(x :: AAI) (y :: AAI) -> consistent (box x y)
-    test "transitiveClosure" $ \(x :: AAI) ->            consistent (transitiveClosure x)
-    test "scc"               $ \(x :: AI)  ->            consistent (scc x)
-    test "toAcyclic"         $ \(x :: AI)  ->       fmap consistent (toAcyclic x) /= Just False
-    test "toAcyclicOrd"      $ \(x :: AI)  ->            consistent (toAcyclicOrd x)
+    test "transpose"         $ \(x :: AAI)            -> consistent (transpose x)
+    test "box"      $ size10 $ \(x :: AAI) (y :: AAI) -> consistent (box x y)
+    test "transitiveClosure" $ \(x :: AAI)            -> consistent (transitiveClosure x)
+    test "scc"               $ \(x :: AI)             -> consistent (scc x)
+    test "toAcyclic"         $ \(x :: AI)        -> fmap consistent (toAcyclic x) /= Just False
+    test "toAcyclicOrd"      $ \(x :: AI)             -> consistent (toAcyclicOrd x)
 
-    putStrLn "\n============ AcyclicOrd consistent============"
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.edge ============"
+    test "edge x y               == connect (vertex x) (vertex y)" $ \x y ->
+          (edge x y :: AAI)      == connect (vertex x) (vertex y)
 
-    test "edge" $ \x y                       -> consistent (edge x y :: AAI)
-    test "overlay" $ \x y                    -> consistent (overlay x y :: AAI)
-    test "connect" $ \x y                    -> consistent (connect x y :: AAI)
-    test "edges" $ \x                        -> consistent (edges x :: AAI)
-    test "overlays" $ \x                     -> consistent (overlays x :: AAI)
-    test "connects" $ \x                     -> consistent (connects x :: AAI)
-    test "replaceVertex" $ \x y z            -> consistent (replaceVertex x y z :: AAI)
-    test "mergeVertices" $ \(apply -> p) v x -> consistent (mergeVertices p v x :: AAI)
-    test "gmap" $ \(apply -> f) x            -> consistent (gmap f (x :: AAI) :: AAI)
-
-    putStrLn "\n============AcyclicOrd edge============"
-
-    test "edge x y                      == connect (vertex x) (vertex y)" $ \x y ->
-          (edge x y :: AAI)             == connect (vertex x) (vertex y)
-    test "hasEdge 1 2 (edge 1 2)        == True" $
+    test "hasEdge 1 2 (edge 1 2) == True" $
           hasEdge 1 2 (edge 1 2 :: AAI) == True
-    test "hasEdge 2 1 (edge 2 1)        == False" $
+
+    test "hasEdge 2 1 (edge 2 1) == False" $
           hasEdge 2 1 (edge 2 1 :: AAI) == False
-    test "edgeCount   (edge 1 2)        == 1" $
+
+    test "edgeCount   (edge 1 2) == 1" $
           edgeCount   (edge 1 2 :: AAI) == 1
-    test "edgeCount   (edge 2 1)        == 0" $
+
+    test "edgeCount   (edge 2 1) == 0" $
           edgeCount   (edge 2 1 :: AAI) == 0
-    test "vertexCount (edge 1 1)        == 1" $
+
+    test "vertexCount (edge 1 1) == 1" $
           vertexCount (edge 1 1 :: AAI) == 1
-    test "vertexCount (edge 1 2)        == 2" $
+
+    test "vertexCount (edge 1 2) == 2" $
           vertexCount (edge 1 2 :: AAI) == 2
-    test "vertexCount (edge 2 1)        == 2" $
+
+    test "vertexCount (edge 2 1) == 2" $
           vertexCount (edge 2 1 :: AAI) == 2
 
-    putStrLn "\n============AcyclicOrd overlay============"
-
-    test "isEmpty     (overlay x y)        == isEmpty x && isEmpty y" $ \x y ->
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.overlay ============"
+    test "isEmpty     (overlay x y) == isEmpty x && isEmpty y" $ \x y ->
           isEmpty     (overlay x y :: AAI) == (isEmpty x && isEmpty y)
-    test "hasVertex z (overlay x y)        == hasVertex z x || hasVertex z y" $ \x y z ->
+
+    test "hasVertex z (overlay x y) == hasVertex z x || hasVertex z y" $ \x y z ->
           hasVertex z (overlay x y :: AAI) == (hasVertex z x || hasVertex z y)
-    test "vertexCount (overlay x y)        >= vertexCount x" $ \x y ->
+
+    test "vertexCount (overlay x y) >= vertexCount x" $ \x y ->
           vertexCount (overlay x y :: AAI) >= vertexCount x
-    test "vertexCount (overlay x y)        <= vertexCount x + vertexCount y" $ \x y ->
+
+    test "vertexCount (overlay x y) <= vertexCount x + vertexCount y" $ \x y ->
           vertexCount (overlay x y :: AAI) <= vertexCount x + vertexCount y
-    test "edgeCount   (overlay x y)        >= edgeCount x" $ \x y ->
+
+    test "edgeCount   (overlay x y) >= edgeCount x" $ \x y ->
           edgeCount   (overlay x y :: AAI) >= edgeCount x
-    test "edgeCount   (overlay x y)        <= edgeCount x + edgeCount y" $ \x y ->
+
+    test "edgeCount   (overlay x y) <= edgeCount x + edgeCount y" $ \x y ->
           edgeCount   (overlay x y :: AAI) <= edgeCount x + edgeCount y
-    test "vertexCount (overlay 1 2)        == 2" $
+
+    test "vertexCount (overlay 1 2) == 2" $
           vertexCount (overlay 1 2 :: AAI) == 2
-    test "edgeCount   (overlay 1 2)        == 0" $
+
+    test "edgeCount   (overlay 1 2) == 0" $
           edgeCount   (overlay 1 2 :: AAI) == 0
 
-    putStrLn "\n============AcyclicOrd connect============"
-
-    test "isEmpty     (connect x y)        == isEmpty x && isEmpty y" $ \x y ->
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.connect ============"
+    test "isEmpty     (connect x y) == isEmpty x && isEmpty y" $ \x y ->
           isEmpty     (connect x y :: AAI) == (isEmpty x && isEmpty y)
-    test "hasVertex z (connect x y)        == hasVertex z x || hasVertex z y" $ \x y z ->
+
+    test "hasVertex z (connect x y) == hasVertex z x || hasVertex z y" $ \x y z ->
           hasVertex z (connect x y :: AAI) == (hasVertex z x || hasVertex z y)
-    test "vertexCount (connect x y)        >= vertexCount x" $ \x y ->
+
+    test "vertexCount (connect x y) >= vertexCount x" $ \x y ->
           vertexCount (connect x y :: AAI) >= vertexCount x
-    test "vertexCount (connect x y)        <= vertexCount x + vertexCount y" $ \x y ->
+
+    test "vertexCount (connect x y) <= vertexCount x + vertexCount y" $ \x y ->
           vertexCount (connect x y :: AAI) <= vertexCount x + vertexCount y
-    test "edgeCount   (connect x y)        >= edgeCount x" $ \x y ->
+
+    test "edgeCount   (connect x y) >= edgeCount x" $ \x y ->
           edgeCount   (connect x y :: AAI) >= edgeCount x
-    test "edgeCount   (connect x y)        >= edgeCount y" $ \x y ->
+
+    test "edgeCount   (connect x y) >= edgeCount y" $ \x y ->
           edgeCount   (connect x y :: AAI) >= edgeCount y
-    test "edgeCount   (connect x y)        <= vertexCount x * vertexCount y + edgeCount x + edgeCount y" $ \x y ->
+
+    test "edgeCount   (connect x y) <= vertexCount x * vertexCount y + edgeCount x + edgeCount y" $ \x y ->
           edgeCount   (connect x y :: AAI) <= vertexCount x * vertexCount y + edgeCount x + edgeCount y
-    test "vertexCount (connect 1 2)        == 2" $
+
+    test "vertexCount (connect 1 2) == 2" $
           vertexCount (connect 1 2 :: AAI) == 2
-    test "edgeCount   (connect 1 2)        == 1" $
+
+    test "edgeCount   (connect 1 2) == 1" $
           edgeCount   (connect 1 2 :: AAI) == 1
+
     test "edgeCount   (connect 2 1) == 0" $
           edgeCount   (connect 2 1 :: AAI) == 0
 
-    putStrLn "\n============AcyclicOrd edges============"
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.edges ============"
+    test "edges []          == empty" $
+          (edges [] :: AAI) == empty
 
-    test "edges []                   == empty" $
-          (edges [] :: AAI)          == empty
-    test "edges [(x,y)]              == edge x y" $ \x y ->
-          (edges [(x,y)] :: AAI)     == edge x y
-    test "edgeCount . edges          == length . filter (uncurry (<)) . Data.List.nub" $ \x ->
+    test "edges [(x,y)]     == edge x y" $ \x y ->
+          (edges [(x,y)] :: AAI) == edge x y
+
+    test "edgeCount . edges == length . filter (uncurry (<)) . Data.List.nub" $ \x ->
           edgeCount (edges x :: AAI) == (length . filter (uncurry (<)) . List.nub $ x)
-    test "edgeList . edges           == filter (uncurry (<)) . Data.List.nub . Data.List.sort" $ \x ->
-          edgeList (edges x :: AAI)  == (filter (uncurry (<)) . List.nub . List.sort $ x)
 
-    putStrLn "\n============AcyclicOrd overlays============"
+    test "edgeList . edges  == filter (uncurry (<)) . Data.List.nub . Data.List.sort" $ \x ->
+          edgeList (edges x :: AAI) == (filter (uncurry (<)) . List.nub . List.sort $ x)
 
-    test "overlays []               == empty" $
-          (overlays [] :: AAI)      == empty
-    test "overlays [x]              == x" $ \x ->
-          (overlays [x] :: AAI)     == x
-    test "overlays [x,y]            == overlay x y" $ \x y ->
-          (overlays [x,y] :: AAI)   == overlay x y
-    test "overlays                  == foldr overlay empty" $ \x ->
-          (overlays x :: AAI)       == foldr overlay empty x
-    test "isEmpty . overlays        == all isEmpty" $ \x ->
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.overlays ============"
+    test "overlays []        == empty" $
+          (overlays [] :: AAI) == empty
+
+    test "overlays [x]       == x" $ \x ->
+          (overlays [x] :: AAI) == x
+
+    test "overlays [x,y]     == overlay x y" $ \x y ->
+          (overlays [x,y] :: AAI) == overlay x y
+
+    test "overlays           == foldr overlay empty" $ size10 $ \x ->
+          (overlays x :: AAI) == foldr overlay empty x
+
+    test "isEmpty . overlays == all isEmpty" $ size10 $ \x ->
           isEmpty (overlays x :: AAI) == all isEmpty x
 
-    putStrLn "\n============ Acyclic.AdjacencyMap.Show ============"
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.connects ============"
+    test "connects []        == empty" $
+          (connects [] :: AAI) == empty
 
-    test "connects []                 == empty" $
-          (connects [] :: AAI)        == empty
-    test "connects [x]                == x" $ \x ->
-          (connects [x] :: AAI)       == x
-    test "connects [x,y]              == connect x y" $ \x y ->
-          (connects [x,y] :: AAI)     == connect x y
-    test "connects                    == foldr connect empty" $ \x ->
-          (connects x :: AAI)         == foldr connect empty x
-    test "isEmpty . connects          == all isEmpty" $ \x ->
+    test "connects [x]       == x" $ \x ->
+          (connects [x] :: AAI) == x
+
+    test "connects [x,y]     == connect x y" $ \x y ->
+          (connects [x,y] :: AAI) == connect x y
+
+    test "connects           == foldr connect empty" $ size10 $ \x ->
+          (connects x :: AAI) == foldr connect empty x
+
+    test "isEmpty . connects == all isEmpty" $ size10 $ \x ->
           isEmpty (connects x :: AAI) == all isEmpty x
 
-    putStrLn "\n============AcyclicOrd replaceVertex============"
-
-    test "replaceVertex x x                   == id" $ \x y ->
-          (replaceVertex x x y :: AAI)        == id y
-    test "replaceVertex x y (vertex x)        == vertex y" $ \x y ->
-          replaceVertex x y (vertex x :: AAI) == vertex y
-    test "replaceVertex x y                   == mergeVertices ( == x) y" $ \x y z ->
-          (replaceVertex x y z :: AAI)        == mergeVertices ( == x) y z
-    test "replaceVertex 1 2 (1 * 3)           == 2 * 3" $
-          replaceVertex 1 2 (1 * 3 :: AAI)    == 2 * 3
-    test "replaceVertex 1 4 (1 * 3)           == 4 + 3" $
-          replaceVertex 1 4 (1 * 3 :: AAI)    == 4 + 3
-
-    putStrLn "\n============AcyclicOrd mergeVertices============"
-
-    test "mergeVertices (const False) x               == id" $ \x y ->
-          mergeVertices (const False) x (y :: AAI)    == id y
-    test "mergeVertices (                             == x) y             == replaceVertex x y" $ \x y z ->
-          mergeVertices (                             == x) y (z :: AAI)  == replaceVertex x y z
-    test "mergeVertices even 1 (0 * 2)                == 1" $
-          mergeVertices even 1 (0 * 2 :: AAI)         == 1
-    test "mergeVertices odd  1 (3 + 4 * 5)            == 4 + 1" $
-          mergeVertices odd  1 (3 + 4 * 5 :: AAI)     == 4 + 1
-    test "mergeVertices even 1 (2 * 3 + 4 * 5)        == 1 * 3 + 1 * 5" $
-          mergeVertices even 1 (2 * 3 + 4 * 5 :: AAI) == 1 * 3 + 1 * 5
-
-    putStrLn "\n============AcyclicOrd gmap============"
-
-    test "gmap f empty                                 == empty" $ \(apply -> f) ->
-          gmap f (empty :: AAI)                        == (empty :: AAI)
-    test "gmap f (vertex x)                            == vertex (f x)" $ \(apply -> f) x ->
-          gmap f (vertex x :: AAI)                     == (vertex (f x) :: AAI)
-    test "edgeCount (gmap f (edge x y))                <= edgeCount (edge (f x) (f y))" $ \(apply -> f) x y ->
-          edgeCount (gmap f (edge x y :: AAI))         <= edgeCount (edge (f x) (f y) :: AAI)
-    test "vertexList (gmap f (edge x y))               == vertexList (edge (f x) (f y))" $ \(apply -> f) x y ->
-          vertexList (gmap f (edge x y :: AAI))        == vertexList (edge (f x) (f y) :: AAI)
-    test "gmap id                                      == id" $ \x ->
-          gmap id (x :: AAI)                           == id x
-    test "vertexList . gmap f . gmap g                 == vertexList . gmap (f . g)" $ \(apply -> f) (apply -> g) x ->
-          vertexList (gmap f (gmap g x :: AAI) :: AAI) == vertexList (gmap (f . g) (x :: AAI))
-    test "edgeCount (gmap f (gmap g x))                <= edgeCount (gmap (f . g) x)" $ \(apply -> f) (apply -> g) x ->
-          edgeCount (gmap f (gmap g x :: AAI) :: AAI)  <= edgeCount (gmap (f . g) (x :: AAI))
+    putStrLn "\n============ Acyclic.AdjacencyMap.Ord.consistent ============"
+    test "edge"              $ \x y -> consistent (edge x y    :: AAI)
+    test "overlay"           $ \x y -> consistent (overlay x y :: AAI)
+    test "connect"           $ \x y -> consistent (connect x y :: AAI)
+    test "edges"             $ \x   -> consistent (edges x     :: AAI)
+    test "overlays" $ size10 $ \x   -> consistent (overlays x  :: AAI)
+    test "connects" $ size10 $ \x   -> consistent (connects x  :: AAI)

--- a/test/Algebra/Graph/Test/Arbitrary.hs
+++ b/test/Algebra/Graph/Test/Arbitrary.hs
@@ -62,11 +62,11 @@ instance Arbitrary a => Arbitrary (Graph a) where
 
 -- An Arbitrary instance for Acyclic.AdjacencyMap
 instance (Ord a, Arbitrary a) => Arbitrary (AAM.AdjacencyMap a) where
-    arbitrary = AAM.fromGraph (<) <$> arbitrary
+    arbitrary = AAM.toAcyclicOrd <$> arbitrary
 
     shrink g = shrinkVertices ++ shrinkEdges
       where
-        shrinkVertices = 
+        shrinkVertices =
           let vertices = AAM.vertexList g
           in [ AAM.removeVertex x g | x <- vertices ]
 

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -870,7 +870,7 @@ testHasVertex :: TestsuiteInt g -> IO ()
 testHasVertex (prefix, API{..}) = do
     putStrLn $ "\n============ " ++ prefix ++ "hasVertex ============"
     test "hasVertex x empty            == False" $ \x ->
-          hasVertex x empty          == False
+          hasVertex x empty            == False
 
     test "hasVertex x (vertex x)       == True" $ \x ->
           hasVertex x (vertex x)       == True
@@ -1520,10 +1520,13 @@ testInduceJust (prefix, API{..}) = do
     putStrLn $ "\n============ " ++ prefix ++ "induceJust ============"
     test "induceJust (vertex Nothing)                               == empty" $
           induceJust (vertex (Nothing :: Maybe Int))                == empty
+
     test "induceJust (edge (Just x) Nothing)                        == vertex x" $ \x ->
           induceJust (edge (Just x) (Nothing :: Maybe Int))         == vertex x
+
     test "induceJust . gmap Just                                    == id" $ \(x :: g Int) ->
          (induceJust . gmap Just) x                                 == id x
+
     test "induceJust . gmap (\\x -> if p x then Just x else Nothing) == induce p" $ \(x :: g Int) (apply -> p) ->
          (induceJust . gmap (\x -> if p x then Just x else Nothing)) x == induce p x
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -26,18 +26,19 @@ import System.Environment
 main :: IO ()
 main = do
     selected <- getArgs
+    putStrLn (show selected)
     let go current = when (null selected || current `elem` selected)
-    go "AcyclicAdjacencyMap"   testAcyclicAdjacencyMap
-    go "AdjacencyIntMap"       testAdjacencyIntMap
-    go "AdjacencyMap"          testAdjacencyMap
-    go "BipartiteAdjacencyMap" testBipartiteAdjacencyMap
-    go "Export"                testExport
-    go "Graph"                 testGraph
-    go "Internal"              testInternal
-    go "LabelledAdjacencyMap"  testLabelledAdjacencyMap
-    go "LabelledGraph"         testLabelledGraph
-    go "NonEmptyAdjacencyMap"  testNonEmptyAdjacencyMap
-    go "NonEmptyGraph"         testNonEmptyGraph
-    go "Relation"              testRelation
-    go "SymmetricRelation"     testSymmetricRelation
-    go "Typed"                 testTyped
+    go "Acyclic.AdjacencyMap"   testAcyclicAdjacencyMap
+    go "AdjacencyIntMap"        testAdjacencyIntMap
+    go "AdjacencyMap"           testAdjacencyMap
+    go "Bipartite.AdjacencyMap" testBipartiteAdjacencyMap
+    go "Export"                 testExport
+    go "Graph"                  testGraph
+    go "Internal"               testInternal
+    go "Labelled.AdjacencyMap"  testLabelledAdjacencyMap
+    go "Labelled.Graph"         testLabelledGraph
+    go "NonEmpty.AdjacencyMap"  testNonEmptyAdjacencyMap
+    go "NonEmpty.Graph"         testNonEmptyGraph
+    go "Relation"               testRelation
+    go "Symmetric.Relation"     testSymmetricRelation
+    go "Typed"                  testTyped

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -20,13 +20,12 @@ import System.Environment
 -- you would like to execute only some specific testsuites, you can specify
 -- their names in the command line. For example:
 --
--- stack test --test-arguments "Graph SymmetricRelation"
+-- > stack test --test-arguments "Graph Symmetric.Relation"
 --
 -- will test the modules "Algebra.Graph" and "Algebra.Graph.Symmetric.Relation".
 main :: IO ()
 main = do
     selected <- getArgs
-    putStrLn (show selected)
     let go current = when (null selected || current `elem` selected)
     go "Acyclic.AdjacencyMap"   testAcyclicAdjacencyMap
     go "AdjacencyIntMap"        testAdjacencyIntMap


### PR DESCRIPTION
This PR includes:
* A lot of changes to comments, examples, implementation and tests.
* Renaming `disjointOverlay` to `union` and `disjointConnect` to `join`, which are commonly used terms.
* Adding some missing functions: `isSubgraphOf`, `preSet`, `postSet`.
* Removal of `PartialOrder`: I'm still hesitating about providing an unsafe construction method.
* Moving `Acyclic.Ord` to `Acyclic.AdjacencyMap.Ord`, and removing some functions from the API.