### PR TITLE
Use Semigroup constraint for LAM instead of Monoid

### DIFF
--- a/src/Algebra/Graph/Class.hs
+++ b/src/Algebra/Graph/Class.hs
@@ -155,7 +155,7 @@ instance Dioid e => Graph (LG.Graph e a) where
     overlay = LG.overlay
     connect = LG.connect one
 
-instance (Dioid e, Eq e, Ord a) => Graph (LAM.AdjacencyMap e a) where
+instance (Dioid e, Ord a) => Graph (LAM.AdjacencyMap e a) where
     type Vertex (LAM.AdjacencyMap e a) = a
     empty   = LAM.empty
     vertex  = LAM.vertex

--- a/src/Algebra/Graph/Labelled.hs
+++ b/src/Algebra/Graph/Labelled.hs
@@ -118,7 +118,7 @@ instance (Eq e, Monoid e, Ord a) => T.ToGraph (Graph e a) where
 -- subgraphs.
 -- Extract the adjacency map of a graph.
 toAdjacencyMap :: (Eq e, Monoid e, Ord a) => Graph e a -> AM.AdjacencyMap e a
-toAdjacencyMap = foldg AM.empty AM.vertex AM.connect
+toAdjacencyMap = foldg AM.empty AM.vertex (\e x y -> AM.trimZeroes $ AM.connect e x y)
 
 -- Convert the adjacency map to a graph.
 fromAdjacencyMap :: Monoid e => AM.AdjacencyMap e a -> Graph e a

--- a/test/Algebra/Graph/Test/Arbitrary.hs
+++ b/test/Algebra/Graph/Test/Arbitrary.hs
@@ -182,10 +182,10 @@ instance Arbitrary AIM.AdjacencyIntMap where
 
 -- | Generate an arbitrary labelled 'LAM.AdjacencyMap'. It is guaranteed
 -- that the resulting adjacency map is 'consistent'.
-arbitraryLabelledAdjacencyMap :: (Arbitrary a, Ord a, Eq e, Arbitrary e, Monoid e) => Gen (LAM.AdjacencyMap e a)
+arbitraryLabelledAdjacencyMap :: (Arbitrary a, Ord a, Semigroup e, Arbitrary e) => Gen (LAM.AdjacencyMap e a)
 arbitraryLabelledAdjacencyMap = LAM.fromAdjacencyMaps <$> arbitrary
 
-instance (Arbitrary a, Ord a, Eq e, Arbitrary e, Monoid e) => Arbitrary (LAM.AdjacencyMap e a) where
+instance (Arbitrary a, Ord a, Semigroup e, Arbitrary e) => Arbitrary (LAM.AdjacencyMap e a) where
     arbitrary = arbitraryLabelledAdjacencyMap
 
     shrink g = shrinkVertices ++ shrinkEdges
@@ -198,7 +198,7 @@ instance (Arbitrary a, Ord a, Eq e, Arbitrary e, Monoid e) => Arbitrary (LAM.Adj
            let edges = LAM.edgeList g
            in  [ LAM.removeEdge v w g | (_, v, w) <- edges ]
 
--- | Generate an arbitrary labelled 'LAM.Graph' value of a specified size.
+-- | Generate an arbitrary labelled 'LG.Graph' value of a specified size.
 arbitraryLabelledGraph :: (Arbitrary a, Arbitrary e) => Gen (LG.Graph e a)
 arbitraryLabelledGraph = sized expr
   where


### PR DESCRIPTION
As discussed in https://github.com/snowleopard/alga/issues/307, this eases the `Monoid` restriction labeled adjacency maps to `Semigroup`.