### PR TITLE
Fix CI: Update actions/cache v2 → v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         echo "name=libdir::$(ghc --print-libdir)" >> $GITHUB_OUTPUT
       shell: bash
     - run: cabal v2-freeze --enable-tests
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ steps.get-ghc-libdir.outputs.libdir }}-${{ hashFiles('cabal.project.freeze') }}


### PR DESCRIPTION
`actions/cache@v2` was deprecated in Dec 2024, and sunset in Feb 2025, requiring an upgrade:

- https://github.com/actions/cache/discussions/1510