### PR TITLE
Fix typos

### DIFF
--- a/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Acyclic/AdjacencyMap.hs
@@ -505,7 +505,7 @@ toAcyclicOrd = AAM . filterEdges (<)
 -- TODO: Change Arbitrary instance of Acyclic and Labelled Acyclic graph
 -- | Construct an acyclic graph from a given adjacency map using 'scc'.
 -- If the graph is acyclic in nature, the same graph is returned as an acyclic graph.
--- If the graph is cyclic, then a representative for every strongly conected
+-- If the graph is cyclic, then a representative for every strongly connected
 -- component in its condensation graph is chosen an these representatives are
 -- used to build an acyclic graph.
 --

--- a/src/Algebra/Graph/Bipartite/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Bipartite/AdjacencyMap.hs
@@ -729,7 +729,7 @@ neighbours v = Set.toAscList . AM.postSet v
 -- 'AdjacencyMap' with the same set of edges and each vertex marked with the
 -- part it belongs to. In case of failure, return any odd cycle in the graph.
 --
--- The returned partition is lexicographicaly minimal. That is, consider the
+-- The returned partition is lexicographically minimal. That is, consider the
 -- string of part identifiers for each vertex in ascending order. Then,
 -- considering that the identifier of the left part is less then the identifier
 -- of the right part, this string is lexicographically minimal of all such

--- a/src/Algebra/Graph/Labelled.hs
+++ b/src/Algebra/Graph/Labelled.hs
@@ -15,7 +15,7 @@
 -- graphs with edge labels. The API will be expanded in the next release.
 -----------------------------------------------------------------------------
 module Algebra.Graph.Labelled (
-    -- * Algebraic data type for edge-labeleld graphs
+    -- * Algebraic data type for edge-labelled graphs
     Graph (..), empty, vertex, edge, (-<), (>-), overlay, connect, vertices,
     edges, overlays,
 


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.