### PR TITLE
Removed unecessary condition

### DIFF
--- a/src/Algebra/Graph/Label.hs
+++ b/src/Algebra/Graph/Label.hs
@@ -334,7 +334,7 @@ instance (Monoid a, Ord a) => Semiring (Minimum a) where
 
 instance (Monoid a, Ord a) => Dioid (Minimum a)
 
-instance (Num a, Show a) => Show (Minimum a) where
+instance Show a => Show (Minimum a) where
     show (Minimum Infinite  ) = "one"
     show (Minimum (Finite x)) = show x
 


### PR DESCRIPTION
Minor change: Removed `Num` constraint on `Show` for `Minimum` in `Algebra.Graph.Label`