### PR TITLE
Export.Dot: Extend Style to define Quoting styles

### DIFF
--- a/src/Algebra/Graph/Export/Dot.hs
+++ b/src/Algebra/Graph/Export/Dot.hs
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------
 module Algebra.Graph.Export.Dot (
     -- * Graph attributes and style
-    Attribute (..), Style (..), defaultStyle, defaultStyleViaShow,
+    Attribute (..), Quoting (..), Style (..), defaultStyle, defaultStyleViaShow,
 
     -- * Export functions
     export, exportAsIs, exportViaShow
@@ -33,6 +33,9 @@ import qualified Algebra.Graph.Export as E
 -- | An attribute is just a key-value pair, for example @"shape" := "box"@.
 -- Attributes are used to specify the style of graph elements during export.
 data Attribute s = (:=) s s
+
+-- | Used to determine whether to use double-quotes around attribute values.
+data Quoting = DoubleQuotes | NoQuotes
 
 -- | The record 'Style' @a@ @s@ specifies the style to use when exporting a
 -- graph in the DOT format. Here @a@ is the type of the graph vertices, and @s@
@@ -57,12 +60,14 @@ data Style a s = Style
     -- ^ Attributes of a specific vertex.
     , edgeAttributes   :: a -> a -> [Attribute s]
     -- ^ Attributes of a specific edge.
+    , attributeQuoting :: Quoting
+    -- ^ What style of quoting to apply to attributes.
     }
 
 -- | Default style for exporting graphs. All style settings are empty except for
 -- 'vertexName', which is provided as the only argument.
 defaultStyle :: Monoid s => (a -> s) -> Style a s
-defaultStyle v = Style mempty [] [] [] [] v (const []) (\_ _ -> [])
+defaultStyle v = Style mempty [] [] [] [] v (const []) (\_ _ -> []) DoubleQuotes
 
 -- | Default style for exporting graphs whose vertices are 'Show'-able. All
 -- style settings are empty except for 'vertexName', which is computed from
@@ -88,7 +93,8 @@ defaultStyleViaShow = defaultStyle (fromString . show)
 --     , 'defaultEdgeAttributes'   = 'mempty'
 --     , 'vertexName'              = \\x   -> "v" ++ 'show' x
 --     , 'vertexAttributes'        = \\x   -> ["color" := "blue"   | 'odd' x      ]
---     , 'edgeAttributes'          = \\x y -> ["style" := "dashed" | 'odd' (x * y)] }
+--     , 'edgeAttributes'          = \\x y -> ["style" := "dashed" | 'odd' (x * y)]
+--     , 'attributeQuoting'        = 'DoubleQuotes' }
 --
 -- > putStrLn $ export style (1 * 2 + 3 * 4 * 5 :: 'Graph' Int)
 --
@@ -113,7 +119,7 @@ export :: (IsString s, Monoid s, Ord a, ToGraph g, ToVertex g ~ a) => Style a s 
 export Style {..} g = render $ header <> body <> "}\n"
   where
     header    = "digraph" <+> literal graphName <> "\n{\n"
-    with x as = if null as then mempty else line (x <+> attributes as)
+    with x as = if null as then mempty else line (x <+> attributes attributeQuoting as)
     line s    = indent 2 s <> "\n"
     body      = unlines (map literal preamble)
              <> ("graph" `with` graphAttributes)
@@ -121,17 +127,20 @@ export Style {..} g = render $ header <> body <> "}\n"
              <> ("edge"  `with` defaultEdgeAttributes)
              <> E.export vDoc eDoc g
     label     = doubleQuotes . literal . vertexName
-    vDoc x    = line $ label x <+>                      attributes (vertexAttributes x)
-    eDoc x y  = line $ label x <> " -> " <> label y <+> attributes (edgeAttributes x y)
+    vDoc x    = line $ label x <+>                      attributes attributeQuoting (vertexAttributes x)
+    eDoc x y  = line $ label x <> " -> " <> label y <+> attributes attributeQuoting (edgeAttributes x y)
 
--- | A list of attributes formatted as a DOT document.
--- Example: @attributes ["label" := "A label", "shape" := "box"]@
+-- | A quoting type and list of attributes formatted as a DOT document.
+-- Example: @attributes DoubleQuotes ["label" := "A label", "shape" := "box"]@
 -- corresponds to document: @ [label="A label" shape="box"]@.
-attributes :: IsString s => [Attribute s] -> Doc s
-attributes [] = mempty
-attributes as = brackets . mconcat . intersperse " " $ map dot as
+attributes :: IsString s => Quoting -> [Attribute s] -> Doc s
+attributes _ [] = mempty
+attributes q as = brackets . mconcat . intersperse " " $ map dot as
   where
-    dot (k := v) = literal k <> "=" <> doubleQuotes (literal v)
+    dot (k := v) = literal k <> "=" <> quoting (literal v)
+    quoting = case q of
+        DoubleQuotes -> doubleQuotes
+        NoQuotes     -> id
 
 -- | Export a graph whose vertices are represented simply by their names.
 --

