### PR TITLE
Revise ToGraph

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.7
+
+* #293: Fix the `ToGraph` instance of symmetric relations.
+
 ## 0.6.1
 
 * Drop dependency on `mtl`.

--- a/src/Algebra/Graph/Labelled.hs
+++ b/src/Algebra/Graph/Labelled.hs
@@ -52,9 +52,12 @@ import Algebra.Graph.Internal (List)
 import Algebra.Graph.Label
 
 import qualified Algebra.Graph.Labelled.AdjacencyMap as AM
-import qualified Data.Set                            as Set
-import qualified Data.Map                            as Map
-import qualified GHC.Exts                            as Exts
+import qualified Algebra.Graph.ToGraph               as T
+
+import qualified Data.IntSet as IntSet
+import qualified Data.Set    as Set
+import qualified Data.Map    as Map
+import qualified GHC.Exts    as Exts
 
 -- | Edge-labelled graphs, where the type variable @e@ stands for edge labels.
 -- For example, 'Graph' @Bool@ @a@ is isomorphic to unlabelled graphs defined in
@@ -99,6 +102,16 @@ instance Monoid e => Semigroup (Graph e a) where
 -- | Defined via 'overlay' and 'empty'.
 instance Monoid e => Monoid (Graph e a) where
     mempty = empty
+
+instance (Eq e, Monoid e, Ord a) => T.ToGraph (Graph e a) where
+    type ToVertex (Graph e a)  = a
+    foldg e v o c              = foldg e v (\e -> if e == mempty then o else c)
+    vertexList                 = vertexList
+    vertexSet                  = vertexSet
+    toAdjacencyMap             = AM.skeleton . toAdjacencyMap
+    toAdjacencyMapTranspose    = T.toAdjacencyMap . transpose
+    toAdjacencyIntMap          = T.toAdjacencyIntMap . toAdjacencyMap
+    toAdjacencyIntMapTranspose = T.toAdjacencyIntMap . T.toAdjacencyMapTranspose
 
 -- TODO: This is a very inefficient implementation. Find a way to construct an
 -- adjacency map directly, without building intermediate representations for all

--- a/src/Algebra/Graph/Labelled.hs
+++ b/src/Algebra/Graph/Labelled.hs
@@ -103,6 +103,7 @@ instance Monoid e => Semigroup (Graph e a) where
 instance Monoid e => Monoid (Graph e a) where
     mempty = empty
 
+-- TODO: Add tests.
 instance (Eq e, Monoid e, Ord a) => T.ToGraph (Graph e a) where
     type ToVertex (Graph e a)  = a
     foldg e v o c              = foldg e v (\e -> if e == mempty then o else c)

--- a/src/Algebra/Graph/Labelled/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap.hs
@@ -124,6 +124,7 @@ instance (Ord a, Eq e, Monoid e) => Semigroup (AdjacencyMap e a) where
 instance (Ord a, Eq e, Monoid e) => Monoid (AdjacencyMap e a) where
     mempty = empty
 
+-- TODO: Add tests.
 -- | Defined via 'skeleton' and the 'T.ToGraph' instance of 'AM.AdjacencyMap'.
 instance (Eq e, Monoid e, Ord a) => T.ToGraph (AdjacencyMap e a) where
     type ToVertex (AdjacencyMap e a) = a

--- a/src/Algebra/Graph/Labelled/AdjacencyMap.hs
+++ b/src/Algebra/Graph/Labelled/AdjacencyMap.hs
@@ -52,8 +52,11 @@ import GHC.Generics
 import Algebra.Graph.Label
 
 import qualified Algebra.Graph.AdjacencyMap as AM
-import qualified Data.Map.Strict            as Map
-import qualified Data.Set                   as Set
+import qualified Algebra.Graph.ToGraph      as T
+
+import qualified Data.IntSet     as IntSet
+import qualified Data.Map.Strict as Map
+import qualified Data.Set        as Set
 
 -- | Edge-labelled graphs, where the type variable @e@ stands for edge labels.
 -- For example, 'AdjacencyMap' @Bool@ @a@ is isomorphic to unlabelled graphs
