### PR TITLE
Implement induce via induceJust

### DIFF
--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -1135,7 +1135,6 @@ transpose :: Graph a -> Graph a
 transpose g = buildg $ \e v o c -> foldg e v o (flip c) g
 {-# INLINE transpose #-}
 
--- TODO: Implement via 'induceJust' to reduce code duplication.
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
 -- Complexity: /O(s)/ time, memory and size, assuming that the predicate takes
@@ -1151,12 +1150,7 @@ transpose g = buildg $ \e v o c -> foldg e v o (flip c) g
 -- 'isSubgraphOf' (induce p x) x == True
 -- @
 induce :: (a -> Bool) -> Graph a -> Graph a
-induce p g = buildg $ \e v o c -> fromMaybe e $
-    foldg Nothing (\x -> if p x then Just (v x) else Nothing) (k o) (k c) g
-  where
-    k _ x        Nothing  = x -- Constant folding to get rid of Empty leaves
-    k _ Nothing  y        = y
-    k f (Just x) (Just y) = Just (f x y)
+induce p = induceJust . fmap (\a -> if p a then Just a else Nothing)
 {-# INLINE induce #-}
 
 -- | Construct the /induced subgraph/ of a given graph by removing the vertices

--- a/src/Algebra/Graph/Labelled.hs
+++ b/src/Algebra/Graph/Labelled.hs
@@ -506,7 +506,6 @@ transpose = foldg empty vertex (fmap flip connect)
 emap :: (e -> f) -> Graph e a -> Graph f a
 emap f = foldg Empty Vertex (Connect . f)
 
--- TODO: Implement via 'induceJust' to reduce code duplication.
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
 -- Complexity: /O(s)/ time, memory and size, assuming that the predicate takes
@@ -520,11 +519,7 @@ emap f = foldg Empty Vertex (Connect . f)
 -- 'isSubgraphOf' (induce p x) x == True
 -- @
 induce :: (a -> Bool) -> Graph e a -> Graph e a
-induce p = foldg Empty (\x -> if p x then Vertex x else Empty) c
-  where
-    c _ x     Empty = x -- Constant folding to get rid of Empty leaves
-    c _ Empty y     = y
-    c e x     y     = Connect e x y
+induce p = induceJust . fmap (\a -> if p a then Just a else Nothing)
 
 -- | Construct the /induced subgraph/ of a given graph by removing the vertices
 -- that are 'Nothing'.

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -816,7 +816,6 @@ transpose = foldg1 vertex overlay (flip connect)
 "transpose/clique1"   forall xs. transpose (clique1 xs) = clique1 (NonEmpty.reverse xs)
  #-}
 
--- TODO: Implement via 'induceJust1' to reduce code duplication.
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate. Returns @Nothing@ if the
 -- resulting graph is empty.
@@ -830,12 +829,7 @@ transpose = foldg1 vertex overlay (flip connect)
 -- induce1 p '>=>' induce1 q == induce1 (\\x -> p x && q x)
 -- @
 induce1 :: (a -> Bool) -> Graph a -> Maybe (Graph a)
-induce1 p = foldg1
-    (\x -> if p x then Just (Vertex x) else Nothing) (k Overlay) (k Connect)
-  where
-    k _ Nothing  a        = a
-    k _ a        Nothing  = a
-    k f (Just a) (Just b) = Just (f a b)
+induce1 p = induceJust1 . fmap (\a -> if p a then Just a else Nothing)
 
 -- | Construct the /induced subgraph/ of a given graph by removing the vertices
 -- that are 'Nothing'. Returns 'Nothing' if the resulting graph is empty.

--- a/src/Algebra/Graph/NonEmpty/AdjacencyMap.hs
+++ b/src/Algebra/Graph/NonEmpty/AdjacencyMap.hs
@@ -637,7 +637,7 @@ induce1 = fmap toNonEmpty . coerce AM.induce
 -- induceJust1 . 'gmap' (\\x -> if p x then 'Just' x else 'Nothing') == 'induce1' p
 -- @
 induceJust1 :: Ord a => AdjacencyMap (Maybe a) -> Maybe (AdjacencyMap a)
-induceJust1 m = toNonEmpty (AM.induceJust (coerce m))
+induceJust1 = toNonEmpty . AM.induceJust . coerce
 
 -- | Compute the /reflexive and transitive closure/ of a graph.
 -- Complexity: /O(n * m * log(n)^2)/ time.

--- a/src/Algebra/Graph/Undirected.hs
+++ b/src/Algebra/Graph/Undirected.hs
@@ -764,7 +764,6 @@ mergeVertices :: (a -> Bool) -> a -> Graph a -> Graph a
 mergeVertices = coerce21 G.mergeVertices
 {-# INLINE mergeVertices #-}
 
--- TODO: Implement via 'induceJust' to reduce code duplication.
 -- | Construct the /induced subgraph/ of a given graph by removing the
 -- vertices that do not satisfy a given predicate.
 -- Complexity: /O(s)/ time, memory and size, assuming that the predicate takes


### PR DESCRIPTION
Implementing `induce` as `induce p = induceJust . fmap (\a -> if p a then Just a else Nothing)` seems to pass inspection tests. My understanding is that this means `fmap` fuses nicely with the `induceJust`, and so using this simpler definition comes at no runtime cost.

@nobrakal Could you have a look?