### PR TITLE
Import liftM2 from Control.Monad instead of Control.Monad.State

### DIFF
--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -53,6 +53,7 @@ module Algebra.Graph.NonEmpty (
     ) where
 
 import Control.DeepSeq
+import Control.Monad
 import Control.Monad.State
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Semigroup ((<>))


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `alga` in line with the proposed change, because at the moment `Algebra.Graph.NonEmpty` imports `liftM2` (originally from `Control.Monad`) from `Control.Monad.State`.