### PR TITLE
Stop supporting GHC 8.0 and 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['9.0', '8.10', '8.8', '8.6', '8.4', '8.2', '8.0']
+        ghc: ['9.0', '8.10', '8.8', '8.6', '8.4']
         include:
         - os: windows-latest
         - os: macOS-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.7
 
+* #278: Stop supporting GHC 8.0 and GHC 8.2.
 * #273: Add attribute quoting style to `Export.Dot`.
 * #259: Allow newer QuickCheck.
 
@@ -19,7 +20,7 @@
 * #220, #237, #255: Add `Algebra.Graph.Undirected`.
 * #203, #215, #223: Add `Acyclic.AdjacencyMap`.
 * #202, #209, #211: Add `induceJust` and `induceJust1`.
-* #172, #245: Stop supporting GHC 7.8.4 and GHC 7.10.3.
+* #172, #245: Stop supporting GHC 7.8 and GHC 7.10.
 * #208: Add `fromNonEmpty` to `NonEmpty.AdjacencyMap`.
 * #208: Add `fromAdjacencyMap` to `AdjacencyIntMap`.
 * #208: Drop `Internal` modules for `AdjacencyIntMap`, `AdjacencyMap`,

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -12,7 +12,7 @@ homepage:      https://github.com/snowleopard/alga
 bug-reports:   https://github.com/snowleopard/alga/issues
 category:      Algebra, Algorithms, Data Structures, Graphs
 build-type:    Simple
-tested-with:   GHC==9.0, GHC==8.10, GHC==8.8, GHC==8.6, GHC==8.4, GHC==8.2, GHC==8.0
+tested-with:   GHC==9.0, GHC==8.10, GHC==8.8, GHC==8.6, GHC==8.4
 description:
     <https://github.com/snowleopard/alga Alga> is a library for algebraic construction and
     manipulation of graphs in Haskell. See <https://github.com/snowleopard/alga-paper this paper>

--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -155,6 +155,6 @@ test-suite test-alga
     build-depends:      algebraic-graphs,
                         extra              >= 1.4     && < 2,
                         inspection-testing >= 0.4.2.2 && < 0.5,
-                        QuickCheck         >= 2.10    && < 2.15
+                        QuickCheck         >= 2.14    && < 2.15
     other-extensions:   ConstrainedClassMethods
                         TemplateHaskell

--- a/src/Algebra/Graph.hs
+++ b/src/Algebra/Graph.hs
@@ -55,7 +55,6 @@ import Control.Monad (MonadPlus (..))
 import Control.Monad.State (runState, get, put)
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
-import Data.Semigroup ((<>))
 import Data.String
 import Data.Tree
 import GHC.Generics

--- a/src/Algebra/Graph/Export.hs
+++ b/src/Algebra/Graph/Export.hs
@@ -26,7 +26,6 @@ module Algebra.Graph.Export (
     ) where
 
 import Data.Foldable (fold)
-import Data.Semigroup
 import Data.String hiding (unlines)
 import Prelude hiding (unlines)
 

--- a/src/Algebra/Graph/Internal.hs
+++ b/src/Algebra/Graph/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Algebra.Graph.Internal
@@ -122,11 +121,7 @@ maybeF f x = Just . maybe x (f x)
 
 -- | Compute the Cartesian product of two sets.
 setProduct :: Set a -> Set b -> Set (a, b)
-#if MIN_VERSION_containers(0,5,11)
 setProduct = Set.cartesianProduct
-#else
-setProduct x y = Set.fromDistinctAscList [ (a, b) | a <- Set.toAscList x, b <- Set.toAscList y ]
-#endif
 
 -- | Compute the Cartesian product of two sets, applying a function to each
 -- resulting pair.