@@ -120,6 +123,29 @@ instance (Ord a, Eq e, Monoid e) => Semigroup (AdjacencyMap e a) where
 -- | Defined via 'overlay' and 'empty'.
 instance (Ord a, Eq e, Monoid e) => Monoid (AdjacencyMap e a) where
     mempty = empty
+
+-- | Defined via 'skeleton' and the 'T.ToGraph' instance of 'AM.AdjacencyMap'.
+instance (Eq e, Monoid e, Ord a) => T.ToGraph (AdjacencyMap e a) where
+    type ToVertex (AdjacencyMap e a) = a
+    toGraph                    = T.toGraph . skeleton
+    foldg e v o c              = T.foldg e v o c . skeleton
+    isEmpty                    = isEmpty
+    hasVertex                  = hasVertex
+    hasEdge                    = hasEdge
+    vertexCount                = vertexCount
+    edgeCount                  = edgeCount
+    vertexList                 = vertexList
+    vertexSet                  = vertexSet
+    vertexIntSet               = IntSet.fromAscList . vertexList
+    edgeList                   = T.edgeList . skeleton
+    edgeSet                    = T.edgeSet . skeleton
+    adjacencyList              = T.adjacencyList . skeleton
+    preSet                     = preSet
+    postSet                    = postSet
+    toAdjacencyMap             = skeleton
+    toAdjacencyIntMap          = T.toAdjacencyIntMap . skeleton
+    toAdjacencyMapTranspose    = T.toAdjacencyMapTranspose . skeleton
+    toAdjacencyIntMapTranspose = T.toAdjacencyIntMapTranspose . skeleton
 
 -- | Construct the /empty graph/.
 --

--- a/src/Algebra/Graph/Relation.hs
+++ b/src/Algebra/Graph/Relation.hs
@@ -49,11 +49,17 @@ import Data.String
 import Data.Tree
 import Data.Tuple
 
-import qualified Data.Maybe as Maybe
-import qualified Data.Set   as Set
-import qualified Data.Tree  as Tree
+import qualified Data.IntSet as IntSet
+import qualified Data.Maybe  as Maybe
+import qualified Data.Set    as Set
+import qualified Data.Tree   as Tree
 
 import Algebra.Graph.Internal
