### PR TITLE
improve dfs & top sort performance

### DIFF
--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -1,5 +1,3 @@
-{-# language ViewPatterns #-}
-
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Acyclic.AdjacencyMap

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -52,14 +52,13 @@ module Algebra.Graph.Acyclic.AdjacencyMap (
     consistent
     ) where
 
-import Data.Maybe
+import Data.Either
 import Data.Set (Set)
 import Data.Coerce (coerce)
 
 import qualified Algebra.Graph.AdjacencyMap           as AM
 import qualified Algebra.Graph.AdjacencyMap.Algorithm as AM
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap  as NAM
-import qualified Data.Graph.Typed                     as Typed
 import qualified Data.Map                             as Map
 import qualified Data.Set                             as Set
 
@@ -485,7 +484,8 @@ transitiveClosure = coerce AM.transitiveClosure
 -- topSort                       == 'fromJust' . 'AM.topSort' . 'fromAcyclic'
 -- @
 topSort :: Ord a => AdjacencyMap a -> [a]
-topSort (AAM am) = fromJust (AM.topSort am)
+topSort (AAM am) = fromRight impossible (AM.topSort am) where
+  impossible = error "topSort on Acyclic Graph returned cycle"
 
 -- | Compute the acyclic /condensation/ of a graph, where each vertex
 -- corresponds to a /strongly-connected component/ of the original graph. Note

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -486,6 +486,7 @@ transitiveClosure = coerce AM.transitiveClosure
 -- @
 topSort :: Ord a => AdjacencyMap a -> [a]
 topSort (AM.topSort . coerce -> Right vs) = vs
+topSort _ = error "topSort on Acyclic Graph produced cycle"
 
 -- | Compute the acyclic /condensation/ of a graph, where each vertex
 -- corresponds to a /strongly-connected component/ of the original graph. Note

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -52,6 +52,7 @@ module Algebra.Graph.Acyclic.AdjacencyMap (
     consistent
     ) where
 
+import Data.Maybe
 import Data.Set (Set)
 import Data.Coerce (coerce)
 
@@ -479,12 +480,12 @@ transitiveClosure = coerce AM.transitiveClosure
 -- @
 -- topSort 'empty'                 == []
 -- topSort ('vertex' x)            == [x]
--- topSort (1 * (2 + 4) + 3 * 4) == [3, 1, 4, 2]
+-- topSort (1 * (2 + 4) + 3 * 4) == [1, 2, 3, 4]
 -- topSort ('join' x y)            == 'fmap' 'Left' (topSort x) ++ 'fmap' 'Right' (topSort y)
--- topSort                       == 'Data.Maybe.fromJust' . topSort . 'fromAcyclic'
+-- topSort                       == 'fromJust' . 'AM.topSort' . 'fromAcyclic'
 -- @
-topSort :: (Ord a) => AdjacencyMap a -> [a]
-topSort (AAM am) = Typed.topSort (Typed.fromAdjacencyMap am)
+topSort :: Ord a => AdjacencyMap a -> [a]
+topSort (AAM am) = fromJust (AM.topSort am)
 
 -- | Compute the acyclic /condensation/ of a graph, where each vertex
 -- corresponds to a /strongly-connected component/ of the original graph. Note

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -485,8 +485,9 @@ transitiveClosure = coerce AM.transitiveClosure
 -- 'Right' . topSort               == 'AM.topSort' . 'fromAcyclic'
 -- @
 topSort :: Ord a => AdjacencyMap a -> [a]
-topSort (AM.topSort . coerce -> Right vs) = vs
-topSort _ = error "topSort on Acyclic Graph produced cycle"
+topSort g = case AM.topSort (coerce g) of
+  Right vs -> vs
+  Left _ ->error "Internal error: the acyclicity invariant is violated in topSort"
 
 -- | Compute the acyclic /condensation/ of a graph, where each vertex
 -- corresponds to a /strongly-connected component/ of the original graph. Note

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -487,7 +487,7 @@ transitiveClosure = coerce AM.transitiveClosure
 topSort :: Ord a => AdjacencyMap a -> [a]
 topSort g = case AM.topSort (coerce g) of
   Right vs -> vs
-  Left _ ->error "Internal error: the acyclicity invariant is violated in topSort"
+  Left _ -> error "Internal error: the acyclicity invariant is violated in topSort"
 
 -- | Compute the acyclic /condensation/ of a graph, where each vertex
 -- corresponds to a /strongly-connected component/ of the original graph. Note

--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -1,3 +1,5 @@
+{-# language ViewPatterns #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Acyclic.AdjacencyMap
@@ -52,7 +54,6 @@ module Algebra.Graph.Acyclic.AdjacencyMap (
     consistent
     ) where
 
-import Data.Either
 import Data.Set (Set)
 import Data.Coerce (coerce)
 
@@ -481,11 +482,10 @@ transitiveClosure = coerce AM.transitiveClosure
 -- topSort ('vertex' x)            == [x]
 -- topSort (1 * (2 + 4) + 3 * 4) == [1, 2, 3, 4]
 -- topSort ('join' x y)            == 'fmap' 'Left' (topSort x) ++ 'fmap' 'Right' (topSort y)
--- topSort                       == 'fromJust' . 'AM.topSort' . 'fromAcyclic'
+-- 'Right' . topSort               == 'AM.topSort' . 'fromAcyclic'
 -- @
 topSort :: Ord a => AdjacencyMap a -> [a]
-topSort (AAM am) = fromRight impossible (AM.topSort am) where
-  impossible = error "topSort on Acyclic Graph returned cycle"
+topSort (AM.topSort . coerce -> Right vs) = vs
 
 -- | Compute the acyclic /condensation/ of a graph, where each vertex
 -- corresponds to a /strongly-connected component/ of the original graph. Note

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -258,7 +258,7 @@ topSort' g = callCC $ \cyclic -> do
 -- is cyclic.
 --
 -- @
--- topSort (1 * 2 + 3 * 1)               == Just [3,1,2]
+-- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 -- topSort (1 * 2 + 2 * 1)               == Nothing
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isJust' . topSort                      == 'isAcyclic'

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -32,12 +32,10 @@ import Control.Monad
 import Control.Monad.State.Strict
 import Control.Monad.Cont
 import Data.Either
-import Data.Maybe
 import Data.Tree
 
 import Algebra.Graph.AdjacencyIntMap
 
-import qualified Data.Graph.Typed   as Typed
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.IntSet        as IntSet
 
@@ -239,6 +237,7 @@ type TopOrder = Either [Int] [Int]
 backtrack :: Int -> Int -> [Int] -> IntMap.IntMap Int -> Either [Int] a
 backtrack v u vs table = case IntMap.lookup u table of
   Just w -> if w == v then Left (u:vs) else backtrack v w (u:vs) table
+  Nothing -> Left vs
 
 topSort' :: (MonadState S m, MonadCont m) => AdjacencyIntMap -> m TopOrder
 topSort' g = callCC $ \cyclic -> do

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -186,12 +186,11 @@ dfsForestFrom' :: [Int] -> AdjacencyIntMap -> Forest Int
 dfsForestFrom' vs g = evalState (explore vs) mempty where
   explore (v:vs) = discovered v >>= \case
     True -> (:) <$> walk v <*> explore vs
-    False -> explore vs 
+    False -> explore vs
   explore [] = return []
-  walk v = Node v <$> (explore $ adjacent v)
+  walk v = Node v <$> explore (adjacent v)
   adjacent v = IntSet.toList (postIntSet v g)
-  undiscovered v = gets (not . IntSet.member v)
-  discovered v = do new <- undiscovered v
+  discovered v = do new <- gets (not . IntSet.member v)
                     when new $ modify' (IntSet.insert v)
                     return new
 

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -238,9 +238,9 @@ topSort' g = callCC $ \cyclic -> do
       exit v = modify' (\(S p vs) -> S (IntMap.alter mark v p) (v:vs)) where
         mark = fmap (fmap (const True)) -- mark tree as explored/done
       node_state v = gets (IntMap.lookup v . table)
-      retrace v vs@(u:_) table@(IntMap.lookup u -> Just (Just w,_))
-        | w == v = v:vs
+      retrace v vs@(u:_) table@(IntMap.lookup u -> ~(Just (Just w,_)))
         | v == u = vs
+        | v == w = v:vs
         | otherwise = retrace v (w:vs) table
       dfs u =
         do forM_ (IntSet.toDescList $ postIntSet u g) $ \v ->

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -274,9 +274,9 @@ topSort' g = callCC $ \cyclic -> do
 -- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 -- topSort ('path' [1..5])                 == Right [1..5]
 -- topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
--- topSort (1 * 2 + 2 * 1)               == Left [1,2]
--- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left [4,3,2]
--- topSort ('circuit' [1..5])              == Left [1..5]
+-- topSort (1 * 2 + 2 * 1)               == Left (2 ':|' [1])
+-- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left (4 ':|' [3,2])
+-- topSort ('circuit' [1..5])              == Left (5 ':|' [1..4])
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -237,21 +237,20 @@ reachable x = concat . bfs [x]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isJust' . topSort                      == 'isAcyclic'
 -- @
+  
 topSort :: AdjacencyIntMap -> Maybe [Int]
-topSort g = check $ execState (mapM_ explore $ vertexList g) (mempty,[]) where
+topSort g = check $ execState topologicalSort (mempty,[]) where
+  topologicalSort = mapM_ (explore.fst) $ IntMap.toDescList $ adjacencyIntMap g
    -- todo add early exit if cycle detected. also add ability to detect
   check (_,result) = guard (isTopSortOf result g) >> return result
   explore v = do new <- undiscovered v
                  when new $ do mark v
                                mapM_ explore =<< adjacent v
                                include v
-  adjacent v = filterM undiscovered $ IntSet.toList (postIntSet v g)
+  adjacent v = filterM undiscovered $ IntSet.toDescList (postIntSet v g)
   include v = modify' (\(s,vs) -> (s, v:vs))
   mark v = modify' (\(s,vs) -> (IntSet.insert v s, vs))
   undiscovered v = gets (\(s,_) -> not (IntSet.member v s))
---then Just result else Nothing
---  where
---    result = Typed.topSort (Typed.fromAdjacencyMap m)
 
 -- | Check if a given graph is /acyclic/.
 --

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -179,13 +179,12 @@ dfsForestFrom :: [Int] -> AdjacencyIntMap -> Forest Int
 dfsForestFrom vs g = dfsForestFrom' [ v | v <- vs, hasVertex v g ] g
 
 dfsForestFrom' :: [Int] -> AdjacencyIntMap -> Forest Int
-dfsForestFrom' vs g = prune $ evalState (explore vs) IntSet.empty where
-  prune ts = [ Node t (prune xs) | Node (Just t) xs <- ts ]
-  explore (v:vs) = (:) <$> unfoldTreeM walk v <*> explore vs
+dfsForestFrom' vs g = evalState (explore vs) mempty where
+  explore (v:vs) = discovered v >>= \case
+    True -> (:) <$> walk v <*> explore vs
+    False -> explore vs 
   explore [] = return []
-  walk v = discovered v >>= \case
-    True -> (Just v,) <$> adjacentM v
-    False -> pure (Nothing,[])
+  walk v = Node v <$> (explore =<< adjacentM v)
   adjacentM v = filterM undiscovered $ IntSet.toList (postIntSet v g)
   undiscovered v = gets (not . IntSet.member v)
   discovered v = do new <- undiscovered v
@@ -239,15 +238,13 @@ reachable x = concat . bfs [x]
 -- 'isJust' . topSort                      == 'isAcyclic'
 -- @
 topSort :: AdjacencyIntMap -> Maybe [Int]
-topSort g = check $ execState (explore $ vertexList g) (IntSet.empty,[]) where
-  check (_,result) = guard (isTopSortOf result g) >> return result
+topSort g = check $ execState (mapM_ explore $ vertexList g) (mempty,[]) where
    -- todo add early exit if cycle detected. also add ability to detect
-  explore (v:vs) = do new <- undiscovered v
-                      when new $ do mark v
-                                    explore =<< adjacent v
-                                    include v
-                      explore vs
-  explore [] = return ()
+  check (_,result) = guard (isTopSortOf result g) >> return result
+  explore v = do new <- undiscovered v
+                 when new $ do mark v
+                               mapM_ explore =<< adjacent v
+                               include v
   adjacent v = filterM undiscovered $ IntSet.toList (postIntSet v g)
   include v = modify' (\(s,vs) -> (s, v:vs))
   mark v = modify' (\(s,vs) -> (IntSet.insert v s, vs))

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -156,9 +156,11 @@ bfs vs = bfsForestFrom vs >=> levels
 dfsForest :: AdjacencyIntMap -> Forest Int
 dfsForest g = dfsForestFrom' (vertexList g) g
 
--- | Compute the /depth-first search/ forest of a graph, searching from each of
--- the given vertices in order. Note that the resulting forest does not
--- necessarily span the whole graph, as some vertices may be unreachable.
+-- | Compute the /depth-first search/ forest of a graph from the given
+--   vertices, where adjacent vertices are expanded smallest to
+--   biggest according to their 'Ord' instance. Note that the
+--   resulting forest does not necessarily span the whole graph, as
+--   some vertices may be unreachable.
 -- 
 --   Let /L/ be the number of seed vertices and /W/ the number of bits
 --   in a machine word. Complexity: /O((L+m)*W)/ time and /O(n)/
@@ -198,8 +200,9 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
                     when new $ modify' (IntSet.insert v)
                     return new
 
--- | Compute the list of vertices visited by the /depth-first search/ in a graph,
--- when searching from each of the given vertices in order.
+-- | Compute the vertices visited by /depth-first search/ in a graph
+--   from the given vertices. Adjacent vertices are expanded smallest
+--   to biggest according to their 'Ord' instance.
 -- 
 --   Let /L/ be the number of seed vertices and /W/ the number of bits
 --   in a machine word. Complexity: /O((L+m)*W)/ time and /O(n)/

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -128,9 +128,9 @@ bfsForestFrom' vs g = evalState (explore vs) IntSet.empty where
 bfs :: [Int] -> AdjacencyIntMap -> [[Int]]
 bfs vs = bfsForestFrom vs >=> levels
 
--- | Compute the /depth-first search/ forest of a graph that
---   corresponds to searching from each of the graph vertices in the
---   'Ord' 'Int' order.
+-- | Compute the /depth-first search/ forest of a graph, where
+--   adjacent vertices are expanded smallest to biggest with respect
+--   to their 'Ord' instance.
 --
 --   Let /W/ be the number of bits in a machine word. Complexity:
 --   /O((n+m)*W)/ time and /O(n)/ space.
@@ -188,8 +188,8 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
     True -> (:) <$> walk v <*> explore vs
     False -> explore vs 
   explore [] = return []
-  walk v = Node v <$> (explore =<< adjacentM v)
-  adjacentM v = filterM undiscovered $ IntSet.toList (postIntSet v g)
+  walk v = Node v <$> (explore $ adjacent v)
+  adjacent v = IntSet.toList (postIntSet v g)
   undiscovered v = gets (not . IntSet.member v)
   discovered v = do new <- undiscovered v
                     when new $ modify' (IntSet.insert v)
@@ -214,10 +214,13 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
 dfs :: [Int] -> AdjacencyIntMap -> [Int]
 dfs vs = dfsForestFrom vs >=> flatten
 
--- | Compute the list of vertices that are /reachable/ from a given source
--- vertex in a graph. The vertices in the resulting list appear in
--- /breadth-first order/. 
+-- | Compute the list of vertices that are /reachable/ from a given
+--   source vertex in a graph. The vertices in the resulting list
+--   appear in /breadth-first order/.
 --
+--   Let /W/ be the number of bits in a machine word. Complexity:
+--   /O(m*W)/ time and /O(n)/ space.
+-- 
 -- @
 -- reachable x $ 'empty'                       == []
 -- reachable 1 $ 'vertex' 1                    == [1]

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -30,6 +30,7 @@ module Algebra.Graph.AdjacencyIntMap.Algorithm (
 
 import Control.Monad
 import Control.Monad.State.Strict
+import Data.Either
 import Data.Maybe
 import Data.Tree
 
@@ -237,7 +238,7 @@ reachable x = concat . bfs [x]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isJust' . topSort                      == 'isAcyclic'
 -- @
-  
+
 topSort :: AdjacencyIntMap -> Maybe [Int]
 topSort g = check $ execState topologicalSort (mempty,[]) where
   topologicalSort = mapM_ (explore.fst) $ IntMap.toDescList $ adjacencyIntMap g
@@ -251,6 +252,28 @@ topSort g = check $ execState topologicalSort (mempty,[]) where
   include v = modify' (\(s,vs) -> (s, v:vs))
   mark v = modify' (\(s,vs) -> (IntSet.insert v s, vs))
   undiscovered v = gets (\(s,_) -> not (IntSet.member v s))
+
+-- data Color = White | Gray | Black
+--   deriving (Show,Read,Eq,Ord,Enum,Bounded)
+--   
+-- topSort :: AdjacencyIntMap -> Either [Int] [Int]
+-- topSort g = evalState explore state0 where
+--   state0 = (adjacencyIntMap g,mempty,[])
+-- --  topologicalSort = mapM_ (explore.fst) $ IntMap.toDescList $ adjacencyIntMap g
+--    -- todo add early exit if cycle detected. also add ability to detect
+-- --  check (_,result) = guard (isTopSortOf result g) >> return result
+--   explore = gets (IntMap.maxViewWithKey . graph) >>= \case
+--     Nothing -> Right <$> gets ordering
+--     Just ((u,vs),g') -> undefined
+--   graph (g,_,_) = g
+--   graph' g (_,m,vs) = (g,m,vs)
+--   ordering (_,_,vs) = vs
+--   parents (_,m,_) = m
+  
+--   adjacent v = filterM undiscovered $ IntSet.toDescList (postIntSet v g)
+--   include v = modify' (\(s,vs) -> (s, v:vs))
+--   mark v = modify' (\(s,vs) -> (IntSet.insert v s, vs))
+--   undiscovered v = gets (\(s,_) -> not (IntSet.member v s))
 
 -- | Check if a given graph is /acyclic/.
 --

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -159,6 +159,10 @@ dfsForest g = dfsForestFrom' (vertexList g) g
 -- | Compute the /depth-first search/ forest of a graph, searching from each of
 -- the given vertices in order. Note that the resulting forest does not
 -- necessarily span the whole graph, as some vertices may be unreachable.
+-- 
+--   Let /L/ be the number of seed vertices and /W/ the number of bits
+--   in a machine word. Complexity: /O((L+m)*W)/ time and /O(n)/
+--   space.
 --
 -- @
 -- dfsForestFrom vs 'empty'                           == []
@@ -196,6 +200,10 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
 
 -- | Compute the list of vertices visited by the /depth-first search/ in a graph,
 -- when searching from each of the given vertices in order.
+-- 
+--   Let /L/ be the number of seed vertices and /W/ the number of bits
+--   in a machine word. Complexity: /O((L+m)*W)/ time and /O(n)/
+--   space.
 --
 -- @
 -- dfs vs    $ 'empty'                    == []
@@ -215,7 +223,7 @@ dfs vs = dfsForestFrom vs >=> flatten
 
 -- | Compute the list of vertices that are /reachable/ from a given
 --   source vertex in a graph. The vertices in the resulting list
---   appear in /breadth-first order/.
+--   appear in /depth-first order/.
 --
 --   Let /W/ be the number of bits in a machine word. Complexity:
 --   /O(m*W)/ time and /O(n)/ space.
@@ -232,7 +240,7 @@ dfs vs = dfsForestFrom vs >=> flatten
 -- 'isSubgraphOf' ('vertices' $ reachable x y) y == True
 -- @
 reachable :: Int -> AdjacencyIntMap -> [Int]
-reachable x = concat . bfs [x]
+reachable x = dfs [x]
 
 type Cycle = NonEmpty
 type TopSort = Either (Cycle Int) [Int]

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -129,11 +129,10 @@ bfs :: [Int] -> AdjacencyIntMap -> [[Int]]
 bfs vs = bfsForestFrom vs >=> levels
 
 -- | Compute the /depth-first search/ forest of a graph, where
---   adjacent vertices are expanded smallest to biggest with respect
+--   adjacent vertices are expanded in increasing order with respect
 --   to their 'Ord' instance.
 --
---   Let /W/ be the number of bits in a machine word. Complexity:
---   /O((n+m)*W)/ time and /O(n)/ space.
+--   Complexity: /O((n+m)*min(n,W))/ time and /O(n)/ space.
 --
 -- @
 -- dfsForest 'empty'                       == []
@@ -157,14 +156,13 @@ dfsForest :: AdjacencyIntMap -> Forest Int
 dfsForest g = dfsForestFrom' (vertexList g) g
 
 -- | Compute the /depth-first search/ forest of a graph from the given
---   vertices, where adjacent vertices are expanded smallest to
---   biggest according to their 'Ord' instance. Note that the
+--   vertices, where adjacent vertices are expanded in increasing
+--   order with respect to to their 'Ord' instance. Note that the
 --   resulting forest does not necessarily span the whole graph, as
 --   some vertices may be unreachable.
 -- 
---   Let /L/ be the number of seed vertices and /W/ the number of bits
---   in a machine word. Complexity: /O((L+m)*W)/ time and /O(n)/
---   space.
+--   Let /L/ be the number of seed vertices. Complexity:
+--   /O((L+m)*min(n,W))/ time and /O(n)/ space.
 --
 -- @
 -- dfsForestFrom vs 'empty'                           == []
@@ -201,12 +199,11 @@ dfsForestFrom' vs g = evalState (explore vs) IntSet.empty where
                     return new
 
 -- | Compute the vertices visited by /depth-first search/ in a graph
---   from the given vertices. Adjacent vertices are expanded smallest
---   to biggest according to their 'Ord' instance.
+--   from the given vertices. Adjacent vertices are explored in
+--   increasing order with respect to their 'Ord' instance.
 -- 
---   Let /L/ be the number of seed vertices and /W/ the number of bits
---   in a machine word. Complexity: /O((L+m)*W)/ time and /O(n)/
---   space.
+--   Let /L/ be the number of seed vertices. Complexity:
+--   /O((L+m)*min(n,W))/ time and /O(n)/ space.
 --
 -- @
 -- dfs vs    $ 'empty'                    == []
@@ -228,8 +225,7 @@ dfs vs = dfsForestFrom vs >=> flatten
 --   source vertex in a graph. The vertices in the resulting list
 --   appear in /depth-first order/.
 --
---   Let /W/ be the number of bits in a machine word. Complexity:
---   /O(m*W)/ time and /O(n)/ space.
+--   Complexity: /O(m*min(n,W))/ time and /O(n)/ space.
 -- 
 -- @
 -- reachable x $ 'empty'                       == []
@@ -283,17 +279,16 @@ topSort' g = callCC $ \cyclic ->
 
 -- | Compute a topological sort of a DAG or discover a cycle.
 --
---   Vertices are expanded largest to smallest according their 'Ord'
---   instance. This gives the lexicographically smallest topological
---   ordering in the case of success. In the case of failure, the
---   cycle is characterized by being the lexicographically smallest up
---   to rotation with respect to @Ord (Dual Int)@ in the first
---   connected component of the graph containing a cycle, where the
---   connected components are ordered by their largest vertex with
---   respect to @Ord a@.
+--   Vertices are expanded in increasing order with respect to their
+--   'Ord' instance. This gives the lexicographically smallest
+--   topological ordering in the case of success. In the case of
+--   failure, the cycle is characterized by being the
+--   lexicographically smallest up to rotation with respect to @Ord
+--   (Dual Int)@ in the first connected component of the graph
+--   containing a cycle, where the connected components are ordered by
+--   their largest vertex with respect to @Ord a@.
 --
---   Let /W/ be the number of bits in a machine word. Complexity:
---   /O((n+m)*W)/ time and /O(n)/ space.
+--   Complexity: /O((n+m)*min(n,W))/ time and /O(n)/ space.
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
@@ -312,8 +307,7 @@ topSort g = runContT (evalStateT (topSort' g) (S IntMap.empty [])) id
 
 -- | Check if a given graph is /acyclic/.
 --
---   Let /W/ be the number of bits in a machine word. Complexity:
---   /O((n+m)*W)/ time and /O(n)/ space.
+--   Complexity: /O((n+m)*min(n,W))/ time and /O(n)/ space.
 --
 -- @
 -- isAcyclic (1 * 2 + 3 * 1) == True

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -227,34 +227,40 @@ dfs vs = dfsForestFrom vs >=> flatten
 reachable :: Int -> AdjacencyIntMap -> [Int]
 reachable x = concat . bfs [x]
 
-type TopOrder = Either [Int] [Int]
-type ParentTable = IntMap.IntMap (Maybe Int,Bool)
-data S = S { table :: !ParentTable, order :: [Int] }
+data S = S { parent    :: !(IntMap.IntMap Int)
+           , processed :: !(IntMap.IntMap Bool)
+           , order     :: [Int] }
 
+type TopOrder = Either [Int] [Int]
+
+pattern TreeEdge :: Maybe Bool
 pattern TreeEdge <- Nothing
-pattern BackEdge <- Just (_,False)
-pattern Parent p <- Just (Just p,_)
+pattern BackEdge :: Maybe Bool
+pattern BackEdge <- Just False
+
+retrace :: Int -> [Int] -> IntMap.IntMap Int -> [Int]
+retrace v [] _ = [v] -- impossible
+retrace v vs@(u:_) table
+  | v == u = vs
+  | Just p <- IntMap.lookup u table = retrace v (p:vs) table
+  | otherwise = vs -- impossible
 
 topSort' :: (MonadState S m, MonadCont m) => AdjacencyIntMap -> m TopOrder
 topSort' g = callCC $ \cyclic -> do
-  let unexplored u = gets (not . IntMap.member u . table)
-      parent u v = modify' (\(S p vs) -> S (IntMap.insert v (u,False) p) vs)
-      exit v = modify' (\(S p vs) -> S (IntMap.alter done v p) (v:vs)) where
-        done = fmap (fmap (const True))
-      edge_type v = gets (IntMap.lookup v . table)
-      retrace v vs@(u:_) table@(IntMap.lookup u -> ~(Parent p))
-        | v == u    = vs
-        | otherwise = retrace v (p:vs) table
-      dfs u =
-        do forM_ (IntSet.toDescList $ postIntSet u g) $ \v ->
-             edge_type v >>= \case
-               TreeEdge -> parent (Just u) v >> dfs v
-               BackEdge -> cyclic . Left . retrace v [u] =<< gets table
-               _        -> pure ()
-           exit u
+  let unexplored v = gets (not . IntMap.member v . processed)
+      enter u v = modify' aux where
+        aux (S p s vs) = S (IntMap.insert v u p) (IntMap.insert v False s) vs
+      exit v = modify' (\(S p s vs) -> S p (IntMap.insert v True s) (v:vs))
+      edge_type v = gets (IntMap.lookup v . processed)
+      dfs u = do forM_ (IntSet.toDescList $ postIntSet u g) $ \v ->
+                   edge_type v >>= \case
+                     TreeEdge -> enter u v >> dfs v
+                     BackEdge -> cyclic . Left . retrace v [u] =<< gets parent
+                     _        -> return ()
+                 exit u
   forM_ (map fst $ IntMap.toDescList $ adjacencyIntMap g) $
     \v -> do new_tree <- unexplored v
-             when new_tree $ parent Nothing v >> dfs v
+             when new_tree $ dfs v
   Right <$> gets order
 
 -- | Compute a topological sort of the vertices of a graph. Given a
@@ -265,15 +271,15 @@ topSort' g = callCC $ \cyclic -> do
 -- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 -- topSort ('path' [1..5])                 == Right [1..5]
 -- topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
--- topSort (1 * 2 + 2 * 1)               == Left [2,1]
+-- topSort (1 * 2 + 2 * 1)               == Left [1,2]
 -- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left [4,3,2]
--- topSort ('circuit' [1..5])              == Left [5,1,2,3,4]
+-- topSort ('circuit' [1..5])              == Left [1..5]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @
 topSort :: AdjacencyIntMap -> Either [Int] [Int]
 topSort g = runContT (evalStateT (topSort' g) initialState) id where
-  initialState = S mempty mempty
+  initialState = S mempty mempty mempty
 
 -- | Check if a given graph is /acyclic/.
 --

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -227,37 +227,32 @@ dfs vs = dfsForestFrom vs >=> flatten
 reachable :: Int -> AdjacencyIntMap -> [Int]
 reachable x = concat . bfs [x]
 
-data N = Root
-       | Discovered {-# unpack #-} !Int
-       | Explored {-# unpack #-} !Int
-
 type TopOrder = Either [Int] [Int]
-type ParentTable = IntMap.IntMap N
+type ParentTable = IntMap.IntMap (Maybe Int,Bool)
 data S = S { table :: !ParentTable, order :: [Int] }
 
 topSort' :: (MonadState S m, MonadCont m) => AdjacencyIntMap -> m TopOrder
 topSort' g = callCC $ \cyclic -> do
   let parent u v = modify' (\(S p vs) -> S (IntMap.alter (register u) v p) vs)
-      register u = fmap (const u) -- mark parent as u 
+      register u = const (Just (u, False)) -- mark parent as u 
       explored v = modify' (\(S p vs) -> S (IntMap.alter mark v p) (v:vs))
-      mark = fmap (\(Discovered n) -> Explored n) -- mark tree as explored/done
+      mark = fmap (fmap (const True)) -- mark tree as explored/done
       node_state v = gets (IntMap.lookup v . table)
       unexplored u = gets (not . IntMap.member u . table)
       build_cycle u v = cyclic . Left . expand_cycle v [u,v] =<< gets table
       expand_cycle w vs@(v:_) table =
         case IntMap.lookup v table of
-          Just (Discovered u) -> if u == v then vs else expand_cycle w (u:vs) table
-          Just (Explored u) -> if u == v then vs else expand_cycle w (u:vs) table
+          Just (Just u,_) -> if u == v then vs else expand_cycle w (u:vs) table
           Just _ -> tail vs
       dfs u = do forM_ (IntSet.toDescList $ postIntSet u g) $ \v ->
                    node_state v >>= \case
-                     Nothing -> parent (Discovered u) v >> dfs v -- new node
-                     Just (Explored _) -> pure () -- part of explored tree
-                     Just (Discovered _) -> build_cycle u v -- part of cycle
+                     Nothing -> parent (Just u) v >> dfs v -- new node
+                     Just (_,True) -> pure () -- part of explored tree
+                     Just (_,False) -> build_cycle u v -- part of cycle
                  explored u
   forM_ (map fst $ IntMap.toDescList $ adjacencyIntMap g) $
     \v -> do new_tree <- unexplored v
-             when new_tree $ parent Root v >> dfs v
+             when new_tree $ parent Nothing v >> dfs v
   Right <$> gets order
 
 -- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -257,12 +257,17 @@ topSort' g = callCC $ \cyclic -> do
              when new_tree $ parent Nothing v >> dfs v
   Right <$> gets order
 
--- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph
--- is cyclic.
+-- | Compute a topological sort of the vertices of a graph. Given a
+--  DAG, the lexicographically least topological ordering is returned,
+--  otherwise, a cycle is.
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
+-- topSort ('path' [1..5])                 == Right [1..5]
+-- topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
 -- topSort (1 * 2 + 2 * 1)               == Left [2,1]
+-- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left [4,3,2]
+-- topSort ('circuit' [1..5])              == Left [5,1,2,3,4]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -29,8 +29,8 @@ module Algebra.Graph.AdjacencyIntMap.Algorithm (
     ) where
 
 import Control.Monad
-import Control.Monad.State.Strict
 import Control.Monad.Cont
+import Control.Monad.State.Strict
 import Data.List.NonEmpty (NonEmpty(..),(<|))
 import Data.Tree
 
@@ -275,9 +275,18 @@ topSort' g = callCC $ \cyclic ->
                           _ -> error "impossible"
 
 
--- | Compute a topological sort of the vertices of a graph. Given a
---  DAG, the lexicographically least topological ordering is returned,
---  otherwise, a cycle is.
+-- | Compute a topological ordering of the vertices of a DAG or
+--   discover a cycle.
+--
+--   Vertices are expanded largest to smallest according their 'Ord'
+--   instance. This gives the lexicographically smallest such ordering
+--   in the case of success. In the case of failure, the cycle is
+--   characterized by being the lexicographically smallest by @Ord
+--   (Dual Int)@ up to rotation, in the first connected component of
+--   the graph, where the connected components are ordered by their
+--   largest vertex by @Ord Int@.
+--
+--   Complexity: /O((n+m)*log n)/ time and /O(n+m)/ space.
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
@@ -285,9 +294,9 @@ topSort' g = callCC $ \cyclic ->
 -- topSort (3 * (1 * 4 + 2 * 5))              == Right [3,1,2,4,5]
 -- topSort (1 * 2 + 2 * 1)                    == Left (2 ':|' [1])
 -- topSort ('path' [5,4..1] + 'edge' 2 4)         == Left (4 ':|' [3,2])
--- topSort ('circuit' [1..5])                   == Left (5 ':|' [1..4])
+-- topSort ('circuit' [1..3])                   == Left (3 ':|' [1,2])
 -- topSort ('circuit' [1..3] + 'circuit' [3,2,1]) == Left (3 ':|' [2])
--- topSort (1*2+2*1+3*4+4*3+5*1)              == Left (1 ':|' [2])
+-- topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 :| [2])
 -- fmap ('flip' 'isTopSortOf' x) (topSort x)      /= Right False
 -- 'isRight' . topSort                          == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -247,8 +247,8 @@ pattern Parent p <- Just (Left p)
 unexplored :: MonadState S m => Int -> m Bool
 unexplored u = gets (not . IntMap.member u . table)
 
-enter :: MonadState S m => Entry -> Int -> m ()
-enter u v = modify' (\(S p vs) -> S (IntMap.insert v u p) vs)
+enter :: MonadState S m => Int -> Int -> m ()
+enter u v = modify' (\(S p vs) -> S (IntMap.insert v (Left u) p) vs)
 
 exit :: MonadState S m => Int -> m ()
 exit v = modify' (\(S p vs) -> S (IntMap.alter (fmap done) v p) (v:vs)) where
@@ -274,13 +274,13 @@ topSort' g = callCC $ \cyclic -> do
         enter z x
         forM_ (adjacent x) $ \y ->
           classify y >>= \case
-            TreeEdge -> dfs (Left x) y
+            TreeEdge -> dfs x y
             BackEdge -> cyclic . Left . retrace x y =<< gets table
             _        -> return ()
         exit x
   forM_ vertices $ \v -> do
     new <- unexplored v
-    when new $ dfs (Left v) v
+    when new $ dfs v v
   Right <$> gets order
 
 -- | Compute a topological sort of the vertices of a graph. Given a

--- a/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyIntMap/Algorithm.hs
@@ -128,8 +128,12 @@ bfsForestFrom' vs g = evalState (explore vs) IntSet.empty where
 bfs :: [Int] -> AdjacencyIntMap -> [[Int]]
 bfs vs = bfsForestFrom vs >=> levels
 
--- | Compute the /depth-first search/ forest of a graph that corresponds to
--- searching from each of the graph vertices in the 'Ord' @a@ order.
+-- | Compute the /depth-first search/ forest of a graph that
+--   corresponds to searching from each of the graph vertices in the
+--   'Ord' 'Int' order.
+--
+--   Let /W/ be the number of bits in a machine word. Complexity:
+--   /O((n+m)*W)/ time and /O(n)/ space.
 --
 -- @
 -- dfsForest 'empty'                       == []
@@ -275,18 +279,18 @@ topSort' g = callCC $ \cyclic ->
                           _ -> error "impossible"
 
 
--- | Compute a topological ordering of the vertices of a DAG or
---   discover a cycle.
+-- | Compute a topological sort of a DAG or discover a cycle.
 --
 --   Vertices are expanded largest to smallest according their 'Ord'
---   instance. This gives the lexicographically smallest such ordering
---   in the case of success. In the case of failure, the cycle is
---   characterized by being the lexicographically smallest by @Ord
---   (Dual Int)@ up to rotation, in the first connected component of
---   the graph, where the connected components are ordered by their
---   largest vertex by @Ord Int@.
+--   instance. This gives the lexicographically smallest topological
+--   ordering in the case of success. In the case of failure, the
+--   cycle is characterized by being the lexicographically smallest up
+--   to rotation with respect to @Ord (Dual a)@ in the first connected
+--   component of the graph, where the connected components are
+--   ordered by their largest vertex with respect to @Ord a@.
 --
---   Complexity: /O((n+m)*log n)/ time and /O(n+m)/ space.
+--   Let /W/ be the number of bits in a machine word. Complexity:
+--   /O((n+m)*W)/ time and /O(n)/ space.
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
@@ -296,7 +300,7 @@ topSort' g = callCC $ \cyclic ->
 -- topSort ('path' [5,4..1] + 'edge' 2 4)         == Left (4 ':|' [3,2])
 -- topSort ('circuit' [1..3])                   == Left (3 ':|' [1,2])
 -- topSort ('circuit' [1..3] + 'circuit' [3,2,1]) == Left (3 ':|' [2])
--- topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 :| [2])
+-- topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 ':|' [2])
 -- fmap ('flip' 'isTopSortOf' x) (topSort x)      /= Right False
 -- 'isRight' . topSort                          == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -189,8 +189,8 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
     True -> (:) <$> walk v <*> explore vs
     False -> explore vs 
   explore [] = return []
-  walk v = Node v <$> (explore =<< adjacentM v)
-  adjacentM v = filterM undiscovered $ Set.toList (postSet v g)
+  walk v = Node v <$> explore (adjacent v)
+  adjacent v = Set.toList (postSet v g)
   undiscovered v = gets (not . Set.member v)
   discovered v = do new <- undiscovered v
                     when new $ modify' (Set.insert v)

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -237,7 +237,6 @@ reachable x = concat . bfs [x]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isJust' . topSort                      == 'isAcyclic'
 -- @
-
 topSort :: Ord a => AdjacencyMap a -> Maybe [a]
 topSort g = check $ execState topologicalSort (mempty,[]) where
   topologicalSort = mapM_ explore $ Set.toDescList $ vertexSet g
@@ -251,9 +250,6 @@ topSort g = check $ execState topologicalSort (mempty,[]) where
   include v = modify' (\(s,vs) -> (s, v:vs))
   mark v = modify' (\(s,vs) -> (Set.insert v s, vs))
   undiscovered v = gets (\(s,_) -> not (Set.member v s))
---then Just result else Nothing
---  where
---    result = Typed.topSort (Typed.fromAdjacencyMap m)
 
 -- | Check if a given graph is /acyclic/.
 --

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -237,15 +237,17 @@ reachable x = concat . bfs [x]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isJust' . topSort                      == 'isAcyclic'
 -- @
+
 topSort :: Ord a => AdjacencyMap a -> Maybe [a]
-topSort g = check $ execState (mapM_ explore $ vertexList g) (mempty,[]) where
+topSort g = check $ execState topologicalSort (mempty,[]) where
+  topologicalSort = mapM_ explore $ Set.toDescList $ vertexSet g
    -- todo add early exit if cycle detected. also add ability to detect
   check (_,result) = guard (isTopSortOf result g) >> return result
   explore v = do new <- undiscovered v
                  when new $ do mark v
                                mapM_ explore =<< adjacent v
                                include v
-  adjacent v = filterM undiscovered $ Set.toList (postSet v g)
+  adjacent v = filterM undiscovered $ Set.toDescList (postSet v g)
   include v = modify' (\(s,vs) -> (s, v:vs))
   mark v = modify' (\(s,vs) -> (Set.insert v s, vs))
   undiscovered v = gets (\(s,_) -> not (Set.member v s))

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -160,7 +160,10 @@ dfsForest g = dfsForestFrom (vertexList g) g
 --   from each of the given vertices in order. Note that the resulting
 --   forest does not necessarily span the whole graph, as some
 --   vertices may be unreachable.
---
+-- 
+--   Let /L/ be the number of seed vertices. Complexity: /O((L+m)*log n)/
+--   time and /O(n)/ space.
+-- 
 -- @
 -- dfsForestFrom vs 'empty'                           == []
 -- 'forest' (dfsForestFrom [1]   $ 'edge' 1 1)          == 'vertex' 1
@@ -191,13 +194,15 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
   explore [] = return []
   walk v = Node v <$> explore (adjacent v)
   adjacent v = Set.toList (postSet v g)
-  undiscovered v = gets (not . Set.member v)
-  discovered v = do new <- undiscovered v
+  discovered v = do new <- gets (not . Set.member v)
                     when new $ modify' (Set.insert v)
                     return new
 
 -- | Compute the list of vertices visited by the /depth-first search/ in a
 --   graph, when searching from each of the given vertices in order.
+--
+--   Let /L/ be the number of seed vertices. Complexity: /O((L+m)*log n)/
+--   time and /O(n)/ space.
 --
 -- @
 -- dfs vs    $ 'empty'                    == []
@@ -217,7 +222,9 @@ dfs vs = dfsForestFrom vs >=> flatten
 
 -- | Compute the list of vertices that are /reachable/ from a given
 -- source vertex in a graph. The vertices in the resulting list appear
--- in /breadth-first order/.
+-- in /depth-first order/.
+-- 
+--   Complexity: /O(m*log n)/ time and /O(n)/ space.
 --
 -- @
 -- reachable x $ 'empty'                       == []
@@ -231,7 +238,7 @@ dfs vs = dfsForestFrom vs >=> flatten
 -- 'isSubgraphOf' ('vertices' $ reachable x y) y == True
 -- @
 reachable :: Ord a => a -> AdjacencyMap a -> [a]
-reachable x = concat . bfs [x]
+reachable x = dfs [x]
 
 type Cycle = NonEmpty 
 type Entry a = Either a a

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -263,9 +263,9 @@ classify :: (Ord a, MonadState (S a) m) => a -> m (Maybe (Entry a))
 classify v = gets (Map.lookup v . table)
 
 retrace :: Ord a => a -> Cycle a -> ParentTable a -> Cycle a
-retrace v vs@(u :| _) table
-  | v == u = vs
-  | Parent p <- Map.lookup u table = retrace v (p <| vs) table
+retrace x0 vs@(x :| _) table
+  | x0 == x = vs
+  | Parent z <- Map.lookup x table = retrace x0 (z <| vs) table
   | otherwise = vs -- impossible
 
 topSort' :: (Ord a, MonadState (S a) m, MonadCont m)
@@ -291,14 +291,16 @@ topSort' g = callCC $ \cyclic -> do
 --  otherwise, a cycle is.
 --
 -- @
--- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
--- topSort ('path' [1..5])                 == Right [1..5]
--- topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
--- topSort (1 * 2 + 2 * 1)               == Left (2 ':|' [1])
--- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left (4 ':|' [3,2])
--- topSort ('circuit' [1..5])              == Left (5 ':|' [1..4])
--- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
--- 'isRight' . topSort                     == 'isAcyclic'
+-- topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
+-- topSort ('path' [1..5])                      == Right [1..5]
+-- topSort (3 * (1 * 4 + 2 * 5))              == Right [3,1,2,4,5]
+-- topSort (1 * 2 + 2 * 1)                    == Left (2 ':|' [1])
+-- topSort ('path' [5,4..1] + 'edge' 2 4)         == Left (4 ':|' [3,2])
+-- topSort ('circuit' [1..5])                   == Left (5 ':|' [1..4])
+-- topSort ('circuit' [1..3] + 'circuit' [3,2,1]) == Left (3 ':|' [2])
+-- topSort (1*2+2*1+3*4+4*3+5*1)              == Left (1 ':|' [2])
+-- fmap ('flip' 'isTopSortOf' x) (topSort x)      /= Right False
+-- 'isRight' . topSort                          == 'isAcyclic'
 -- @
 topSort :: Ord a => AdjacencyMap a -> Either (Cycle a) [a]
 topSort g = runContT (evalStateT (topSort' g) initialState) id where

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -249,8 +249,8 @@ pattern Parent p <- Just (Left p)
 unexplored :: (Ord a, MonadState (S a) m) => a -> m Bool
 unexplored u = gets (not . Map.member u . table)
 
-enter :: (Ord a, MonadState (S a) m) => Entry a -> a -> m ()
-enter u v = modify' (\(S p vs) -> S (Map.insert v u p) vs)
+enter :: (Ord a, MonadState (S a) m) => a -> a -> m ()
+enter u v = modify' (\(S p vs) -> S (Map.insert v (Left u) p) vs)
 
 exit :: (Ord a, MonadState (S a) m) => a -> m ()
 exit v = modify' (\(S p vs) -> S (Map.alter (fmap done) v p) (v:vs)) where
@@ -277,13 +277,13 @@ topSort' g = callCC $ \cyclic -> do
         enter z x
         forM_ (adjacent x) $ \y ->
           classify y >>= \case
-            TreeEdge -> dfs (Left x) y
+            TreeEdge -> dfs x y
             BackEdge -> cyclic . Left . retrace x y =<< gets table
             _        -> return ()
         exit x
   forM_ vertices $ \v -> do
     new <- unexplored v
-    when new $ dfs (Left v) v
+    when new $ dfs v v
   Right <$> gets order
 
 -- | Compute a topological sort of the vertices of a graph. Given a

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -28,6 +28,7 @@ import Control.Monad
 import Control.Monad.Cont
 import Control.Monad.State.Strict
 import Data.Foldable (toList)
+import Data.List.NonEmpty (NonEmpty(..),(<|))
 import Data.Maybe
 import Data.Tree
 
@@ -229,40 +230,43 @@ dfs vs = dfsForestFrom vs >=> flatten
 reachable :: Ord a => a -> AdjacencyMap a -> [a]
 reachable x = concat . bfs [x]
 
-data S a = S { parent    :: !(Map.Map a a)
-             , processed :: !(Map.Map a Bool)
+type Cycle = NonEmpty 
+type TopSort a = Either (Cycle a) [a]
+type ParentTable a = Map.Map a (Maybe a,Bool)
+data S a = S { table    :: !(ParentTable a)
              , order     :: [a] }
-type TopOrder a = Either [a] [a]
 
-pattern TreeEdge :: Maybe Bool
-pattern TreeEdge <- Nothing
-pattern BackEdge :: Maybe Bool
-pattern BackEdge <- Just False :: Maybe Bool
-
-retrace :: Ord a => a -> [a] -> Map.Map a a -> [a]
-retrace v [] _ = [v] -- impossible
-retrace v vs@(u:_) table
+retrace :: Ord a => a -> Cycle a -> ParentTable a -> Cycle a
+retrace v vs@(u :| _) table
   | v == u = vs
-  | Just p <- Map.lookup u table = retrace v (p:vs) table
+  | Parent p <- Map.lookup u table = retrace v (p <| vs) table
   | otherwise = vs -- impossible
 
+pattern TreeEdge :: Maybe (Maybe a , Bool)
+pattern TreeEdge <- Nothing
+pattern BackEdge :: Maybe (Maybe a, Bool)
+pattern BackEdge <- Just (_,False)
+pattern Parent :: a -> Maybe (Maybe a, Bool)
+pattern Parent p <- Just (Just p,_)
+
 topSort' :: (Ord a, MonadState (S a) m, MonadCont m)
-         => AdjacencyMap a -> m (TopOrder a)
+         => AdjacencyMap a -> m (TopSort a)
 topSort' g = callCC $ \cyclic -> do
-  let unexplored v = gets (not . Map.member v . processed)
-      enter u v = modify' aux where
-        aux (S p s vs) = S (Map.insert v u p) (Map.insert v False s) vs
-      exit v = modify' (\(S p s vs) -> S p (Map.insert v True s) (v:vs))
-      edge_type v = gets (Map.lookup v . processed)
-      dfs u = do forM_ (Set.toDescList $ postSet u g) $ \v ->
-                   edge_type v >>= \case
-                     TreeEdge -> enter u v >> dfs v
-                     BackEdge -> cyclic . Left . retrace v [u] =<< gets parent
-                     _        -> return ()
-                 exit u
+  let unexplored u = gets (not . Map.member u . table)
+      parent u v = modify' (\(S p vs) -> S (Map.insert v (u,False) p) vs)
+      exit v = modify' (\(S p vs) -> S (Map.alter done v p) (v:vs)) where
+        done = fmap (fmap (const True))
+      edge_type v = gets (Map.lookup v . table)
+      dfs u =
+        do forM_ (Set.toDescList $ postSet u g) $ \v ->
+             edge_type v >>= \case
+               TreeEdge -> parent (Just u) v >> dfs v
+               BackEdge -> cyclic . Left . retrace v (u :| []) =<< gets table
+               _        -> return ()
+           exit u
   forM_ (map fst $ Map.toDescList $ adjacencyMap g) $
     \v -> do new_tree <- unexplored v
-             when new_tree $ dfs v
+             when new_tree $ parent Nothing v >> dfs v
   Right <$> gets order
 
 -- | Compute a topological sort of the vertices of a graph. Given a
@@ -279,9 +283,9 @@ topSort' g = callCC $ \cyclic -> do
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @
-topSort :: Ord a => AdjacencyMap a -> Either [a] [a]
+topSort :: Ord a => AdjacencyMap a -> TopSort a
 topSort g = runContT (evalStateT (topSort' g) initialState) id where
-  initialState = S mempty mempty mempty
+  initialState = S mempty mempty 
 
 -- | Check if a given graph is /acyclic/.
 --

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -130,7 +130,7 @@ bfs :: Ord a => [a] -> AdjacencyMap a -> [[a]]
 bfs vs = bfsForestFrom vs >=> levels
 
 -- | Compute the /depth-first search/ forest of a graph, where
---   adjacent vertices are expanded smallest to biggest with respect
+--   adjacent vertices are expanded in increasing order with respect
 --   to their 'Ord' instance.
 --
 --   Complexity: /O((n+m)*log n)/ time and /O(n)/ space.
@@ -157,8 +157,8 @@ dfsForest :: Ord a => AdjacencyMap a -> Forest a
 dfsForest g = dfsForestFrom (vertexList g) g
 
 -- | Compute the /depth-first search/ forest of a graph from the given
---   vertices, where adjacent vertices are expanded smallest to
---   biggest according to their 'Ord' instance. Note that the
+--   vertices, where adjacent vertices are expanded in increasing
+--   order with respect to their 'Ord' instance. Note that the
 --   resulting forest does not necessarily span the whole graph, as
 --   some vertices may be unreachable.
 -- 
@@ -200,8 +200,8 @@ dfsForestFrom' vs g = evalState (explore vs) Set.empty where
                     return new
 
 -- | Compute the vertices visited by /depth-first search/ in a graph
---   from the given vertices. Adjacent vertices are expanded smallest
---   to biggest according to their 'Ord' instance.
+--   from the given vertices. Adjacent vertices are expanded in
+--   increasing order with respect to their 'Ord' instance.
 --
 --   Let /L/ be the number of seed vertices. Complexity: /O((L+m)*log n)/
 --   time and /O(n)/ space.
@@ -223,8 +223,8 @@ dfs :: Ord a => [a] -> AdjacencyMap a -> [a]
 dfs vs = dfsForestFrom vs >=> flatten
 
 -- | Compute the list of vertices that are /reachable/ from a given
--- source vertex in a graph. The vertices in the resulting list appear
--- in /depth-first order/.
+--   source vertex in a graph. The vertices in the resulting list
+--   appear in /depth-first order/.
 -- 
 --   Complexity: /O(m*log n)/ time and /O(n)/ space.
 --
@@ -281,14 +281,14 @@ topSort' g = callCC $ \cyclic ->
 
 -- | Compute a topological sort of a DAG or discover a cycle.
 --
---   Vertices are expanded largest to smallest according their 'Ord'
---   instance. This gives the lexicographically smallest topological
---   ordering in the case of success. In the case of failure, the
---   cycle is characterized by being the lexicographically smallest up
---   to rotation with respect to @Ord (Dual a)@ in the first connected
---   component of the graph containing a cycle, where the connected
---   components are ordered by their largest vertex with respect to
---   @Ord a@.
+--   Vertices are expanded in increasing order with respect to their
+--   'Ord' instance. This gives the lexicographically smallest
+--   topological ordering in the case of success. In the case of
+--   failure, the cycle is characterized by being the
+--   lexicographically smallest up to rotation with respect to @Ord
+--   (Dual a)@ in the first connected component of the graph
+--   containing a cycle, where the connected components are ordered by
+--   their largest vertex with respect to @Ord a@.
 --
 --   Complexity: /O((n+m)*log n)/ time and /O(n)/ space.
 --

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -156,10 +156,11 @@ bfs vs = bfsForestFrom vs >=> levels
 dfsForest :: Ord a => AdjacencyMap a -> Forest a
 dfsForest g = dfsForestFrom (vertexList g) g
 
--- | Compute the /depth-first search/ forest of a graph, searching
---   from each of the given vertices in order. Note that the resulting
---   forest does not necessarily span the whole graph, as some
---   vertices may be unreachable.
+-- | Compute the /depth-first search/ forest of a graph from the given
+--   vertices, where adjacent vertices are expanded smallest to
+--   biggest according to their 'Ord' instance. Note that the
+--   resulting forest does not necessarily span the whole graph, as
+--   some vertices may be unreachable.
 -- 
 --   Let /L/ be the number of seed vertices. Complexity: /O((L+m)*log n)/
 --   time and /O(n)/ space.
@@ -198,8 +199,9 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
                     when new $ modify' (Set.insert v)
                     return new
 
--- | Compute the list of vertices visited by the /depth-first search/ in a
---   graph, when searching from each of the given vertices in order.
+-- | Compute the vertices visited by /depth-first search/ in a graph
+--   from the given vertices. Adjacent vertices are expanded smallest
+--   to biggest according to their 'Ord' instance.
 --
 --   Let /L/ be the number of seed vertices. Complexity: /O((L+m)*log n)/
 --   time and /O(n)/ space.

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -61,7 +61,6 @@ import qualified Data.Set                            as Set
 --                                                                        , subForest = [] }]}]
 -- 'forest' (bfsForest ('circuit' [1..5] + 'circuit' [5,4..1])) == 'path' [1,2,3] + 'path' [1,5,4]
 -- @
-
 bfsForest :: Ord a => AdjacencyMap a -> Forest a
 bfsForest g = bfsForestFrom' (vertexList g) g
 
@@ -130,8 +129,11 @@ bfsForestFrom' vs g = evalState (explore vs) Set.empty where
 bfs :: Ord a => [a] -> AdjacencyMap a -> [[a]]
 bfs vs = bfsForestFrom vs >=> levels
 
--- | Compute the /depth-first search/ forest of a graph that corresponds to
--- searching from each of the graph vertices in the 'Ord' @a@ order.
+-- | Compute the /depth-first search/ forest of a graph that
+--   corresponds to searching from each of the graph vertices in the
+--   'Ord' @a@ order.
+--
+--   Complexity: /O((n+m)*log n)/ time and /O(n)/ space.
 --
 -- @
 -- dfsForest 'empty'                       == []
@@ -277,9 +279,17 @@ topSort' g = callCC $ \cyclic ->
                           Parent z -> aux (z <| xs)
                           _ -> error "impossible"
 
--- | Compute a topological sort of the vertices of a graph. Given a
---  DAG, the lexicographically least topological ordering is returned,
---  otherwise, a cycle is.
+-- | Compute a topological ordering of a DAG or discover a cycle.
+--
+--   Vertices are expanded largest to smallest according their 'Ord'
+--   instance. This gives the lexicographically smallest topological
+--   ordering in the case of success. In the case of failure, the
+--   cycle is characterized by being the lexicographically smallest up
+--   to rotation with respect to @Ord (Dual a)@ in the first connected
+--   component of the graph, where the connected components are
+--   ordered by their largest vertex with respect to @Ord a@.
+--
+--   Complexity: /O((n+m)*log n)/ time and /O(n)/ space.
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
@@ -287,9 +297,9 @@ topSort' g = callCC $ \cyclic ->
 -- topSort (3 * (1 * 4 + 2 * 5))              == Right [3,1,2,4,5]
 -- topSort (1 * 2 + 2 * 1)                    == Left (2 ':|' [1])
 -- topSort ('path' [5,4..1] + 'edge' 2 4)         == Left (4 ':|' [3,2])
--- topSort ('circuit' [1..5])                   == Left (5 ':|' [1..4])
+-- topSort ('circuit' [1..3])                   == Left (3 ':|' [1,2])
 -- topSort ('circuit' [1..3] + 'circuit' [3,2,1]) == Left (3 ':|' [2])
--- topSort (1*2+2*1+3*4+4*3+5*1)              == Left (1 ':|' [2])
+-- topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 :| [2])
 -- fmap ('flip' 'isTopSortOf' x) (topSort x)      /= Right False
 -- 'isRight' . topSort                          == 'isAcyclic'
 -- @
@@ -298,6 +308,8 @@ topSort g = runContT (evalStateT (topSort' g) initialState) id where
   initialState = S mempty mempty 
 
 -- | Check if a given graph is /acyclic/.
+-- 
+--   Complexity: /O((n+m)*log n)/ time and /O(n)/ space.
 --
 -- @
 -- isAcyclic (1 * 2 + 3 * 1) == True

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -247,13 +247,11 @@ reachable :: Ord a => a -> AdjacencyMap a -> [a]
 reachable x = dfs [x]
 
 type Cycle = NonEmpty 
-data Entry a = Entered a | Exited a | OpenRoot | ClosedRoot
-type TopSort a = Either (Cycle a) [a]
-type ParentTable a = Map.Map a (Entry a)
-data S a = S { table :: !(ParentTable a), order :: [a] }
+data Entry a = Entered !a | Exited !a | OpenRoot | ClosedRoot
+data S a = S { table :: !(Map.Map a (Entry a)), order :: [a] }
 
 topSort' :: (Ord a, MonadState (S a) m, MonadCont m)
-         => AdjacencyMap a -> m (TopSort a)
+         => AdjacencyMap a -> m (Either (Cycle a) [a])
 topSort' g = callCC $ \cyclic ->
   do let vertices = map fst $ Map.toDescList $ adjacencyMap g
          adjacent = Set.toDescList . flip postSet g
@@ -261,10 +259,11 @@ topSort' g = callCC $ \cyclic ->
            do enter prev curr
               forM_ (adjacent curr) $ \next ->
                 nodeState next >>= \case
-                  Nothing -> dfs (Entered curr) next
-                  Just (Exited v) -> return ()
-                  Just ClosedRoot -> return ()
-                  _ -> cyclic . Left . retrace curr next =<< gets table
+                  Nothing          -> dfs (Entered curr) next
+                  Just (Exited v)  -> return ()
+                  Just ClosedRoot  -> return ()
+                  Just (Entered v) -> cyclic . Left . retrace curr next =<< gets table
+                  Just OpenRoot    -> cyclic . Left . retrace curr next =<< gets table
               exit curr
      forM_ vertices $ \v -> nodeState v >>= \case
        Nothing -> dfs OpenRoot v
@@ -275,19 +274,22 @@ topSort' g = callCC $ \cyclic ->
     enter u v = modify' (\(S p vs) -> S (Map.insert v u p) vs)
     exit v = modify' (\(S p vs) -> S (Map.alter (fmap leave) v p) (v:vs))
       where leave = \case
-              Entered x -> Exited x
-              OpenRoot -> ClosedRoot
-              _ -> error "Internal error: dfs search order violated"
+              Entered x  -> Exited x
+              OpenRoot   -> ClosedRoot
+              Exited x   -> error "Internal error: dfs search order violated"
+              ClosedRoot -> error "Internal error: dfs search order violated"
     retrace curr head table = aux (curr :| []) where
       aux xs@(curr :| _)
         | head == curr = xs
         | otherwise = case table Map.! curr of
             Entered prev -> aux (prev <| xs)
-            _ -> error "Internal error: dfs back edge mistakingly identified"
+            OpenRoot     -> error "Internal error: dfs search order violated"
+            Exited  prev -> error "Internal error: dfs search order violated"
+            ClosedRoot   -> error "Internal error: dfs search order violated"
 
 -- | Compute a topological sort of a DAG or discover a cycle.
 --
---   Vertices are expanded in increasing order with respect to their
+--   Vertices are expanded in decreasing order with respect to their
 --   'Ord' instance. This gives the lexicographically smallest
 --   topological ordering in the case of success. In the case of
 --   failure, the cycle is characterized by being the

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -270,16 +270,16 @@ topSort' g = callCC $ \cyclic ->
     unexplored u = gets (not . Map.member u . table)
     enter u v = modify' (\(S p vs) -> S (Map.insert v (Left u) p) vs)
     exit v = modify' (\(S p vs) -> S (Map.alter (fmap done) v p) (v:vs))
-    done = \case
-      Left x -> Right x
-      _ -> error "impossible"
+      where done = \case
+              Left x -> Right x
+              _ -> error "impossible"
     retrace x x0 table = aux (x :| []) where
       aux xs@(x :| _) | x0 == x = xs
                       | otherwise = case table Map.! x of
                           Parent z -> aux (z <| xs)
                           _ -> error "impossible"
 
--- | Compute a topological ordering of a DAG or discover a cycle.
+-- | Compute a topological sort of a DAG or discover a cycle.
 --
 --   Vertices are expanded largest to smallest according their 'Ord'
 --   instance. This gives the lexicographically smallest topological
@@ -299,7 +299,7 @@ topSort' g = callCC $ \cyclic ->
 -- topSort ('path' [5,4..1] + 'edge' 2 4)         == Left (4 ':|' [3,2])
 -- topSort ('circuit' [1..3])                   == Left (3 ':|' [1,2])
 -- topSort ('circuit' [1..3] + 'circuit' [3,2,1]) == Left (3 ':|' [2])
--- topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 :| [2])
+-- topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 ':|' [2])
 -- fmap ('flip' 'isTopSortOf' x) (topSort x)      /= Right False
 -- 'isRight' . topSort                          == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -277,9 +277,9 @@ topSort' g = callCC $ \cyclic -> do
 -- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 -- topSort ('path' [1..5])                 == Right [1..5]
 -- topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
--- topSort (1 * 2 + 2 * 1)               == Left [1,2]
--- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left [4,3,2]
--- topSort ('circuit' [1..5])              == Left [5,1,2,3,4]
+-- topSort (1 * 2 + 2 * 1)               == Left (2 ':|' [1])
+-- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left (4 ':|' [3,2])
+-- topSort ('circuit' [1..5])              == Left (5 ':|' [1..4])
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -241,9 +241,9 @@ topSort' g = callCC $ \cyclic -> do
       exit v = modify' (\(S p vs) -> S (Map.alter mark v p) (v:vs)) where
         mark = fmap (fmap (const True)) -- mark tree as explored/done
       node_state v = gets (Map.lookup v . table)
-      retrace v vs@(u:_) table@(Map.lookup u -> Just (Just w,_))
-        | w == v = v:vs
+      retrace v vs@(u:_) table@(Map.lookup u -> ~(Just (Just w,_)))
         | v == u = vs
+        | v == w = v:vs
         | otherwise = retrace v (w:vs) table
       dfs u =
         do forM_ (Set.toDescList $ postSet u g) $ \v ->

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -1,4 +1,4 @@
-{-# language LambdaCase, PatternSynonyms #-}
+{-# language LambdaCase #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -243,51 +243,41 @@ reachable :: Ord a => a -> AdjacencyMap a -> [a]
 reachable x = dfs [x]
 
 type Cycle = NonEmpty 
-type Entry a = Either a a
+data Entry a = Entered (Maybe a) | Exited (Maybe a)
 type TopSort a = Either (Cycle a) [a]
 type ParentTable a = Map.Map a (Entry a)
 data S a = S { table :: !(ParentTable a), order :: [a] }
-
--- Tree edge when node has not been explored
-pattern TreeEdge :: Maybe (Entry a)
-pattern TreeEdge <- Nothing
--- Back edge when node is being processed, but not done
-pattern BackEdge :: Maybe (Entry a)
-pattern BackEdge <- Just (Left _)
--- Pattern to retrieve Parent from table lookup
-pattern Parent :: a -> Entry a
-pattern Parent p <- Left p
 
 topSort' :: (Ord a, MonadState (S a) m, MonadCont m)
          => AdjacencyMap a -> m (TopSort a)
 topSort' g = callCC $ \cyclic ->
   do let vertices = map fst $ Map.toDescList $ adjacencyMap g
          adjacent = Set.toDescList . flip postSet g
-         dfs z x =
-           do enter z x
-              forM_ (adjacent x) $ \y ->
-                classify y >>= \case
-                  TreeEdge -> dfs x y
-                  BackEdge -> cyclic . Left . retrace x y =<< gets table
-                  _        -> return ()
-              exit x
-     forM_ vertices $ \v ->
-       do new <- unexplored v
-          when new $ dfs undefined v
+         dfs prev curr =
+           do enter prev curr
+              forM_ (adjacent curr) $ \next ->
+                nodeState next >>= \case
+                  Nothing -> dfs (Just curr) next
+                  Just (Exited _) -> return ()
+                  _ -> cyclic . Left . retrace curr next =<< gets table
+              exit curr
+     forM_ vertices $ \v -> nodeState v >>= \case
+       Nothing -> dfs Nothing v
+       _       -> return ()
      Right <$> gets order
   where
-    classify v = gets (Map.lookup v . table)
-    unexplored u = gets (not . Map.member u . table)
-    enter u v = modify' (\(S p vs) -> S (Map.insert v (Left u) p) vs)
-    exit v = modify' (\(S p vs) -> S (Map.alter (fmap done) v p) (v:vs)) where
-      done = \case
-        Left x -> Right x
-        _ -> error "Internal error: dfs node was exitted before it was entered"
+    nodeState v = gets (Map.lookup v . table)
+    enter u v = modify' (\(S p vs) -> S (Map.insert v (Entered u) p) vs)
+    exit v = modify' (\(S p vs) -> S (Map.alter (fmap leave) v p) (v:vs))
+      where leave = \case
+              Entered x -> Exited x
+              _ -> error "Internal error: dfs search order violated"
     retrace x x0 table = aux (x :| []) where
-      aux xs@(x :| _) | x0 == x = xs
-                      | otherwise = case table Map.! x of
-                          Parent z -> aux (z <| xs)
-                          _ -> error "Internal error: dfs back edge was mistakingly identified"
+      aux xs@(x :| _)
+        | x0 == x = xs
+        | otherwise = case table Map.! x of
+            Entered (Just z) -> aux (z <| xs)
+            _ -> error "Internal error: dfs back edge was mistakingly identified"
 
 -- | Compute a topological sort of a DAG or discover a cycle.
 --

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -229,37 +229,33 @@ dfs vs = concatMap flatten . dfsForestFrom vs
 reachable :: Ord a => a -> AdjacencyMap a -> [a]
 reachable x = concat . bfs [x]
 
-data S a = S { table :: !(Map.Map a a)
-             , seen :: !(Map.Map a Bool)
-             , order :: [a] } deriving (Show)
-
+type ParentTable a = Map.Map a (Maybe a,Bool)
+data S a = S { table :: !(ParentTable a), order :: [a] }
 type TopOrder a = Either [a] [a]
 
-backtrack :: Ord a => a -> [a] -> Map.Map a a -> [a]
-backtrack w vs@(v:_) table = case Map.lookup v table of
-  Just u -> if u == w then vs else backtrack w (u:vs) table
-  Nothing -> vs
-  
-topSort' :: (Ord a, MonadState (S a) m, MonadCont m) => AdjacencyMap a -> m (TopOrder a)
+topSort' :: (Ord a, MonadState (S a) m, MonadCont m)
+         => AdjacencyMap a -> m (TopOrder a)
 topSort' g = callCC $ \cyclic -> do
-  let enter v = modify' (\(S p s vs) -> S p (Map.insert v False s) vs)
-      exit v = modify' (\(S p s vs) -> S p (Map.insert v True s) (v:vs))
-      parent u v = modify' (\(S p s vs) -> S (Map.insert v u p) s vs)
-      nodeState v = gets (Map.lookup v . seen)
+  let parent u v = modify' (\(S p vs) -> S (Map.alter (register u) v p) vs)
+      register u = const (Just (u, False)) -- mark parent as u 
+      explored v = modify' (\(S p vs) -> S (Map.alter mark v p) (v:vs))
+      mark = fmap (fmap (const True)) -- mark tree as explored/done
+      node_state v = gets (Map.lookup v . table)
       unexplored u = gets (not . Map.member u . table)
-      explore u =
-        do enter u
-           forM_ (Set.toDescList (postSet u g)) $ \v ->
-             nodeState v >>= \case
-               Nothing -> parent u v >> explore v
-               -- True => tree fully explored, False => not (cycle)               
-               Just False -> cyclic . Left . backtrack v [u,v] =<< gets table
-               Just True -> pure ()
-           exit u
-           
-  forM_ (map fst $ Map.toDescList $ adjacencyMap g) $ \v ->
-    do new <- unexplored v
-       when new $ explore v
+      build_cycle u v = cyclic . Left . expand_cycle v [u,v] =<< gets table
+      expand_cycle w vs@(v:_) table =
+        case Map.lookup v table of
+          Just (Just u,_) -> if u == v then vs else expand_cycle w (u:vs) table
+          Just _ -> tail vs
+      dfs u = do forM_ (Set.toDescList $ postSet u g) $ \v ->
+                   node_state v >>= \case
+                     Nothing -> parent (Just u) v >> dfs v -- new node
+                     Just (_,True) -> pure () -- part of explored tree
+                     Just (_,False) -> build_cycle u v -- part of cycle
+                 explored u
+  forM_ (map fst $ Map.toDescList $ adjacencyMap g) $
+    \v -> do new_tree <- unexplored v
+             when new_tree $ parent Nothing v >> dfs v
   Right <$> gets order
 
 -- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph
@@ -273,7 +269,7 @@ topSort' g = callCC $ \cyclic -> do
 -- @
 topSort :: Ord a => AdjacencyMap a -> Either [a] [a]
 topSort g = runContT (runStateT (topSort' g) initialState) fst where
-  initialState = S mempty mempty mempty
+  initialState = S mempty mempty 
 
 -- | Check if a given graph is /acyclic/.
 --

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -209,7 +209,7 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
 -- dfs [3] $ 'circuit' [1..5] + 'circuit' [5,4..1] == [3,2,1,5,4]
 -- @
 dfs :: Ord a => [a] -> AdjacencyMap a -> [a]
-dfs vs = concatMap flatten . dfsForestFrom vs
+dfs vs = dfsForestFrom vs >=> flatten
 
 -- | Compute the list of vertices that are /reachable/ from a given
 -- source vertex in a graph. The vertices in the resulting list appear
@@ -262,7 +262,7 @@ topSort' g = callCC $ \cyclic -> do
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
--- topSort (1 * 2 + 2 * 1)               == Left [2,2]
+-- topSort (1 * 2 + 2 * 1)               == Left [2,1]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Just False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -260,12 +260,17 @@ topSort' g = callCC $ \cyclic -> do
              when new_tree $ parent Nothing v >> dfs v
   Right <$> gets order
 
--- | Compute the /topological sort/ of a graph or return @Nothing@ if the graph
--- is cyclic.
+-- | Compute a topological sort of the vertices of a graph. Given a
+--  DAG, the lexicographically least topological ordering is returned,
+--  otherwise, a cycle is.
 --
 -- @
 -- topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
+-- topSort ('path' [1..5])                 == Right [1..5]
+-- topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
 -- topSort (1 * 2 + 2 * 1)               == Left [2,1]
+-- topSort ('path' [5,4..1] + 'edge' 2 4)    == Left [4,3,2]
+-- topSort ('circuit' [1..5])              == Left [5,1,2,3,4]
 -- fmap ('flip' 'isTopSortOf' x) (topSort x) /= Right False
 -- 'isRight' . topSort                     == 'isAcyclic'
 -- @

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -129,9 +129,9 @@ bfsForestFrom' vs g = evalState (explore vs) Set.empty where
 bfs :: Ord a => [a] -> AdjacencyMap a -> [[a]]
 bfs vs = bfsForestFrom vs >=> levels
 
--- | Compute the /depth-first search/ forest of a graph that
---   corresponds to searching from each of the graph vertices in the
---   'Ord' @a@ order.
+-- | Compute the /depth-first search/ forest of a graph, where
+--   adjacent vertices are expanded smallest to biggest with respect
+--   to their 'Ord' instance.
 --
 --   Complexity: /O((n+m)*log n)/ time and /O(n)/ space.
 --
@@ -156,9 +156,10 @@ bfs vs = bfsForestFrom vs >=> levels
 dfsForest :: Ord a => AdjacencyMap a -> Forest a
 dfsForest g = dfsForestFrom (vertexList g) g
 
--- | Compute the /depth-first search/ forest of a graph, searching from each of
--- the given vertices in order. Note that the resulting forest does not
--- necessarily span the whole graph, as some vertices may be unreachable.
+-- | Compute the /depth-first search/ forest of a graph, searching
+--   from each of the given vertices in order. Note that the resulting
+--   forest does not necessarily span the whole graph, as some
+--   vertices may be unreachable.
 --
 -- @
 -- dfsForestFrom vs 'empty'                           == []
@@ -196,7 +197,7 @@ dfsForestFrom' vs g = evalState (explore vs) mempty where
                     return new
 
 -- | Compute the list of vertices visited by the /depth-first search/ in a
--- graph, when searching from each of the given vertices in order.
+--   graph, when searching from each of the given vertices in order.
 --
 -- @
 -- dfs vs    $ 'empty'                    == []

--- a/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
+++ b/src/Algebra/Graph/AdjacencyMap/Algorithm.hs
@@ -158,7 +158,7 @@ bfs vs = bfsForestFrom vs >=> levels
 -- 'forest' (dfsForest $ 'circuit' [1..5] + 'circuit' [5,4..1]) == 'path' [1,2,3,4,5]
 -- @
 dfsForest :: Ord a => AdjacencyMap a -> Forest a
-dfsForest g = dfsForestFrom (vertexList g) g
+dfsForest g = dfsForestFrom' (vertexList g) g
 
 -- | Compute the /depth-first search/ forest of a graph from the given
 --   vertices, where adjacent vertices are expanded in increasing

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -51,7 +51,6 @@ module Algebra.Graph.ToGraph (
 
 import Data.IntMap        (IntMap)
 import Data.IntSet        (IntSet)
-import Data.List.NonEmpty (NonEmpty)
 import Data.Map           (Map)
 import Data.Set           (Set)
 import Data.Tree
@@ -261,13 +260,13 @@ class ToGraph t where
     reachable :: Ord (ToVertex t) => ToVertex t -> t -> [ToVertex t]
     reachable x = AM.reachable x . toAdjacencyMap
 
-    -- | Compute the /topological sort/ of a graph or return @Nothing@ if the
+    -- | Compute the /topological sort/ of a graph or a @AM.Cycle@ if the
     -- graph is cyclic.
     --
     -- @
     -- topSort == Algebra.Graph.AdjacencyMap.'AM.topSort' . toAdjacencyMap
     -- @
-    topSort :: Ord (ToVertex t) => t -> Either (NonEmpty (ToVertex t)) [ToVertex t]
+    topSort :: Ord (ToVertex t) => t -> Either (AM.Cycle (ToVertex t)) [ToVertex t]
     topSort = AM.topSort . toAdjacencyMap
 
     -- | Check if a given graph is /acyclic/.

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -49,10 +49,11 @@ module Algebra.Graph.ToGraph (
     adjacencyMap, adjacencyIntMap, adjacencyMapTranspose, adjacencyIntMapTranspose
     ) where
 
-import Data.IntMap (IntMap)
-import Data.IntSet (IntSet)
-import Data.Map    (Map)
-import Data.Set    (Set)
+import Data.IntMap        (IntMap)
+import Data.IntSet        (IntSet)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map           (Map)
+import Data.Set           (Set)
 import Data.Tree
 
 import qualified Algebra.Graph                                as G
@@ -266,7 +267,7 @@ class ToGraph t where
     -- @
     -- topSort == Algebra.Graph.AdjacencyMap.'AM.topSort' . toAdjacencyMap
     -- @
-    topSort :: Ord (ToVertex t) => t -> Either [ToVertex t] [ToVertex t]
+    topSort :: Ord (ToVertex t) => t -> Either (NonEmpty (ToVertex t)) [ToVertex t]
     topSort = AM.topSort . toAdjacencyMap
 
     -- | Check if a given graph is /acyclic/.

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -266,7 +266,7 @@ class ToGraph t where
     -- @
     -- topSort == Algebra.Graph.AdjacencyMap.'AM.topSort' . toAdjacencyMap
     -- @
-    topSort :: Ord (ToVertex t) => t -> Maybe [ToVertex t]
+    topSort :: Ord (ToVertex t) => t -> Either [ToVertex t] [ToVertex t]
     topSort = AM.topSort . toAdjacencyMap
 
     -- | Check if a given graph is /acyclic/.

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -49,10 +49,10 @@ module Algebra.Graph.ToGraph (
     adjacencyMap, adjacencyIntMap, adjacencyMapTranspose, adjacencyIntMapTranspose
     ) where
 
-import Data.IntMap        (IntMap)
-import Data.IntSet        (IntSet)
-import Data.Map           (Map)
-import Data.Set           (Set)
+import Data.IntMap (IntMap)
+import Data.IntSet (IntSet)
+import Data.Map    (Map)
+import Data.Set    (Set)
 import Data.Tree
 
 import qualified Algebra.Graph                                as G

--- a/test/Algebra/Graph/Test/API.hs
+++ b/test/Algebra/Graph/Test/API.hs
@@ -104,7 +104,7 @@ data API g c where
         , dfsForestFrom              :: forall a. c a => [a] -> g a -> Forest a
         , dfs                        :: forall a. c a => [a] -> g a -> [a]
         , reachable                  :: forall a. c a => a -> g a -> [a]
-        , topSort                    :: forall a. c a => g a -> Maybe [a]
+        , topSort                    :: forall a. c a => g a -> Either [a] [a]
         , isAcyclic                  :: forall a. c a => g a -> Bool
         , toAdjacencyMap             :: forall a. c a => g a -> AM.AdjacencyMap a
         , toAdjacencyIntMap          :: g Int -> AIM.AdjacencyIntMap

--- a/test/Algebra/Graph/Test/API.hs
+++ b/test/Algebra/Graph/Test/API.hs
@@ -22,6 +22,7 @@ module Algebra.Graph.Test.API (
     ) where
 
 import Data.Coerce
+import Data.List.NonEmpty (NonEmpty)
 import Data.Monoid (Any)
 import Data.IntMap (IntMap)
 import Data.IntSet (IntSet)
@@ -104,7 +105,7 @@ data API g c where
         , dfsForestFrom              :: forall a. c a => [a] -> g a -> Forest a
         , dfs                        :: forall a. c a => [a] -> g a -> [a]
         , reachable                  :: forall a. c a => a -> g a -> [a]
-        , topSort                    :: forall a. c a => g a -> Either [a] [a]
+        , topSort                    :: forall a. c a => g a -> Either (NonEmpty a) [a]
         , isAcyclic                  :: forall a. c a => g a -> Bool
         , toAdjacencyMap             :: forall a. c a => g a -> AM.AdjacencyMap a
         , toAdjacencyIntMap          :: g Int -> AIM.AdjacencyIntMap

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -444,13 +444,13 @@ testAcyclicAdjacencyMap = do
     test "topSort (vertex x)            == [x]" $ \(x :: Int) ->
           topSort (vertex x)            == [x]
 
-    test "topSort (1 * (2 + 4) + 3 * 4) == [3, 1, 4, 2]" $
-          topSort (1 * (2 + 4) + 3 * 4) == [3, 1, 4, 2 :: Int]
+    test "topSort (1 * (2 + 4) + 3 * 4) == [1, 2, 3, 4]" $
+          topSort (1 * (2 + 4) + 3 * 4) == [1, 2, 3, 4 :: Int]
 
     test "topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)" $ \(x :: AAI) (y :: AAI) ->
           topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)
 
-    test "topSort                       == fromJust . topSort . fromAcyclic" $ \(x :: AAI) ->
+    test "topSort                       == (fromJust . AM.topSort . fromAcyclic)" $ \(x :: AAI) ->
           topSort x                     == (fromJust . AM.topSort . fromAcyclic) x
 
     putStrLn "\n============ Acyclic.AdjacencyMap.scc ============"

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -18,7 +18,7 @@ import Algebra.Graph.Test
 import Algebra.Graph.Test.Generic
 
 import Data.Bifunctor
-import Data.Maybe
+import Data.Either
 import Data.Tuple
 
 import qualified Algebra.Graph.AdjacencyMap           as AM
@@ -450,8 +450,8 @@ testAcyclicAdjacencyMap = do
     test "topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)" $ \(x :: AAI) (y :: AAI) ->
           topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)
 
-    test "topSort                       == (fromJust . AM.topSort . fromAcyclic)" $ \(x :: AAI) ->
-          topSort x                     == (fromJust . AM.topSort . fromAcyclic) x
+    test "topSort                       == (fromRight (error \"impossible\") . AM.topSort . fromAcyclic)" $ \(x :: AAI) ->
+          topSort x                     == (fromRight (error "impossible") . AM.topSort . fromAcyclic) x
 
     putStrLn "\n============ Acyclic.AdjacencyMap.scc ============"
     test "           scc empty               == empty" $

--- a/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Acyclic/AdjacencyMap.hs
@@ -18,7 +18,6 @@ import Algebra.Graph.Test
 import Algebra.Graph.Test.Generic
 
 import Data.Bifunctor
-import Data.Either
 import Data.Tuple
 
 import qualified Algebra.Graph.AdjacencyMap           as AM
@@ -450,8 +449,8 @@ testAcyclicAdjacencyMap = do
     test "topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)" $ \(x :: AAI) (y :: AAI) ->
           topSort (join x y)            == fmap Left (topSort x) ++ fmap Right (topSort y)
 
-    test "topSort                       == (fromRight (error \"impossible\") . AM.topSort . fromAcyclic)" $ \(x :: AAI) ->
-          topSort x                     == (fromRight (error "impossible") . AM.topSort . fromAcyclic) x
+    test "Right . topSort                   == AM.topSort . fromAcyclic" $ \(x :: AAI) ->
+          Right (topSort x)                 == AM.topSort (fromAcyclic x)
 
     putStrLn "\n============ Acyclic.AdjacencyMap.scc ============"
     test "           scc empty               == empty" $

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1989,6 +1989,24 @@ testTopSort (prefix, API{..}) = do
     test "topSort (1 * 2 + 3 * 1)               == Right [3,1,2]" $
           topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 
+    test "topSort (1 * 2 + 3 * 1)               == Right [3,1,2]" $
+          topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
+          
+    test "topSort (path [1..5])                 == Right [1..5]" $
+          topSort (path [1..5])                 == Right [1..5]
+          
+    test "topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]" $
+          topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
+          
+    test "topSort (1 * 2 + 2 * 1)               == Left [2,1]" $
+          topSort (1 * 2 + 2 * 1)               == Left [2,1]
+          
+    test "topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]" $
+          topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]
+          
+    test "topSort (circuit [1..5])              == Left [5,1,2,3,4]" $
+          topSort (circuit [1..5])              == Left [5,1,2,3,4]
+          
     test "topSort (1 * 2 + 2 * 1)               == Left [2,1]" $
           topSort (1 * 2 + 2 * 1)               == Left [2,1]
 

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -13,7 +13,7 @@ module Algebra.Graph.Test.Generic where
 
 import Control.Monad (when)
 import Data.Either
-import Data.List (nub)
+import Data.List (nub,sort)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Tree
 import Data.Tuple
@@ -1990,9 +1990,6 @@ testTopSort (prefix, API{..}) = do
     test "topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]" $
           topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
                                                      
-    test "topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]" $
-          topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
-                                                     
     test "topSort (path [1..5])                      == Right [1..5]" $
           topSort (path [1..5])                      == Right [1..5]
                                                      
@@ -2016,6 +2013,11 @@ testTopSort (prefix, API{..}) = do
           
     test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
           fmap (flip isTopSortOf x) (topSort x) /= Right False
+
+    test "topSort . vertices     == Right . nub . sort" $ \vs ->
+         (topSort . vertices) vs == (Right . nubOrd . sort) vs
+      
+          
 
 testIsAcyclic :: TestsuiteInt g -> IO ()
 testIsAcyclic (prefix, API{..}) = do

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1987,26 +1987,32 @@ testReachable (prefix, API{..}) = do
 testTopSort :: TestsuiteInt g -> IO ()
 testTopSort (prefix, API{..}) = do
     putStrLn $ "\n============ " ++ prefix ++ "topSort ============"
-    test "topSort (1 * 2 + 3 * 1)               == Right [3,1,2]" $
-          topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
+    test "topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]" $
+          topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
+                                                     
+    test "topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]" $
+          topSort (1 * 2 + 3 * 1)                    == Right [3,1,2]
+                                                     
+    test "topSort (path [1..5])                      == Right [1..5]" $
+          topSort (path [1..5])                      == Right [1..5]
+                                                     
+    test "topSort (3 * (1 * 4 + 2 * 5))              == Right [3,1,2,4,5]" $
+          topSort (3 * (1 * 4 + 2 * 5))              == Right [3,1,2,4,5]
+                                                     
+    test "topSort (1 * 2 + 2 * 1)                    == Left (2 :| [1])" $
+          topSort (1 * 2 + 2 * 1)                    == Left (2 :| [1])
+                                                     
+    test "topSort (path [5,4..1] + edge 2 4)         == Left (4 :| [3,2])" $
+          topSort (path [5,4..1] + edge 2 4)         == Left (4 :| [3,2])
+                                                     
+    test "topSort (circuit [1..5])                   == Left (5 :| [1..4])" $
+          topSort (circuit [1..5])                   == Left (5 :| [1..4])
 
-    test "topSort (1 * 2 + 3 * 1)               == Right [3,1,2]" $
-          topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
-          
-    test "topSort (path [1..5])                 == Right [1..5]" $
-          topSort (path [1..5])                 == Right [1..5]
-          
-    test "topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]" $
-          topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
+    test "topSort (circuit [1..3] + circuit [3,2,1]) == Left (3 :| [2])" $
+          topSort (circuit [1..3] + circuit [3,2,1]) == Left (3 :| [2])
 
-    test "topSort (1 * 2 + 2 * 1)               == Left (2 :| [1])" $
-          topSort (1 * 2 + 2 * 1)               == Left (2 :| [1])
-
-    test "topSort (path [5,4..1] + edge 2 4)    == Left (4 :| [3,2])" $
-          topSort (path [5,4..1] + edge 2 4)    == Left (4 :| [3,2])
-
-    test "topSort (circuit [1..5])              == Left (5 :| [1..4])" $
-          topSort (circuit [1..5])              == Left (5 :| [1..4])
+    test "topSort (1*2+2*1+3*4+4*3+5*1)              == Left (2 :| [1])" $
+          topSort (1*2+2*1+3*4+4*3+5*1)              == Left (1 :| [2])
           
     test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
           fmap (flip isTopSortOf x) (topSort x) /= Right False

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1989,7 +1989,7 @@ testTopSort (prefix, API{..}) = do
     test "topSort (1 * 2 + 3 * 1)               == Right [3,1,2]" $
           topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 
-    test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
+    test "topSort (1 * 2 + 2 * 1)               == Left [2,1]" $
           topSort (1 * 2 + 2 * 1)               == Left [2,1]
 
 -- todo add appropriate test back

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -14,6 +14,7 @@ module Algebra.Graph.Test.Generic where
 import Control.Monad (when)
 import Data.Either
 import Data.List (nub)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.Tree
 import Data.Tuple
 
@@ -1997,15 +1998,15 @@ testTopSort (prefix, API{..}) = do
           
     test "topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]" $
           topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
-          
---    test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
---          topSort (1 * 2 + 2 * 1)               == Left [1,2]
---          
---    test "topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]" $
---          topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]
---          
---    test "topSort (circuit [1..5])              == Left [1..5]" $
---          topSort (circuit [1..5])              == Left [1..5]
+
+    test "topSort (1 * 2 + 2 * 1)               == Left (2 :| [1])" $
+          topSort (1 * 2 + 2 * 1)               == Left (2 :| [1])
+
+    test "topSort (path [5,4..1] + edge 2 4)    == Left (4 :| [3,2])" $
+          topSort (path [5,4..1] + edge 2 4)    == Left (4 :| [3,2])
+
+    test "topSort (circuit [1..5])              == Left (5 :| [1..4])" $
+          topSort (circuit [1..5])              == Left (5 :| [1..4])
           
     test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
           fmap (flip isTopSortOf x) (topSort x) /= Right False

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -12,8 +12,8 @@
 module Algebra.Graph.Test.Generic where
 
 import Control.Monad (when)
+import Data.Either
 import Data.List (nub)
-import Data.Maybe
 import Data.Tree
 import Data.Tuple
 
@@ -1986,14 +1986,15 @@ testReachable (prefix, API{..}) = do
 testTopSort :: TestsuiteInt g -> IO ()
 testTopSort (prefix, API{..}) = do
     putStrLn $ "\n============ " ++ prefix ++ "topSort ============"
-    test "topSort (1 * 2 + 3 * 1)               == Just [3,1,2]" $
-          topSort (1 * 2 + 3 * 1)               == Just [3,1,2]
+    test "topSort (1 * 2 + 3 * 1)               == Right [3,1,2]" $
+          topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 
-    test "topSort (1 * 2 + 2 * 1)               == Nothing" $
-          topSort (1 * 2 + 2 * 1)               == Nothing
+    test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
+          topSort (1 * 2 + 2 * 1)               == Left [1,2]
 
-    test "fmap (flip isTopSortOf x) (topSort x) /= Just False" $ \x ->
-          fmap (flip isTopSortOf x) (topSort x) /= Just False
+-- todo add appropriate test back
+--    test "fmap (flip isTopSortOf x) (topSort x) /= Just False" $ \x ->
+--          fmap (flip isTopSortOf x) (topSort x) /= Just False
 
 testIsAcyclic :: TestsuiteInt g -> IO ()
 testIsAcyclic (prefix, API{..}) = do
@@ -2007,8 +2008,8 @@ testIsAcyclic (prefix, API{..}) = do
     test "isAcyclic . circuit       == null" $ \xs ->
          (isAcyclic . circuit) xs  == null xs
 
-    test "isAcyclic                 == isJust . topSort" $ \x ->
-          isAcyclic x               == isJust (topSort x)
+    test "isAcyclic                 == isRight . topSort" $ \x ->
+          isAcyclic x               == isRight (topSort x)
 
 testIsDfsForestOf :: TestsuiteInt g -> IO ()
 testIsDfsForestOf (prefix, API{..}) = do

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1992,9 +1992,8 @@ testTopSort (prefix, API{..}) = do
     test "topSort (1 * 2 + 2 * 1)               == Left [2,1]" $
           topSort (1 * 2 + 2 * 1)               == Left [2,1]
 
--- todo add appropriate test back
---    test "fmap (flip isTopSortOf x) (topSort x) /= Just False" $ \x ->
---          fmap (flip isTopSortOf x) (topSort x) /= Just False
+    test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
+          fmap (flip isTopSortOf x) (topSort x) /= Right False
 
 testIsAcyclic :: TestsuiteInt g -> IO ()
 testIsAcyclic (prefix, API{..}) = do

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1998,18 +1998,15 @@ testTopSort (prefix, API{..}) = do
     test "topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]" $
           topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
           
-    test "topSort (1 * 2 + 2 * 1)               == Left [2,1]" $
-          topSort (1 * 2 + 2 * 1)               == Left [2,1]
+    test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
+          topSort (1 * 2 + 2 * 1)               == Left [1,2]
           
     test "topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]" $
           topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]
           
-    test "topSort (circuit [1..5])              == Left [5,1,2,3,4]" $
-          topSort (circuit [1..5])              == Left [5,1,2,3,4]
+    test "topSort (circuit [1..5])              == Left [1..5]" $
+          topSort (circuit [1..5])              == Left [1..5]
           
-    test "topSort (1 * 2 + 2 * 1)               == Left [2,1]" $
-          topSort (1 * 2 + 2 * 1)               == Left [2,1]
-
     test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
           fmap (flip isTopSortOf x) (topSort x) /= Right False
 

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1998,14 +1998,14 @@ testTopSort (prefix, API{..}) = do
     test "topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]" $
           topSort (3 * (1 * 4 + 2 * 5))         == Right [3,1,2,4,5]
           
-    test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
-          topSort (1 * 2 + 2 * 1)               == Left [1,2]
-          
-    test "topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]" $
-          topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]
-          
-    test "topSort (circuit [1..5])              == Left [1..5]" $
-          topSort (circuit [1..5])              == Left [1..5]
+--    test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
+--          topSort (1 * 2 + 2 * 1)               == Left [1,2]
+--          
+--    test "topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]" $
+--          topSort (path [5,4..1] + edge 2 4)    == Left [4,3,2]
+--          
+--    test "topSort (circuit [1..5])              == Left [1..5]" $
+--          topSort (circuit [1..5])              == Left [1..5]
           
     test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
           fmap (flip isTopSortOf x) (topSort x) /= Right False

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -2005,14 +2005,14 @@ testTopSort (prefix, API{..}) = do
     test "topSort (path [5,4..1] + edge 2 4)         == Left (4 :| [3,2])" $
           topSort (path [5,4..1] + edge 2 4)         == Left (4 :| [3,2])
                                                      
-    test "topSort (circuit [1..5])                   == Left (5 :| [1..4])" $
-          topSort (circuit [1..5])                   == Left (5 :| [1..4])
+    test "topSort (circuit [1..5])                   == Left (3 :| [1,2])" $
+          topSort (circuit [1..3])                   == Left (3 :| [1,2])
 
     test "topSort (circuit [1..3] + circuit [3,2,1]) == Left (3 :| [2])" $
           topSort (circuit [1..3] + circuit [3,2,1]) == Left (3 :| [2])
 
-    test "topSort (1*2+2*1+3*4+4*3+5*1)              == Left (2 :| [1])" $
-          topSort (1*2+2*1+3*4+4*3+5*1)              == Left (1 :| [2])
+    test "topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 :| [2])" $
+          topSort (1*2 + 2*1 + 3*4 + 4*3 + 5*1)      == Left (1 :| [2])
           
     test "fmap (flip isTopSortOf x) (topSort x) /= Right False" $ \x ->
           fmap (flip isTopSortOf x) (topSort x) /= Right False

--- a/test/Algebra/Graph/Test/Generic.hs
+++ b/test/Algebra/Graph/Test/Generic.hs
@@ -1990,7 +1990,7 @@ testTopSort (prefix, API{..}) = do
           topSort (1 * 2 + 3 * 1)               == Right [3,1,2]
 
     test "topSort (1 * 2 + 2 * 1)               == Left [1,2]" $
-          topSort (1 * 2 + 2 * 1)               == Left [1,2]
+          topSort (1 * 2 + 2 * 1)               == Left [2,1]
 
 -- todo add appropriate test back
 --    test "fmap (flip isTopSortOf x) (topSort x) /= Just False" $ \x ->


### PR DESCRIPTION
I threw together the monadic tree unfold version.

I also tried doing top sort directly, since I think it could be advantageous to build the final list directly without going through a forest structure first. It should also allow an early exit if a back edge is detected.