### PR TITLE
Allow inspection-testing 0.6

### DIFF
--- a/algebraic-graphs.cabal
+++ b/algebraic-graphs.cabal
@@ -162,7 +162,7 @@ test-suite main
                         Data.Graph.Test.Typed
     build-depends:      algebraic-graphs,
                         extra              >= 1.4     && < 2,
-                        inspection-testing >= 0.4.2.2 && < 0.6,
+                        inspection-testing >= 0.4.2.2 && < 0.7,
                         QuickCheck         >= 2.14    && < 2.16
     other-extensions:   ConstrainedClassMethods
                         TemplateHaskell


### PR DESCRIPTION
The (possible) breaking change at https://github.com/nomeata/inspection-testing/pull/81 shouldn't affect us.