--- a/test/Algebra/Graph/Test/Export.hs
+++ b/test/Algebra/Graph/Test/Export.hs
@@ -125,7 +125,8 @@ testExport = do
             , ED.defaultEdgeAttributes   = mempty
             , ED.vertexName              = \x   -> "v" ++ show x
             , ED.vertexAttributes        = \x   -> ["color" := "blue"   | odd x      ]
-            , ED.edgeAttributes          = \x y -> ["style" := "dashed" | odd (x * y)] }
+            , ED.edgeAttributes          = \x y -> ["style" := "dashed" | odd (x * y)]
+            , ED.attributeQuoting        = ED.DoubleQuotes }
     test "export style (1 * 2 + 3 * 4 * 5 :: Graph Int)" $
         (ED.export style (1 * 2 + 3 * 4 * 5 :: Graph Int) :: String) ==
             unlines [ "digraph Example"
@@ -142,6 +143,27 @@ testExport = do
                     , "  \"v1\" -> \"v2\""
                     , "  \"v3\" -> \"v4\""
                     , "  \"v3\" -> \"v5\" [style=\"dashed\"]"
+                    , "  \"v4\" -> \"v5\""
+                    , "}" ]
+
+    putStrLn "\n=========== Export.Dot.attributeQuoting ============"
+    let style' = style { ED.attributeQuoting = ED.NoQuotes }
+    test "export style' (1 * 2 + 3 * 4 * 5 :: Graph Int)" $
+        (ED.export style' (1 * 2 + 3 * 4 * 5 :: Graph Int) :: String) ==
+            unlines [ "digraph Example"
+                    , "{"
+                    , "  // This is an example"
+                    , ""
+                    , "  graph [label=Example labelloc=top]"
+                    , "  node [shape=circle]"
+                    , "  \"v1\" [color=blue]"
+                    , "  \"v2\""
+                    , "  \"v3\" [color=blue]"
+                    , "  \"v4\""
+                    , "  \"v5\" [color=blue]"
+                    , "  \"v1\" -> \"v2\""
+                    , "  \"v3\" -> \"v4\""
+                    , "  \"v3\" -> \"v5\" [style=dashed]"
                     , "  \"v4\" -> \"v5\""
                     , "}" ]
 


### PR DESCRIPTION
GraphViz supports different types of label. The type is determined by
the delimiters used to quote the label's value. Double-quotes denote
a literal string. Pairs of angle brackets ("<>") denote a "HTML-like"
string, which permits the use of (some) HTML mark-up in the graph.

Extend the `Style` record type to include a `quoting` field, to signal
whether or not attribute values should be double-quoted. A user wishing
to use another quote style must define their style's quoting attribute
as `NoQuote` and then ensure their attribute values contain embedded
quote characters of their choice.

Adjust `defaultStyle` and the `attributes` function accordingly and add
a test.

Fixes #272.

----

[Here's an example of the above in use](https://github.com/jmtd/striot/commit/38ee592c7f4cea4b695c6db5a94fe8522ab9ed5e). Note that I have to take responsibility for wrapping all values, and I vary what delimiter I use. Here's what the result looks like:

```
λ> putStrLn $ jacksonGraphToDot mergeEx
digraph 
{
  graph [bgcolor="white"]
  node [shape="box" fillcolor="white" style="filled"]
  edge [weight="10" color="black" fontcolor="black"]
  "1" [label="streamSource (do {let {x'_0 = \"foo\"};
    threadDelay (1000 * 1000);
    putStrLn \"sending '\" ++ (x'_0 ++ \"'\");
    return x'_0})" xlabel=<<SUP>0.0</SUP>/<SUB>s</SUB>> fillcolor="#ffffff"]
  "2" [label="streamMap (id)" xlabel=<<SUP>1.0</SUP>/<SUB>s</SUB>> fillcolor="#ffffff"]
  "3" [label="streamSource (do {let {x'_0 = \"bar\"};
    threadDelay (1000 * 1000);
    putStrLn \"sending '\" ++ (x'_0 ++ \"'\");
    return x'_0})" xlabel=<<SUP>2.0</SUP>/<SUB>s</SUB>> fillcolor="#ffcccc"]
  "4" [label="streamMap (id)" xlabel=<<SUP>3.0</SUP>/<SUB>s</SUB>> fillcolor="#ffcccc"]
  "5" [label="streamMerge" xlabel=<<SUP>4.0</SUP>/<SUB>s</SUB>> fillcolor="#ffcccc"]
  "6" [label="streamSink (mapM_ print)" xlabel=<<SUP>5.0</SUP>/<SUB>s</SUB>> fillcolor="#ffcccc"]
  "1" -> "2" [label=<<SUP>1.0</SUP>/<SUB>s</SUB> <I>:: String</I>>]
  "2" -> "5" [label=<<SUP>2.0</SUP>/<SUB>s</SUB> <I>:: [String]</I>>]
  "3" -> "4" [label=<<SUP>1.0</SUP>/<SUB>s</SUB> <I>:: String</I>>]
  "4" -> "5" [label=<<SUP>2.0</SUP>/<SUB>s</SUB> <I>:: [String]</I>>]
  "5" -> "6" [label=<<SUP>2.0</SUP>/<SUB>s</SUB> <I>:: String</I>>]
}
```
![alga](https://user-images.githubusercontent.com/63694/129365185-b38ae8fa-8ba4-49e4-89e6-319a327a8def.png)
