### PR TITLE
Recover previous Todo example

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -113,6 +113,7 @@ library
                         Algebra.Graph.Bipartite.AdjacencyMap,
                         Algebra.Graph.Bipartite.AdjacencyMap.Algorithm,
                         Algebra.Graph.Class,
+                        Algebra.Graph.Example.Todo,
                         Algebra.Graph.Export,
                         Algebra.Graph.Export.Dot,
                         Algebra.Graph.HigherKinded.Class,
@@ -144,6 +145,7 @@ test-suite test-alga
                         Algebra.Graph.Test.AdjacencyMap,
                         Algebra.Graph.Test.Arbitrary,
                         Algebra.Graph.Test.Bipartite.AdjacencyMap,
+                        Algebra.Graph.Test.Example.Todo
                         Algebra.Graph.Test.Export,
                         Algebra.Graph.Test.Generic,
                         Algebra.Graph.Test.Graph,

--- a/src/Algebra/Graph/Example/Todo.hs
+++ b/src/Algebra/Graph/Example/Todo.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Algebra.Graph.Example.Todo (Todo, todo, low, high, (~*~), (>*<), priority) where
+
+import Data.Map (Map)
+import Data.String
+
+import Algebra.Graph.AdjacencyMap as AM
+import Algebra.Graph.AdjacencyMap.Algorithm as AM
+import Algebra.Graph.Class as C
+
+import qualified Data.Map as Map
+
+data Todo a = T (Map a Int) (AdjacencyMap a) deriving Show
+
+instance Ord a => Eq (Todo a) where
+  x == y = todo x == todo y
+
+instance (IsString a, Ord a) => IsString (Todo a) where
+  fromString = C.vertex . fromString
+
+-- Lower the priority of items in a given todo list
+low :: Todo a -> Todo a
+low (T p g) = T (Map.map (subtract 1) p) g
+
+-- Raise the priority of items in a given todo list
+high :: Todo a -> Todo a
+high (T p g) = T (Map.map (+1) p) g
+
+-- Specify exact priority of items in a given todo list (default 0)
+priority :: Int -> Todo a -> Todo a
+priority x (T p g) = T (Map.map (const x) p) g
+
+-- Pull the arguments together as close as possible
+(~*~) :: Ord a => Todo a -> Todo a -> Todo a
+x ~*~ y = low x `C.connect` high y
+
+-- Repel the arguments as far as possible
+(>*<) :: Ord a => Todo a -> Todo a -> Todo a
+x >*< y = high x `C.connect` low y
+
+todo :: forall a. Ord a => Todo a -> Maybe [a]
+todo (T p g) =
+  case AM.topSort $ gmap prioritise g of
+    Left _ -> Nothing
+    Right xs -> Just $ map snd xs
+  where
+    prioritise :: a -> (Int, a)
+    prioritise x = (negate $ Map.findWithDefault 0 x p, x)
+
+instance (IsString a, Ord a) => Num (Todo a) where
+  fromInteger i = fromString $ show (fromInteger i :: Integer)
+  (+)           = C.overlay
+  (*)           = C.connect
+  signum        = const C.empty
+  abs           = id
+  negate        = id
+
+instance Ord a => Graph (Todo a) where
+  type Vertex (Todo a) = a
+  empty    = T Map.empty AM.empty
+  vertex x = T (Map.singleton x 0) (C.vertex x)
+  overlay (T p1 g1) (T p2 g2) = T (Map.unionWith (+) p1 p2) (C.overlay g1 g2)
+  connect (T p1 g1) (T p2 g2) = T (Map.unionWith (+) p1 p2) (C.connect g1 g2)

--- a/test/Algebra/Graph/Test/Example/Todo.hs
+++ b/test/Algebra/Graph/Test/Example/Todo.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Algebra.Graph.Test.Example.Todo (
+    testTodo
+    ) where
+
+import Algebra.Graph.Class
+import Algebra.Graph.Test
+import Algebra.Graph.Example.Todo
+
+testTodo :: IO ()
+testTodo = do
+    putStrLn "\n============ Example.Todo (Holiday) ============"
+    
+    test "A todo list is semantically Maybe [a]" $
+        todo ("presents" :: Todo String) == Just ["presents"]
+    
+    test "The overlay operator (+) adds non-dependent items to the todo list" $
+        todo ("coat" + "presents" :: Todo String) == Just ["coat", "presents"]
+    
+    test "The connect operator (*) adds dependency between items" $
+        let 
+            shopping :: Todo String = "presents" + "coat" + "scarf"
+            holiday :: Todo String = shopping * "pack" * "travel"
+        in todo (holiday + "scarf" * "coat")
+            == Just ["presents","scarf","coat", "pack","travel"]
+
+    test "Contradictory constraints make the todo list impossible to schedule" $
+        let 
+            shopping :: Todo String = "presents" + "coat" + "scarf"
+            holiday :: Todo String = shopping * "pack" * "travel"
+        in todo (holiday + "travel" * "presents") == Nothing
+    
+    test "Introduce item priority to schedule the todo list" $ 
+        let
+            shopping :: Todo String
+            shopping = "presents" + "coat" + low "phone wife" * "scarf"
+            holiday :: Todo String
+            holiday = shopping * "pack" * "travel" + "scarf" * "coat"
+        in todo holiday
+            == Just ["presents","phone wife","scarf","coat","pack","travel"]
+
+    test "Custom connect operators pull/repel arguments during scheduling" $
+        let
+            shopping :: Todo String
+            shopping = "presents" + "coat" + "phone wife" ~*~ "scarf"
+            holiday :: Todo String
+            holiday = shopping * "pack" * "travel" + "scarf" * "coat"
+        in todo holiday
+            == Just ["presents","phone wife","scarf","coat","pack","travel"]
+
+    putStrLn "\n============ Example.Todo (Commandline) ============"
+
+    test "The pull connect operator maintains command line semantics" $
+        let
+            cmdl :: Todo String
+            cmdl = "gcc" * ("-c" ~*~ "src.c" + "-o" ~*~ "src.o")
+        in todo cmdl == Just ["gcc","-c","src.c","-o","src.o"]
+    
+    test "Swapping flags are allowed by the commutative overlay opeartor" $
+        let
+            cmdl1 :: Todo String
+            cmdl1 = "gcc" * ("-c" ~*~ "src.c" + "-o" ~*~ "src.o")
+            cmdl2 :: Todo String
+            cmdl2 = "gcc" * ("-o" ~*~ "src.o" + "-c" ~*~ "src.c")
+        in cmdl1 == cmdl2
+    
+    test "The usual connect operator breaks semantics" $
+        let
+            cmdl :: Todo String
+            cmdl = "gcc" * ("-c" * "src.c" + "-o" * "src.o")
+        in 
+            todo cmdl == Just ["gcc","-c","-o","src.c","src.o"]
+
+    test "Transform command lines by adding optimisation flag" $
+        let
+            cmdl :: Todo String
+            cmdl = "gcc" * ("-c" ~*~ "src.c" + "-o" ~*~ "src.o")
+            optimise :: Int -> Todo String -> Todo String
+            optimise level = (* flag)
+                where flag = vertex $ "-O" ++ show level
+        in todo (optimise 2 cmdl) == 
+            Just ["gcc","-c","src.c","-o","src.o","-O2"]