+
+import qualified Algebra.Graph                 as G
+import qualified Algebra.Graph.AdjacencyIntMap as AIM
+import qualified Algebra.Graph.AdjacencyMap    as AM
+import qualified Algebra.Graph.ToGraph         as T
 
 {-| The 'Relation' data type represents a graph as a /binary relation/. We
 define a 'Num' instance as a convenient notation for working with graphs:
@@ -204,6 +210,26 @@ instance Ord a => Semigroup (Relation a) where
 -- | Defined via 'overlay' and 'empty'.
 instance Ord a => Monoid (Relation a) where
     mempty = empty
+
+instance Ord a => T.ToGraph (Relation a) where
+    type ToVertex (Relation a) = a
+    toGraph r                  = G.vertices (Set.toList $ domain   r) `G.overlay`
+                                 G.edges    (Set.toList $ relation r)
+    isEmpty                    = isEmpty
+    hasVertex                  = hasVertex
+    hasEdge                    = hasEdge
+    vertexCount                = vertexCount
+    edgeCount                  = edgeCount
+    vertexList                 = vertexList
+    vertexSet                  = vertexSet
+    vertexIntSet               = IntSet.fromAscList . vertexList
+    edgeList                   = edgeList
+    edgeSet                    = edgeSet
+    adjacencyList              = adjacencyList
+    toAdjacencyMap             = AM.stars . adjacencyList
+    toAdjacencyIntMap          = AIM.stars . adjacencyList
+    toAdjacencyMapTranspose    = AM.transpose . T.toAdjacencyMap
+    toAdjacencyIntMapTranspose = AIM.transpose . T.toAdjacencyIntMap
 
 -- | Construct the /empty graph/.
 --

--- a/src/Algebra/Graph/Relation/Symmetric.hs
+++ b/src/Algebra/Graph/Relation/Symmetric.hs
@@ -13,11 +13,8 @@
 -- import qualified Algebra.Graph.Relation.Symmetric as Symmetric
 -- @
 --
--- 'Relation' is an instance of the 'Algebra.Graph.Class.Graph' type
--- class, which can be used for polymorphic graph construction and manipulation.
---
--- We do not provide a 'Algebra.Graph.ToGraph.ToGraph' instance. Instead, use
--- the corresponding instance of the underlying relation via 'toSymmetric'.
+-- 'Relation' is an instance of the 'Algebra.Graph.Class.Graph' type class,
+-- which can be used for polymorphic graph construction and manipulation.
 -----------------------------------------------------------------------------
 module Algebra.Graph.Relation.Symmetric (
     -- * Data structure
@@ -50,9 +47,14 @@ import Data.Set (Set)
 import Data.String
 import Data.Tree
 
-import qualified Data.Set as Set
+import qualified Data.IntSet as IntSet
+import qualified Data.Set    as Set
 
-import qualified Algebra.Graph.Relation as R
+import qualified Algebra.Graph                 as G
+import qualified Algebra.Graph.AdjacencyIntMap as AIM
+import qualified Algebra.Graph.AdjacencyMap    as AM
+import qualified Algebra.Graph.ToGraph         as T
+import qualified Algebra.Graph.Relation        as R
 
 {-| This data type represents a /symmetric binary relation/ over a set of
 elements of type @a@. Symmetric relations satisfy all laws of the
@@ -141,6 +143,27 @@ instance Ord a => Semigroup (Relation a) where
 instance Ord a => Monoid (Relation a) where
     mempty = empty
 
+-- | Defined via 'fromSymmetric' and the 'T.ToGraph' instance of 'R.Relation'.
+instance Ord a => T.ToGraph (Relation a) where
+    type ToVertex (Relation a) = a
+    toGraph                    = T.toGraph . fromSymmetric
+    isEmpty                    = isEmpty
+    hasVertex                  = hasVertex
+    hasEdge                    = hasEdge
+    vertexCount                = vertexCount
+    edgeCount                  = R.edgeCount . fromSymmetric
+    vertexList                 = vertexList
+    vertexSet                  = vertexSet
+    vertexIntSet               = IntSet.fromAscList . vertexList
+    edgeList                   = R.edgeList . fromSymmetric
+    edgeSet                    = R.relation . fromSymmetric
+    adjacencyList              = adjacencyList
+    toAdjacencyMap             = T.toAdjacencyMap . fromSymmetric
+    toAdjacencyIntMap          = T.toAdjacencyIntMap . fromSymmetric
+    toAdjacencyMapTranspose    = T.toAdjacencyMap    -- No need to transpose!
+    toAdjacencyIntMapTranspose = T.toAdjacencyIntMap -- No need to transpose!
+
+-- | Construct a symmetric relation from a given "Algebra.Graph.Relation".
 -- Complexity: /O(m * log(m))/ time.
 --
 -- @

--- a/src/Algebra/Graph/Relation/Symmetric.hs
+++ b/src/Algebra/Graph/Relation/Symmetric.hs
@@ -15,6 +15,9 @@
 --
 -- 'Relation' is an instance of the 'Algebra.Graph.Class.Graph' type
 -- class, which can be used for polymorphic graph construction and manipulation.
+--
+-- We do not provide a 'Algebra.Graph.ToGraph.ToGraph' instance. Instead, use
+-- the corresponding instance of the underlying relation via 'toSymmetric'.
 -----------------------------------------------------------------------------
 module Algebra.Graph.Relation.Symmetric (
     -- * Data structure
@@ -138,8 +141,7 @@ instance Ord a => Semigroup (Relation a) where
 instance Ord a => Monoid (Relation a) where
     mempty = empty
 
--- | Construct a symmetric relation from a given "Algebra.Graph.Relation".
--- Complexity: /O(m*log(m))/ time.
+-- Complexity: /O(m * log(m))/ time.
 --
 -- @
 -- toSymmetric ('Algebra.Graph.Relation.edge' 1 2)         == 'edge' 1 2

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -58,8 +58,6 @@ import Data.Tree
 import qualified Algebra.Graph                                as G
 import qualified Algebra.Graph.AdjacencyMap                   as AM
 import qualified Algebra.Graph.AdjacencyMap.Algorithm         as AM
-import qualified Algebra.Graph.Labelled                       as LG
-import qualified Algebra.Graph.Labelled.AdjacencyMap          as LAM
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap          as NAM
 import qualified Algebra.Graph.AdjacencyIntMap                as AIM
 import qualified Algebra.Graph.AdjacencyIntMap.Algorithm      as AIM
@@ -398,42 +396,6 @@ instance ToGraph AIM.AdjacencyIntMap where
     toAdjacencyIntMapTranspose = AIM.transpose . toAdjacencyIntMap
     isDfsForestOf              = AIM.isDfsForestOf
     isTopSortOf                = AIM.isTopSortOf
-
--- | See "Algebra.Graph.Labelled".
-instance (Eq e, Monoid e, Ord a) => ToGraph (LG.Graph e a) where
-    type ToVertex (LG.Graph e a) = a
-    foldg e v o c              = LG.foldg e v (\e -> if e == mempty then o else c)
-    vertexList                 = LG.vertexList
-    vertexSet                  = LG.vertexSet
-    toAdjacencyMap             = LAM.skeleton
-                               . LG.foldg LAM.empty LAM.vertex LAM.connect
-    toAdjacencyMapTranspose    = LAM.skeleton
-                               . LG.foldg LAM.empty LAM.vertex (fmap flip LAM.connect)
-    toAdjacencyIntMap          = toAdjacencyIntMap . toAdjacencyMap
-    toAdjacencyIntMapTranspose = toAdjacencyIntMapTranspose . toAdjacencyMapTranspose
-
--- | See "Algebra.Graph.Labelled.AdjacencyMap".
-instance (Eq e, Monoid e, Ord a) => ToGraph (LAM.AdjacencyMap e a) where
-    type ToVertex (LAM.AdjacencyMap e a) = a
-    toGraph                    = toGraph . LAM.skeleton
-    foldg e v o c              = foldg e v o c . LAM.skeleton
-    isEmpty                    = LAM.isEmpty
-    hasVertex                  = LAM.hasVertex
-    hasEdge                    = LAM.hasEdge
-    vertexCount                = LAM.vertexCount
-    edgeCount                  = LAM.edgeCount
-    vertexList                 = LAM.vertexList
-    vertexSet                  = LAM.vertexSet
-    vertexIntSet               = IntSet.fromAscList . LAM.vertexList
-    edgeList                   = edgeList . LAM.skeleton
-    edgeSet                    = edgeSet . LAM.skeleton
-    adjacencyList              = adjacencyList . LAM.skeleton
-    preSet                     = LAM.preSet
-    postSet                    = LAM.postSet
-    toAdjacencyMap             = LAM.skeleton
-    toAdjacencyIntMap          = toAdjacencyIntMap . LAM.skeleton
-    toAdjacencyMapTranspose    = toAdjacencyMapTranspose . LAM.skeleton
-    toAdjacencyIntMapTranspose = toAdjacencyIntMapTranspose . LAM.skeleton
 
 -- | See "Algebra.Graph.NonEmpty.AdjacencyMap".
 instance Ord a => ToGraph (NAM.AdjacencyMap a) where

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -63,8 +63,6 @@ import qualified Algebra.Graph.Labelled.AdjacencyMap          as LAM
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap          as NAM
 import qualified Algebra.Graph.AdjacencyIntMap                as AIM
 import qualified Algebra.Graph.AdjacencyIntMap.Algorithm      as AIM
-import qualified Algebra.Graph.Relation                       as R
-import qualified Algebra.Graph.Relation.Symmetric             as SR
 import qualified Data.IntMap                                  as IntMap
 import qualified Data.IntSet                                  as IntSet
 import qualified Data.Map                                     as Map
@@ -368,6 +366,7 @@ instance Ord a => ToGraph (AM.AdjacencyMap a) where
     isDfsForestOf              = AM.isDfsForestOf
     isTopSortOf                = AM.isTopSortOf
 
+-- | See "Algebra.Graph.AdjacencyIntMap".
 instance ToGraph AIM.AdjacencyIntMap where
     type ToVertex AIM.AdjacencyIntMap = Int
     toGraph                    = G.stars
@@ -465,51 +464,6 @@ instance Ord a => ToGraph (NAM.AdjacencyMap a) where
     toAdjacencyIntMapTranspose = toAdjacencyIntMap . NAM.transpose
     isDfsForestOf f            = isDfsForestOf f . toAdjacencyMap
     isTopSortOf x              = isTopSortOf x . toAdjacencyMap
-
--- TODO: Get rid of "Relation.Internal" and move this instance to "Relation".
--- | See "Algebra.Graph.Relation".
-instance Ord a => ToGraph (R.Relation a) where
-    type ToVertex (R.Relation a) = a
-    toGraph r                  = G.vertices (Set.toList $ R.domain   r) `G.overlay`
-                                 G.edges    (Set.toList $ R.relation r)
-    isEmpty                    = R.isEmpty
-    hasVertex                  = R.hasVertex
-    hasEdge                    = R.hasEdge
-    vertexCount                = R.vertexCount
-    edgeCount                  = R.edgeCount
-    vertexList                 = R.vertexList
-    vertexSet                  = R.vertexSet
-    vertexIntSet               = IntSet.fromAscList . R.vertexList
-    edgeList                   = R.edgeList
-    edgeSet                    = R.edgeSet
-    adjacencyList              = R.adjacencyList
-    toAdjacencyMap             = AM.stars . R.adjacencyList
-    toAdjacencyIntMap          = AIM.stars . R.adjacencyList
-    toAdjacencyMapTranspose    = AM.transpose . toAdjacencyMap
-    toAdjacencyIntMapTranspose = AIM.transpose . toAdjacencyIntMap
-
--- TODO: This instance is probably wrong because of the way it treats edges.
--- Find out a better way to integrate undirected graphs into 'ToGraph'.
--- | See "Algebra.Graph.Symmetric.Relation". Warning: this instance is likely to
--- be modified or removed in future.
-instance Ord a => ToGraph (SR.Relation a) where
-    type ToVertex (SR.Relation a) = a
-    toGraph                    = toGraph . SR.fromSymmetric
-    isEmpty                    = SR.isEmpty
-    hasVertex                  = SR.hasVertex
-    hasEdge                    = SR.hasEdge
-    vertexCount                = SR.vertexCount
-    edgeCount                  = SR.edgeCount
-    vertexList                 = SR.vertexList
-    vertexSet                  = SR.vertexSet
-    vertexIntSet               = IntSet.fromAscList . SR.vertexList
-    edgeList                   = SR.edgeList
-    edgeSet                    = SR.edgeSet
-    adjacencyList              = SR.adjacencyList
-    toAdjacencyMap             = toAdjacencyMap . SR.fromSymmetric
-    toAdjacencyIntMap          = toAdjacencyIntMap . SR.fromSymmetric
-    toAdjacencyMapTranspose    = toAdjacencyMap
-    toAdjacencyIntMapTranspose = toAdjacencyIntMap
 
 -- | The /adjacency map/ of a graph: each vertex is associated with a set of its
 -- /direct successors/.

--- a/src/Algebra/Graph/ToGraph.hs
+++ b/src/Algebra/Graph/ToGraph.hs
@@ -55,16 +55,21 @@ import Data.Map    (Map)
 import Data.Set    (Set)
 import Data.Tree
 
-import qualified Algebra.Graph                                as G
-import qualified Algebra.Graph.AdjacencyMap                   as AM
-import qualified Algebra.Graph.AdjacencyMap.Algorithm         as AM
-import qualified Algebra.Graph.NonEmpty.AdjacencyMap          as NAM
-import qualified Algebra.Graph.AdjacencyIntMap                as AIM
-import qualified Algebra.Graph.AdjacencyIntMap.Algorithm      as AIM
-import qualified Data.IntMap                                  as IntMap
-import qualified Data.IntSet                                  as IntSet
-import qualified Data.Map                                     as Map
-import qualified Data.Set                                     as Set
+import qualified Data.IntMap as IntMap
+import qualified Data.IntSet as IntSet
+import qualified Data.Map    as Map
+import qualified Data.Set    as Set
+
+-- Ideally, we would define all instances in the modules where the corresponding
+-- data types are declared. However, that causes import cycles, so we define a
+-- few instances here.
+
+import qualified Algebra.Graph                           as G
+import qualified Algebra.Graph.AdjacencyMap              as AM
+import qualified Algebra.Graph.AdjacencyMap.Algorithm    as AM
+import qualified Algebra.Graph.NonEmpty.AdjacencyMap     as NAM
+import qualified Algebra.Graph.AdjacencyIntMap           as AIM
+import qualified Algebra.Graph.AdjacencyIntMap.Algorithm as AIM
 
 -- | The 'ToGraph' type class captures data types that can be converted to
 -- algebraic graphs. Instances of this type class should satisfy the laws
@@ -325,6 +330,7 @@ class ToGraph t where
     isTopSortOf :: Ord (ToVertex t) => [ToVertex t] -> t -> Bool
     isTopSortOf vs = AM.isTopSortOf vs . toAdjacencyMap
 
+-- | See "Algebra.Graph".
 instance Ord a => ToGraph (G.Graph a) where
     type ToVertex (G.Graph a) = a
     toGraph = id

--- a/src/Algebra/Graph/Undirected.hs
+++ b/src/Algebra/Graph/Undirected.hs
@@ -88,7 +88,7 @@ working with algebraic graphs; we hope that in future Haskell's Prelude will
 provide a more fine-grained class hierarchy for algebraic structures, which we
 would be able to utilise without violating any laws.
 
-The 'Eq' instance is currently implemented using the 'R.Relation' as the
+The 'Eq' instance is currently implemented using the 'SR.Relation' as the
 /canonical graph representation/ and satisfies all axioms of algebraic graphs:
 
     * 'overlay' is commutative and associative:
@@ -144,7 +144,7 @@ Note that 'size' counts all leaves of the expression:
 'vertexCount' ('empty' + 'empty') == 0
 'size'        ('empty' + 'empty') == 2@
 
-Converting an undirected 'Graph' to the corresponding 'R.Relation' takes
+Converting an undirected 'Graph' to the corresponding 'SR.Relation' takes
 /O(s + m * log(m))/ time and /O(s + m)/ memory. This is also the complexity of
 the graph equality test, because it is currently implemented by converting graph
 expressions to canonical representations based on adjacency maps.

--- a/src/Algebra/Graph/Undirected.hs
+++ b/src/Algebra/Graph/Undirected.hs
@@ -60,7 +60,7 @@ import Data.Tree (Tree, Forest)
 import Data.String
 
 import qualified Algebra.Graph                    as G
-import qualified Algebra.Graph.Relation.Symmetric as R
+import qualified Algebra.Graph.Relation.Symmetric as SR
 import qualified Data.Set                         as Set
 
 -- TODO: Specialise the API for graphs with vertices of type 'Int'.
@@ -238,7 +238,7 @@ toUndirected = coerce
 -- 'Algebra.Graph.edgeCount' . fromUndirected    <= (*2) . 'edgeCount'
 -- @
 fromUndirected :: Ord a => Graph a -> G.Graph a
-fromUndirected = toGraph . toRelation
+fromUndirected = toGraph . SR.fromSymmetric . toRelation
 
 -- | Construct the /empty graph/.
 --
@@ -421,15 +421,15 @@ foldg = coerce G.foldg
 -- isSubgraphOf x y                         ==> x <= y
 -- @
 isSubgraphOf :: Ord a => Graph a -> Graph a -> Bool
-isSubgraphOf x y = R.isSubgraphOf (toRelation x) (toRelation y)
+isSubgraphOf x y = SR.isSubgraphOf (toRelation x) (toRelation y)
 {-# NOINLINE [1] isSubgraphOf #-}
 
 -- TODO: This is a very inefficient implementation. Find a way to construct a
 -- symmetric relation directly, without building intermediate representations
 -- for all subgraphs.
--- | Convert an undirected graph to a symmetric 'R.Relation'.
-toRelation :: Ord a => Graph a -> R.Relation a
-toRelation = foldg R.empty R.vertex R.overlay R.connect
+-- | Convert an undirected graph to a symmetric 'SR.Relation'.
+toRelation :: Ord a => Graph a -> SR.Relation a
+toRelation = foldg SR.empty SR.vertex SR.overlay SR.connect
 {-# INLINE toRelation #-}
 
 -- | Check if a graph is empty.
@@ -516,7 +516,7 @@ vertexCount = coerce01 G.vertexCount
 -- edgeCount            == 'length' . 'edgeList'
 -- @
 edgeCount :: Ord a => Graph a -> Int
-edgeCount = R.edgeCount . toRelation
+edgeCount = SR.edgeCount . toRelation
 {-# INLINE [1] edgeCount #-}
 
 -- | The sorted list of vertices of a given graph.
@@ -542,7 +542,7 @@ vertexList = coerce01 G.vertexList
 -- edgeList ('star' 2 [3,1]) == [(1,2), (2,3)]
 -- @
 edgeList :: Ord a => Graph a -> [(a, a)]
-edgeList = R.edgeList . toRelation
+edgeList = SR.edgeList . toRelation
 {-# INLINE [1] edgeList #-}
 
 -- | The set of vertices of a given graph.
@@ -566,7 +566,7 @@ vertexSet = coerce01 G.vertexSet
 -- edgeSet ('edge' x y) == Set.'Set.singleton' ('min' x y, 'max' x y)
 -- @
 edgeSet :: Ord a => Graph a -> Set (a, a)
-edgeSet = R.edgeSet . toRelation
+edgeSet = SR.edgeSet . toRelation
 {-# INLINE [1] edgeSet #-}
 
 -- | The sorted /adjacency list/ of a graph.
@@ -580,7 +580,7 @@ edgeSet = R.edgeSet . toRelation
 -- 'stars' . adjacencyList        == id
 -- @
 adjacencyList :: Ord a => Graph a -> [(a, [a])]
-adjacencyList = R.adjacencyList . toRelation
+adjacencyList = SR.adjacencyList . toRelation
 {-# INLINE adjacencyList #-}
 {-# SPECIALISE adjacencyList :: Graph Int -> [(Int, [Int])] #-}
 
@@ -593,7 +593,7 @@ adjacencyList = R.adjacencyList . toRelation
 -- neighbours y ('edge' x y) == Set.'Set.fromList' [x]
 -- @
 neighbours :: Ord a => a -> Graph a -> Set a
-neighbours x = R.neighbours x . toRelation
+neighbours x = SR.neighbours x . toRelation
 {-# INLINE neighbours #-}
 
 -- | The /path/ on a list of vertices.


### PR DESCRIPTION
A few changes related to `ToGraph`:
* Move as many instances as possible from the `ToGraph` module to the modules where the data types are actually defined.
* Fix symmetric `Relation` instance, and move it to `Algebra.Graph.Relation.Symmetric`.