--- a/src/Algebra/Graph/Internal.hs
+++ b/src/Algebra/Graph/Internal.hs
@@ -29,8 +29,8 @@ module Algebra.Graph.Internal (
 
 import Data.Coerce
 import Data.Foldable
-import Data.Semigroup
 import Data.IntSet (IntSet)
+import Data.Semigroup (Endo (..))
 import Data.Set (Set)
 
 import qualified Data.IntSet as IntSet

--- a/src/Algebra/Graph/Label.hs
+++ b/src/Algebra/Graph/Label.hs
@@ -33,7 +33,7 @@ import Control.Monad
 import Data.Coerce
 import Data.Maybe
 import Data.Monoid (Any (..), Monoid (..), Sum (..))
-import Data.Semigroup (Max (..), Min (..), Semigroup (..))
+import Data.Semigroup (Max (..), Min (..))
 import Data.Set (Set)
 import GHC.Exts (IsList (..))
 

--- a/src/Algebra/Graph/NonEmpty.hs
+++ b/src/Algebra/Graph/NonEmpty.hs
@@ -56,7 +56,6 @@ import Control.DeepSeq
 import Control.Monad
 import Control.Monad.State
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Semigroup ((<>))
 import Data.String
 
 import Algebra.Graph.Internal

--- a/test/Algebra/Graph/Test/Arbitrary.hs
+++ b/test/Algebra/Graph/Test/Arbitrary.hs
@@ -219,23 +219,6 @@ instance (Arbitrary a, Arbitrary e, Monoid e) => Arbitrary (LG.Graph e a) where
     shrink (LG.Connect e x y) = [LG.Empty, x, y, LG.Connect mempty x y]
                              ++ [LG.Connect e x' y' | (x', y') <- shrink (x, y) ]
 
-#if !MIN_VERSION_QuickCheck(2,14,2)
-instance Arbitrary a => Arbitrary (Tree a) where
-    arbitrary = sized go
-      where
-        go 0 = do
-            root <- arbitrary
-            return $ Node root []
-        go n = do
-            subTrees <- choose (0, n - 1)
-            let subSize = (n - 1) `div` subTrees
-            root     <- arbitrary
-            children <- replicateM subTrees (go subSize)
-            return $ Node root children
-
-    shrink (Node r fs) = [Node r fs' | fs' <- shrink fs]
-#endif
-
 -- TODO: Implement a custom shrink method.
 instance Arbitrary s => Arbitrary (Doc s) where
     arbitrary = mconcat . map literal <$> arbitrary

--- a/test/Algebra/Graph/Test/Export.hs
+++ b/test/Algebra/Graph/Test/Export.hs
@@ -18,7 +18,6 @@ import Algebra.Graph (Graph, circuit)
 import Algebra.Graph.Export hiding (unlines)
 import Algebra.Graph.Export.Dot (Attribute (..))
 import Algebra.Graph.Test
-import Data.Semigroup ((<>))
 
 import qualified Algebra.Graph.Export     as E
 import qualified Algebra.Graph.Export.Dot as ED

--- a/test/Algebra/Graph/Test/Internal.hs
+++ b/test/Algebra/Graph/Test/Internal.hs
@@ -16,7 +16,6 @@ module Algebra.Graph.Test.Internal (
 
 import Algebra.Graph.Internal
 import Algebra.Graph.Test
-import Data.Semigroup ((<>))
 
 testInternal :: IO ()
 testInternal = do

--- a/test/Algebra/Graph/Test/Labelled/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/Labelled/AdjacencyMap.hs
@@ -14,7 +14,7 @@ module Algebra.Graph.Test.Labelled.AdjacencyMap (
     testLabelledAdjacencyMap
     ) where
 
-import Data.Monoid
+import Data.Monoid (Any, Sum (..))
 
 import Algebra.Graph.Label
 import Algebra.Graph.Labelled.AdjacencyMap

--- a/test/Algebra/Graph/Test/Labelled/Graph.hs
+++ b/test/Algebra/Graph/Test/Labelled/Graph.hs
@@ -14,7 +14,7 @@ module Algebra.Graph.Test.Labelled.Graph (
     testLabelledGraph
     ) where
 
-import Data.Monoid
+import Data.Monoid (Any, Sum (..))
 
 import Algebra.Graph.Label
 import Algebra.Graph.Labelled

--- a/test/Algebra/Graph/Test/NonEmpty/AdjacencyMap.hs
+++ b/test/Algebra/Graph/Test/NonEmpty/AdjacencyMap.hs
@@ -15,7 +15,6 @@ module Algebra.Graph.Test.NonEmpty.AdjacencyMap (
     ) where
 
 import Control.Monad
-import Data.Semigroup ((<>))
 import Data.Tree
 import Data.Tuple
 

--- a/test/Algebra/Graph/Test/NonEmpty/Graph.hs
+++ b/test/Algebra/Graph/Test/NonEmpty/Graph.hs
@@ -17,7 +17,6 @@ module Algebra.Graph.Test.NonEmpty.Graph (
 import Control.Monad
 import Data.Either
 import Data.Maybe
-import Data.Semigroup ((<>))
 import Data.Tree
 import Data.Tuple
 


### PR DESCRIPTION
As discussed in #276.

- [x] Drop unnecessary CPP.
- [x] Simplfy imports.