--- a/test/Algebra/Graph/Test/Example/Todo.hs
+++ b/test/Algebra/Graph/Test/Example/Todo.hs
@@ -11,27 +11,26 @@ import Algebra.Graph.Example.Todo
 testTodo :: IO ()
 testTodo = do
     putStrLn "\n============ Example.Todo (Holiday) ============"
-    
     test "A todo list is semantically Maybe [a]" $
         todo ("presents" :: Todo String) == Just ["presents"]
-    
+
     test "The overlay operator (+) adds non-dependent items to the todo list" $
         todo ("coat" + "presents" :: Todo String) == Just ["coat", "presents"]
-    
+
     test "The connect operator (*) adds dependency between items" $
-        let 
+        let
             shopping :: Todo String = "presents" + "coat" + "scarf"
             holiday :: Todo String = shopping * "pack" * "travel"
         in todo (holiday + "scarf" * "coat")
             == Just ["presents","scarf","coat", "pack","travel"]
 
     test "Contradictory constraints make the todo list impossible to schedule" $
-        let 
+        let
             shopping :: Todo String = "presents" + "coat" + "scarf"
             holiday :: Todo String = shopping * "pack" * "travel"
         in todo (holiday + "travel" * "presents") == Nothing
-    
-    test "Introduce item priority to schedule the todo list" $ 
+
+    test "Introduce item priority to schedule the todo list" $
         let
             shopping :: Todo String
             shopping = "presents" + "coat" + low "phone wife" * "scarf"
@@ -50,13 +49,12 @@ testTodo = do
             == Just ["presents","phone wife","scarf","coat","pack","travel"]
 
     putStrLn "\n============ Example.Todo (Commandline) ============"
-
     test "The pull connect operator maintains command line semantics" $
         let
             cmdl :: Todo String
             cmdl = "gcc" * ("-c" ~*~ "src.c" + "-o" ~*~ "src.o")
         in todo cmdl == Just ["gcc","-c","src.c","-o","src.o"]
-    
+
     test "Swapping flags are allowed by the commutative overlay opeartor" $
         let
             cmdl1 :: Todo String
@@ -64,12 +62,12 @@ testTodo = do
             cmdl2 :: Todo String
             cmdl2 = "gcc" * ("-o" ~*~ "src.o" + "-c" ~*~ "src.c")
         in cmdl1 == cmdl2
-    
+
     test "The usual connect operator breaks semantics" $
         let
             cmdl :: Todo String
             cmdl = "gcc" * ("-c" * "src.c" + "-o" * "src.o")
-        in 
+        in
             todo cmdl == Just ["gcc","-c","-o","src.c","src.o"]
 
     test "Transform command lines by adding optimisation flag" $
@@ -79,5 +77,5 @@ testTodo = do
             optimise :: Int -> Todo String -> Todo String
             optimise level = (* flag)
                 where flag = vertex $ "-O" ++ show level
-        in todo (optimise 2 cmdl) == 
+        in todo (optimise 2 cmdl) ==
             Just ["gcc","-c","src.c","-o","src.o","-O2"]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,6 +2,7 @@ import Algebra.Graph.Test.Acyclic.AdjacencyMap
 import Algebra.Graph.Test.AdjacencyIntMap
 import Algebra.Graph.Test.AdjacencyMap
 import Algebra.Graph.Test.Bipartite.AdjacencyMap
+import Algebra.Graph.Test.Example.Todo
 import Algebra.Graph.Test.Export
 import Algebra.Graph.Test.Graph
 import Algebra.Graph.Test.Internal
@@ -44,5 +45,6 @@ main = do
     go "NonEmpty.Graph"                   testNonEmptyGraph
     go "Relation"                         testRelation
     go "Symmetric.Relation"               testSymmetricRelation
+    go "Todo"                             testTodo
     go "Typed"                            testTyped
     go "Undirected"                       testUndirected


### PR DESCRIPTION
Per suggestions in #51:
- Resolve namespace conflict between 'AdjacencyGraph' and 'Class'
- Ignore cycles after topSort in `todo`